### PR TITLE
[webapi] Fix the install issue for testing runtime on ivi

### DIFF
--- a/webapi/webapi-runtime-xwalk-tests/inst.sh.ivi
+++ b/webapi/webapi-runtime-xwalk-tests/inst.sh.ivi
@@ -18,9 +18,9 @@ RESOURCE_DIR=/opt/usr/media
 
 function installpkg(){
     xwalkctl --install $(dirname $0)/$XPKNAME
-    xwalkctl --install $(dirname $0)/$XPKNAME
-    xwalkctl --install $(dirname $0)/$XPKNAME
-    xwalkctl --install $(dirname $0)/$XPKNAME
+    xwalkctl --install $(dirname $0)/$SUBXPK1
+    xwalkctl --install $(dirname $0)/$SUBXPK2
+    xwalkctl --install $(dirname $0)/$SUBXPK3
 
     #TODO: copy resource
     #eg:cp xx $RESOURCE_DIR


### PR DESCRIPTION
From the comment on XWALK-1228, the inst.sh.ivi script has an issue, so fix it.
