### PR TITLE
Xujfx/webapi/csp

### DIFF
--- a/webapi/tct-csp-w3c-tests/csp/csp_base-uri_cross-orign_block.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_base-uri_cross-orign_block.cgi
@@ -46,7 +46,7 @@ Authors:
     <base href = "http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/" />
   </head>
   <body>
-    <p>Test passes if there isn't a filled blue square.</p>
+    <p>Test passes if there is no blue.</p>
     <img src="blue-100x100.png"/>
   </body>
 </html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_chidl-src_asterisk.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_chidl-src_asterisk.cgi
@@ -46,6 +46,6 @@ Authors:
   </head>
   <body>
     <p>Test passes if there is <strong>red</strong>.</p>
-    <iframe src="http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/red-100x100.png"/>
+    <iframe frameborder="no" border="0" src="http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/red-100x100.png"/>
   </body>
 </html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_chidl-src_cross-orgin_allowed.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_chidl-src_cross-orgin_allowed.cgi
@@ -46,6 +46,6 @@ Authors:
   </head>
   <body>
     <p>Test passes if there is <strong>red</strong>.</p>
-    <iframe src="http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/red-100x100.png"/>
+    <iframe frameborder="no" border="0" src="http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/red-100x100.png"/>
   </body>
 </html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_chidl-src_cross-orgin_blocked.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_chidl-src_cross-orgin_blocked.cgi
@@ -46,6 +46,6 @@ Authors:
   </head>
   <body>
     <p>Test passes if there is <strong>no red</strong>.</p>
-    <iframe src="http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/red-100x100.png"/>
+    <iframe frameborder="no" border="0" src="http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/red-100x100.png"/>
   </body>
 </html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_chidl-src_self.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_chidl-src_self.cgi
@@ -46,6 +46,6 @@ Authors:
   </head>
   <body>
     <p>Test passes if there is a filled blue square.</p>
-    <iframe src="support/blue-100x100.png"/>
+    <iframe frameborder="no" border="0" src="support/blue-100x100.png"/>
   </body>
 </html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_default-src_self_frame_allowed.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_default-src_self_frame_allowed.cgi
@@ -46,6 +46,6 @@ Authors:
   </head>
   <body>
     <p>Test passes if there is a filled blue square.</p>
-    <iframe src="support/blue-100x100.png"/>
+    <iframe frameborder="no" border="0" src="support/blue-100x100.png"/>
   </body>
 </html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_frame-ancestors_asterisk.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_frame-ancestors_asterisk.cgi
@@ -46,6 +46,6 @@ Authors:
   </head>
   <body>
     <p>Test passes if there is a filled blue square.</p>
-    <iframe src="support/blue-100x100.png"/>
+    <iframe frameborder="no" border="0" src="support/blue-100x100.png"/>
   </body>
 </html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_frame-ancestors_none.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_frame-ancestors_none.cgi
@@ -46,6 +46,6 @@ Authors:
   </head>
   <body>
     <p>Test passes if there is not a filled blue square.</p>
-    <iframe src="support/blue-100x100.png"/>
+    <iframe frameborder="no" border="0" src="support/blue-100x100.png"/>
   </body>
 </html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_frame-src_asterisk_allowed_ext.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_frame-src_asterisk_allowed_ext.cgi
@@ -46,6 +46,6 @@ Authors:
   </head>
   <body>
     <p>Test passes if there is a filled green square.</p>
-    <iframe src="http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/green-100x100.png"/>
+    <iframe frameborder="no" border="0" src="http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/green-100x100.png"/>
   </body>
 </html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_frame-src_asterisk_allowed_int.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_frame-src_asterisk_allowed_int.cgi
@@ -46,6 +46,6 @@ Authors:
   </head>
   <body>
     <p>Test passes if there is a filled blue square.</p>
-    <iframe src="support/blue-100x100.png"/>
+    <iframe frameborder="no" border="0" src="support/blue-100x100.png"/>
   </body>
 </html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_frame-src_cross-origin_allowed.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_frame-src_cross-origin_allowed.cgi
@@ -46,6 +46,6 @@ Authors:
   </head>
   <body>
     <p>Test passes if there is a filled green square.</p>
-    <iframe src="http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/green-100x100.png"/>
+    <iframe frameborder="no" border="0" src="http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/green-100x100.png"/>
   </body>
 </html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_frame-src_cross-origin_multi_allowed_one.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_frame-src_cross-origin_multi_allowed_one.cgi
@@ -46,6 +46,6 @@ Authors:
   </head>
   <body>
     <p>Test passes if there is a filled green square.</p>
-    <iframe src="http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/green-100x100.png"/>
+    <iframe frameborder="no" border="0" src="http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/green-100x100.png"/>
   </body>
 </html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_frame-src_cross-origin_multi_allowed_two.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_frame-src_cross-origin_multi_allowed_two.cgi
@@ -46,6 +46,6 @@ Authors:
   </head>
   <body>
     <p>Test passes if there is a filled green square.</p>
-    <iframe src="http://127.0.0.1:8082/opt/tct-csp-w3c-tests/csp/support/green-100x100.png"/>
+    <iframe frameborder="no" border="0" src="http://127.0.0.1:8082/opt/tct-csp-w3c-tests/csp/support/green-100x100.png"/>
   </body>
 </html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_frame-src_self_allowed.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_frame-src_self_allowed.cgi
@@ -46,6 +46,6 @@ Authors:
   </head>
   <body>
     <p>Test passes if there is a filled blue square.</p>
-    <iframe src="support/blue-100x100.png"/>
+    <iframe frameborder="no" border="0" src="support/blue-100x100.png"/>
   </body>
 </html> '

--- a/webapi/tct-csp-w3c-tests/csp/w3c/COPYING
+++ b/webapi/tct-csp-w3c-tests/csp/w3c/COPYING
@@ -6,6 +6,8 @@ with some modification below:
 
 2. Update ".php" postfix to ".cgi" in tests
 
+3. Add <body> and remove '<div id="log"><div>' in CSP_default-src-inline-blocked.cgi
+
 These tests are copyright by W3C and/or the author listed in the test
 file. The tests are dual-licensed under the W3C Test Suite License:
 http://www.w3.org/Consortium/Legal/2008/04-testsuite-license

--- a/webapi/tct-csp-w3c-tests/csp/w3c/CSP_default-src-inline-blocked.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/w3c/CSP_default-src-inline-blocked.cgi
@@ -13,7 +13,7 @@ echo '<!DOCTYPE html>
 <script src="../../resources/testharness.js"></script>
 <script src="../../resources/testharnessreport.js"></script>
 </head>
-<div id="log"></div>
+<body>
 <script src="resources/pass.js"></script>
 <script>
 test(function() {assert_true(false)}, "Inline scripts run (1 of 3)");

--- a/webapi/tct-csp-w3c-tests/tests.full.xml
+++ b/webapi/tct-csp-w3c-tests/tests.full.xml
@@ -2621,7 +2621,7 @@
           <steps>
             <step order="1">
               <step_desc>Run the manual testcase: CSP_default-src-inline-blocked.cgi</step_desc>
-              <expected>To pass, if a blank iframe appears below the testharness.</expected>
+              <expected>To pass, if a blank iframe appears.</expected>
             </step>
           </steps>
           <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/w3c/CSP_default-src-inline-blocked.cgi</test_script_entry>

--- a/webapi/tct-csp-w3c-tests/tests.xml
+++ b/webapi/tct-csp-w3c-tests/tests.xml
@@ -1468,7 +1468,7 @@
           <steps>
             <step order="1">
               <step_desc>Run the manual testcase: CSP_default-src-inline-blocked.cgi</step_desc>
-              <expected>To pass, if a blank iframe appears below the testharness.</expected>
+              <expected>To pass, if a blank iframe appears.</expected>
             </step>
           </steps>
           <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/w3c/CSP_default-src-inline-blocked.cgi</test_script_entry>


### PR DESCRIPTION
Impacted Suites: tct-csp-w3c-tests
Impacted TCs num: New 0, Update 13, Delete 0
Unit test Platform: Tizen
Tizen test result summary: Pass 9, Fail 4, Blocked 0

Comments:
1. base-usri, child-src, frame-ancestors are not supported.
2. Change the CSP_default-src-inline-blocked.cgi from auto test to manual test, in order to make the test result is clear, remove the div label with ' id="log" '.
