### PR TITLE
[wrt] Add name tcs for manifest on android

### DIFF
--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_CombinationValue.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_CombinationValue.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_CombinationValue</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_CombinationValue_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_EncodeChinese.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_EncodeChinese.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_EncodeChinese</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_EncodeChinese_tests/manifest.json</li>
+      <li>Install webapp.</li>
+      <li>Launch app.</li>
+      <li>Check app name in App Manager</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully</li>
+      <li>The webapp be installed successfully</li>
+      <li>The app launched successfully.</li>
+      <li>The value is "名字""</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadDoubleQuotationMarks.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadDoubleQuotationMarks.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadDoubleQuotationMarks</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_headdoublequotationmarks_tests/manifest.json</li>
+      <li>Install webapp.</li>
+      <li>Check result in App Manager</li>
+      <li>Click icon to launch.</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully, illegal character is replaced with "_"</li>
+      <li>The webapp be installed successfully</li>
+      <li>The value of "name" is correct,such as ""name":"__headdoublequotationmarks""</li>
+      <li>The app launched successfully.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationAngleBracket.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationAngleBracket.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadEncodePunctuationAngleBracket</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadEncodePunctuationAngleBracket_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationBrace.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationBrace.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadEncodePunctuationBrace</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadEncodePunctuationBrace_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationCaesura.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationCaesura.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadEncodePunctuationCaesura</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadEncodePunctuationCaesura_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure,There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>
+

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationColon.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationColon.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadEncodePunctuationColon</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadEncodePunctuationColon_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationComma.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationComma.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadEncodePunctuationComma</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadEncodePunctuationComma_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationDOT.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationDOT.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadEncodePunctuationDOT</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadEncodePunctuationDOT_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationDash.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationDash.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadEncodePunctuationDash</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadEncodePunctuationDash_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationDoubqQuot.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationDoubqQuot.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadEncodePunctuationDoubqQuot</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadEncodePunctuationDoubqQuot_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationExclamatory.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationExclamatory.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadEncodePunctuationExclamatory</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadEncodePunctuationExclamatory_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationInterrogat.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationInterrogat.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadEncodePunctuationInterrogat</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadEncodePunctuationInterrogat_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationMidBracket.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationMidBracket.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadEncodePunctuationMidBracket</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadEncodePunctuationMidBracket_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationMidpoint.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationMidpoint.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadEncodePunctuationMidpoint</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadEncodePunctuationMidpoint_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationRoundBracket.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationRoundBracket.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadEncodePunctuationRoundBracket</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadEncodePunctuationRoundBracket_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationSemicolon.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationSemicolon.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadEncodePunctuationSemicolon</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadEncodePunctuationSemicolon_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>
+

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationSingleQuot.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationSingleQuot.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadEncodePunctuationSingleQuot</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadEncodePunctuationSingleQuot_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodeUnitDollar.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodeUnitDollar.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadEncodeUnitDollar</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadEncodeUnitDollar_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEscapeCharBackSlash.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEscapeCharBackSlash.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadEscapeCharBackSlash</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadEscapeCharBackSlash_tests/manifest.json</li>
+      <li>Install webapp.</li>
+      <li>Launch app.</li>
+      <li>Check app name in App Manager</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully</li>
+      <li>The webapp be installed successfully</li>
+      <li>The app launched successfully.</li>
+      <li>The value is "_HeadEscapeCharBackSlash"</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEscapeCharLinefeed.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEscapeCharLinefeed.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadEscapeCharLinefeed</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadEscapeCharLinefeed_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEscapeCharSlash.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEscapeCharSlash.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadEscapeCharSlash</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadEscapeCharSlash_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEscapeCharTab.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEscapeCharTab.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadEscapeCharTab</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadEscapeCharTab_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadMatchOperatorAngle.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadMatchOperatorAngle.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadMatchOperatorAngle</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadMatchOperatorAngle_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadMatchOperatorAsterisk.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadMatchOperatorAsterisk.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadMatchOperatorAsterisk</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadMatchOperatorAsterisk_tests/manifest.json</li>
+      <li>Install webapp.</li>
+      <li>Launch app.</li>
+      <li>Check app name in App Manager</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully</li>
+      <li>The webapp be installed successfully</li>
+      <li>The app launched successfully.</li>
+      <li>The value is "_HeadMatchOperatorAsterisk""</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadMatchOperatorInterrogat.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadMatchOperatorInterrogat.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadMatchOperatorInterrogat</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadMatchOperatorInterrogat_tests/manifest.json</li>
+      <li>Install webapp.</li>
+      <li>Launch app.</li>
+      <li>Check app name in App Manager</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully</li>
+      <li>The webapp be installed successfully</li>
+      <li>The app launched successfully.</li>
+      <li>The value is "_HeadMatchOperatorInterrogat""</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadOtherAt.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadOtherAt.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadOtherAt</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadOtherAt_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadOtherDiv.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadOtherDiv.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadOtherDiv</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadOtherDiv_tests/manifest.json</li>
+      <li>Install webapp.</li>
+      <li>Launch app.</li>
+      <li>Check app name in App Manager</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully</li>
+      <li>The webapp be installed successfully</li>
+      <li>The app launched successfully.</li>
+      <li>The value is "_HeadOtherDiv""</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadOtherMinus.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadOtherMinus.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadOtherMinus</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadOtherMinus_tests/manifest.json</li>
+      <li>Install webapp.</li>
+      <li>Launch app.</li>
+      <li>Check app name in App Manager</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully</li>
+      <li>The webapp be installed successfully</li>
+      <li>The app launched successfully.</li>
+      <li>The value is "_HeadOtherMinus""</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadOtherNumber.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadOtherNumber.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadOtherNumber</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadOtherNumber_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadOtherPlus.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadOtherPlus.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadOtherPlus</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadOtherPlus_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationAngleBracket.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationAngleBracket.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadPunctuationAngleBracket</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadPunctuationAngleBracket_tests/manifest.json</li>
+      <li>Install webapp.</li>
+      <li>Launch app.</li>
+      <li>Check app name in App Manager</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully</li>
+      <li>The webapp be installed successfully</li>
+      <li>The app launched successfully.</li>
+      <li>The value is "__HeadPunctuationAngleBracket""</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationBrace.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationBrace.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadPunctuationBrace</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadPunctuationBrace_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationColon.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationColon.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadPunctuationColon</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadPunctuationColon_tests/manifest.json</li>
+      <li>Install webapp.</li>
+      <li>Launch app.</li>
+      <li>Check app name in App Manager</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully</li>
+      <li>The webapp be installed successfully</li>
+      <li>The app launched successfully.</li>
+      <li>The value is "_HeadPunctuationColon""</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationComma.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationComma.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadPunctuationComma</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadPunctuationComma_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationMidBracket.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationMidBracket.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadPunctuationMidBracket</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadPunctuationMidBracket_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationRoundBracket.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationRoundBracket.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadPunctuationRoundBracket</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadPunctuationRoundBracket_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationSemicolon.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationSemicolon.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadPunctuationSemicolon</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadPunctuationSemicolon_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationTilde.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationTilde.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadPunctuationTilde</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadPunctuationTilde_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadRelationalOperatorAnd.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadRelationalOperatorAnd.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadRelationalOperatorAnd</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadRelationalOperatorAnd_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadRelationalOperatorEqual.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadRelationalOperatorEqual.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadRelationalOperatorEqual</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadRelationalOperatorEqual_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadRelationalOperatorNotEqual.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadRelationalOperatorNotEqual.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadRelationalOperatorNotEqual</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadRelationalOperatorNotEqual_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadRelationalOperatorVertical.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadRelationalOperatorVertical.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadRelationalOperatorVertical</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadRelationalOperatorVertical_tests/manifest.json</li>
+      <li>Install webapp.</li>
+      <li>Launch app.</li>
+      <li>Check app name in App Manager</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully</li>
+      <li>The webapp be installed successfully</li>
+      <li>The app launched successfully.</li>
+      <li>The value is "_HeadRelationalOperatorVertical""</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadSingleQuotationMarks.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadSingleQuotationMarks.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadSingleQuotationMarks</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>Build app by "python make_apk.py localpath/manifest_name_headsinglequotationmarks_tests/manifest.json"</li>
+      <li>Install webapp.</li>
+      <li>Check result in App Manager</li>
+      <li>Click icon to launch.</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully, illegal character is replaced with "_"</li>
+      <li>The webapp be installed successfully</li>
+      <li>The value of "name" is correct,such as ""name":"__headsinglequotationmarks""</li>
+      <li>The app launched successfully.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadUnitDollar.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadUnitDollar.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadUnitDolla</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadUnitDolla_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadUnitExclamatory.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadUnitExclamatory.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadUnitExclamatory</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadUnitExclamatory_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadUnitPercent.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadUnitPercent.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadUnitPercent</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_HeadUnitPercent_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadWithDot.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadWithDot.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadWithDot.</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>Build app by "python make_apk.py localpath/manifest_name_headwithdot_tests/manifest.json"</li>
+      <li>Install webapp.</li>
+      <li>Check result in App Manager</li>
+      <li>Click icon to launch.</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully, illegal character is replaced with "_"</li>
+      <li>The webapp be installed successfully</li>
+      <li>The value of "name" is correct,such as ""name":"_headwithdot""</li>
+      <li>The app launched successfully.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadWithSpace.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadWithSpace.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadWithSpace.</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>Build app by "python make_apk.py localpath/manifest_name_headwithspace_tests/manifest.json"</li>
+      <li>Install webapp.</li>
+      <li>Check result in App Manager</li>
+      <li>Click icon to launch.</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully, illegal character is replaced with "_"</li>
+      <li>The webapp be installed successfully</li>
+      <li>The value of "name" is correct,such as ""name":"_headwithspace""</li>
+      <li>The app launched successfully.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadWithStrike.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadWithStrike.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadWithStrike.</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>Build app by "python make_apk.py localpath/manifest_name_headwithStrike_tests/manifest.json"</li>
+      <li>Install webapp.</li>
+      <li>Check result in App Manager</li>
+      <li>Click icon to launch.</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully, illegal character is replaced with "_"</li>
+      <li>The webapp be installed successfully</li>
+      <li>The value of "name" is correct,such as ""name":"_headwithStrike""</li>
+      <li>The app launched successfully.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadWithTab.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadWithTab.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_HeadWithTab.</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_headwithtab_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_LongString.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_LongString.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_LongString.</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>Build app by "python make_apk.py localpath/manifest_name_longstring_tests/manifest.json"</li>
+      <li>Install webapp.</li>
+      <li>Check result in App Manager</li>
+      <li>Click icon to launch.</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully, illegal character is replaced with "_"</li>
+      <li>The webapp be installed successfully</li>
+      <li>The value of "name" is correct,such as ""name":"longlonglonglong_longlonglonglong_longlonglonglong_longlonglonglong_longlonglonglong-longlonglonglong-longlonglonglong-longlonglonglong-longlonglonglong-longlonglonglong-longlonglonglong""</li>
+      <li>The app launched successfully.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleDoubleQuotationMarks.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleDoubleQuotationMarks.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_MiddleDoubleQuotationMarks.</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>Build app by "python make_apk.py localpath/manifest_name_middledoublequotationmarks_tests/manifest.json"</li>
+      <li>Install webapp.</li>
+      <li>Check result in App Manager</li>
+      <li>Click icon to launch.</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully, illegal character is replaced with "_"</li>
+      <li>The webapp be installed successfully</li>
+      <li>The value of "name" is correct,such as ""name":"middle__doublequotationmarks""</li>
+      <li>The app launched successfully.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEncodePunctuationComma.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEncodePunctuationComma.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_MiddleEncodePunctuationComma</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_MiddleEncodePunctuationComma_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEncodePunctuationDOT.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEncodePunctuationDOT.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_MiddleEncodePunctuationDOT</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_MiddleEncodePunctuationDOT_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEncodePunctuationDoubqQuot.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEncodePunctuationDoubqQuot.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_MiddleEncodePunctuationDoubqQuot</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_MiddleEncodePunctuationDoubqQuot_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEncodePunctuationInterrogat.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEncodePunctuationInterrogat.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_MiddleEncodePunctuationInterrogat</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_MiddleEncodePunctuationInterrogat_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEncodePunctuationRoundBracket.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEncodePunctuationRoundBracket.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_MiddleEncodePunctuationRoundBracket</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_Name_MiddleEncodePunctuationRoundBracket_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEncodePunctuationSemicolon.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEncodePunctuationSemicolon.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_MiddleEncodePunctuationSemicolon</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_MiddleEncodePunctuationSemicolon_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEscapeCharBackSlash.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEscapeCharBackSlash.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_MiddleEscapeCharBackSlash</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_MiddleEscapeCharBackSlash_tests/manifest.json</li>
+      <li>Install webapp.</li>
+      <li>Launch app.</li>
+      <li>Check app name in App Manager</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully</li>
+      <li>The webapp be installed successfully</li>
+      <li>The app launched successfully.</li>
+      <li>The value is "Middle_EscapeCharBackSlash"</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEscapeCharLinefeed.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEscapeCharLinefeed.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_MiddleEscapeCharLinefeed</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_MiddleEscapeCharLinefeed_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleMatchOperatorAngle.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleMatchOperatorAngle.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_MiddleMatchOperatorAngle</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_MiddleMatchOperatorAngle_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleMatchOperatorAsterisk.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleMatchOperatorAsterisk.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_MiddleMatchOperatorAsterisk</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_MiddleMatchOperatorAsterisk_tests/manifest.json</li>
+      <li>Install webapp.</li>
+      <li>Launch app.</li>
+      <li>Check app name in App Manager</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully</li>
+      <li>The webapp be installed successfully</li>
+      <li>The app launched successfully.</li>
+      <li>The value is "Middle_MatchOperatorAsterisk""</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleMatchOperatorInterrogat.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleMatchOperatorInterrogat.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_MiddleMatchOperatorInterrogat</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_MiddleMatchOperatorInterrogat_tests/manifest.json</li>
+      <li>Install webapp.</li>
+      <li>Launch app.</li>
+      <li>Check app name in App Manager</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully</li>
+      <li>The webapp be installed successfully</li>
+      <li>The app launched successfully.</li>
+      <li>The value is "Middle_MatchOperatorInterrogat""</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationAngleBracket.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationAngleBracket.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_MiddlePunctuationAngleBracket</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_MiddlePunctuationAngleBracket_tests/manifest.json</li>
+      <li>Install webapp.</li>
+      <li>Launch app.</li>
+      <li>Check app name in App Manager</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully</li>
+      <li>The webapp be installed successfully</li>
+      <li>The app launched successfully.</li>
+      <li>The value is "Middle__PunctuationAngleBracket""</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationBrace.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationBrace.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_MiddlePunctuationBrace</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_MiddlePunctuationBrace_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationColon.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationColon.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_MiddlePunctuationColon</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_MiddlePunctuationColon_tests/manifest.json</li>
+      <li>Install webapp.</li>
+      <li>Launch app.</li>
+      <li>Check app name in App Manager</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully</li>
+      <li>The webapp be installed successfully</li>
+      <li>The app launched successfully.</li>
+      <li>The value is "Middle_PunctuationColon""</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationComma.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationComma.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_MiddlePunctuationComma</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_MiddlePunctuationComma_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationMidBracket.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationMidBracket.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_MiddlePunctuationMidBracket</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_MiddlePunctuationMidBracket_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>
+

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationRoundBracket.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationRoundBracket.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_MiddlePunctuationRoundBracket</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_MiddlePunctuationRoundBracket_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationSemicolon.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationSemicolon.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_MiddlePunctuationSemicolon</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_MiddlePunctuationSemicolon_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationTilde.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationTilde.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_MiddlePunctuationTilde</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_MiddlePunctuationTilde_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleRelationalOperatorAnd.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleRelationalOperatorAnd.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_MiddleRelationalOperatorAnd</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_MiddleRelationalOperatorAnd_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleRelationalOperatorEqual.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleRelationalOperatorEqual.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_MiddleRelationalOperatorEqual</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_MiddleRelationalOperatorEqual_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleRelationalOperatorNotEqual.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleRelationalOperatorNotEqual.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_MiddleRelationalOperatorNotEqual</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_MiddleRelationalOperatorNotEqual_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleRelationalOperatorVertical.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleRelationalOperatorVertical.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_MiddleRelationalOperatorVertical</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_MiddleRelationalOperatorVertical_tests/manifest.json</li>
+      <li>Install webapp.</li>
+      <li>Launch app.</li>
+      <li>Check app name in App Manager</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully</li>
+      <li>The webapp be installed successfully</li>
+      <li>The app launched successfully.</li>
+      <li>The value is "Middle_RelationalOperatorVertical""</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleSingleQuotationMarks.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleSingleQuotationMarks.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_MiddleSingleQuotationMarks.</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>Build app by "python make_apk.py localpath/manifest_name_middlesinglequotationmarks_tests/manifest.json"</li>
+      <li>Install webapp.</li>
+      <li>Check result in App Manager</li>
+      <li>Click icon to launch.</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully, illegal character is replaced with "_"</li>
+      <li>The webapp be installed successfully</li>
+      <li>The value of "name" is correct,such as ""name":"middle__singlequotationmarks""</li>
+      <li>The app launched successfully.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleUnitDollar.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleUnitDollar.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_MiddleUnitDollar</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_MiddleUnitDollar_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleUnitExclamatory.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleUnitExclamatory.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_MiddleUnitExclamatory</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_MiddleUnitExclamatory_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleUnitPercent.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleUnitPercent.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_MiddleUnitPercent</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_MiddleUnitPercent_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleWithTab.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleWithTab.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_MiddleWithTab.</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_middlewithtab_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_NullValue.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_NullValue.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_NullValue</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_NullValue_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_Number.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_Number.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_Number.</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>Build app by "python make_apk.py localpath/manifest_name_number_tests/manifest.json"</li>
+      <li>Install webapp.</li>
+      <li>Check result in App Manager</li>
+      <li>Click icon to launch.</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully</li>
+      <li>The webapp be installed successfully</li>
+      <li>The value of "name" is correct,such as ""name":"123456""</li>
+      <li>The app launched successfully.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailDoubleQuotationMarks.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailDoubleQuotationMarks.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailDoubleQuotationMarks.</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>Build app by "python make_apk.py localpath/manifest_name_taildoublequotationmarks_tests/manifest.json"</li>
+      <li>Install webapp.</li>
+      <li>Check result in App Manager</li>
+      <li>Click icon to launch.</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully, illegal character is replaced with "_"</li>
+      <li>The webapp be installed successfully</li>
+      <li>The value of "name" is correct,such as ""name":"taildoublequotationmarks__""</li>
+      <li>The app launched successfully.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEncodePunctuationComma.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEncodePunctuationComma.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailEncodePunctuationComma</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_TailEncodePunctuationComma_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEncodePunctuationDOT.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEncodePunctuationDOT.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailEncodePunctuationDOT</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_TailEncodePunctuationDOT_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEncodePunctuationDoubqQuot.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEncodePunctuationDoubqQuot.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailEncodePunctuationDoubqQuot</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_TailEncodePunctuationDoubqQuot_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEncodePunctuationInterrogat.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEncodePunctuationInterrogat.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailEncodePunctuationInterrogat</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_TailEncodePunctuationInterrogat_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEncodePunctuationRoundBracket.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEncodePunctuationRoundBracket.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailEncodePunctuationRoundBracket</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_TailEncodePunctuationRoundBracket_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEncodePunctuationSemicolon.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEncodePunctuationSemicolon.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailEncodePunctuationSemicolon</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_TailEncodePunctuationSemicolon_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEscapeCharBackSlash.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEscapeCharBackSlash.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailEscapeCharBackSlash</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_TailEscapeCharBackSlash_tests/manifest.json</li>
+      <li>Install webapp.</li>
+      <li>Launch app.</li>
+      <li>Check app name in App Manager</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully</li>
+      <li>The webapp be installed successfully</li>
+      <li>The app launched successfully.</li>
+      <li>The value is "TailEscapeCharBackSlash_"</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEscapeCharTab.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEscapeCharTab.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailEscapeCharTab</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_TailEscapeCharTab_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailMatchOperatorAngle.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailMatchOperatorAngle.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailMatchOperatorAngle</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_TailMatchOperatorAngle_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailMatchOperatorAsterisk.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailMatchOperatorAsterisk.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailMatchOperatorAsterisk</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_TailMatchOperatorAsterisk_tests/manifest.json</li>
+      <li>Install webapp.</li>
+      <li>Launch app.</li>
+      <li>Check app name in App Manager</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully</li>
+      <li>The webapp be installed successfully</li>
+      <li>The app launched successfully.</li>
+      <li>The value is "TailMatchOperatorAsterisk_""</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailMatchOperatorInterrogat.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailMatchOperatorInterrogat.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailMatchOperatorInterrogat</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_TailMatchOperatorInterrogat_tests/manifest.json</li>
+      <li>Install webapp.</li>
+      <li>Launch app.</li>
+      <li>Check app name in App Manager</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully</li>
+      <li>The webapp be installed successfully</li>
+      <li>The app launched successfully.</li>
+      <li>The value is "TailMatchOperatorInterrogat_""</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationAngleBracket.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationAngleBracket.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailPunctuationAngleBracket</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_TailPunctuationAngleBracket_tests/manifest.json</li>
+      <li>Install webapp.</li>
+      <li>Launch app.</li>
+      <li>Check app name in App Manager</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully</li>
+      <li>The webapp be installed successfully</li>
+      <li>The app launched successfully.</li>
+      <li>The value is "TailPunctuationAngleBracket_""</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationBrace.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationBrace.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailPunctuationBrace</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_TailPunctuationBrace_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationColon.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationColon.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailPunctuationColon</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_TailPunctuationColon_tests/manifest.json</li>
+      <li>Install webapp.</li>
+      <li>Launch app.</li>
+      <li>Check app name in App Manager</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully</li>
+      <li>The webapp be installed successfully</li>
+      <li>The app launched successfully.</li>
+      <li>The value is "TailPunctuationColon_""</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationComma.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationComma.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailPunctuationComma</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_TailPunctuationComma_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationMidBracket.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationMidBracket.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailPunctuationMidBracket</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_TailPunctuationMidBracket_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationRoundBracket.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationRoundBracket.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailPunctuationRoundBracket</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_TailPunctuationRoundBracket_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationSemicolon.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationSemicolon.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailPunctuationSemicolon</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_TailPunctuationSemicolon_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationTilde.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationTilde.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailPunctuationTilde</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_TailPunctuationTilde_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailRelationalOperatorAnd.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailRelationalOperatorAnd.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailRelationalOperatorAnd</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_TailRelationalOperatorAnd_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailRelationalOperatorEqual.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailRelationalOperatorEqual.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailRelationalOperatorEqual</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_TailRelationalOperatorEqual_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailRelationalOperatorRBracket.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailRelationalOperatorRBracket.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailRelationalOperatorRBracket</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_TailRelationalOperatorRBracket_tests/manifest.json</li>
+      <li>Install webapp.</li>
+      <li>Launch app.</li>
+      <li>Check app name in App Manager</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully</li>
+      <li>The webapp be installed successfully</li>
+      <li>The app launched successfully.</li>
+      <li>The value is "TailRelationalOperatorRBracket_""</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailRelationalOperatorVertical.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailRelationalOperatorVertical.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailRelationalOperatorVertical</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_TailRelationalOperatorVertical_tests/manifest.json</li>
+      <li>Install webapp.</li>
+      <li>Launch app.</li>
+      <li>Check app name in App Manager</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully</li>
+      <li>The webapp be installed successfully</li>
+      <li>The app launched successfully.</li>
+      <li>The value is "TailRelationalOperatorVertical_""</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailSingleQuotationMarks.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailSingleQuotationMarks.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailSingleQuotationMarks.</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>Build app by "python make_apk.py localpath/manifest_name_tailsinglequotationmarks_tests/manifest.json"</li>
+      <li>Install webapp.</li>
+      <li>Check result in App Manager</li>
+      <li>Click icon to launch.</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully, illegal character is replaced with "_"</li>
+      <li>The webapp be installed successfully</li>
+      <li>The value of "name" is correct,such as ""name":"tailsinglequotationmarks__""</li>
+      <li>The app launched successfully.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailUnitDollar.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailUnitDollar.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailUnitDollar</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_TailUnitDollar_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailUnitExclamatory.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailUnitExclamatory.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailUnitExclamatory</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_TailUnitExclamatory_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailUnitPercent.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailUnitPercent.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailUnitPercent</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_TailUnitPercent_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailWithDot.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailWithDot.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailWithDot.</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>Build app by "python make_apk.py localpath/manifest_name_tailwithdot_tests/manifest.json"</li>
+      <li>Install webapp.</li>
+      <li>Check result in App Manager</li>
+      <li>Click icon to launch.</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully, illegal character is replaced with "_"</li>
+      <li>The webapp be installed successfully</li>
+      <li>The value of "name" is correct,such as ""name":"tailwithdot_""</li>
+      <li>The app launched successfully.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailWithSpace.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailWithSpace.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailWithSpace.</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>Build app by "python make_apk.py localpath/manifest_name_tailwithspace_tests/manifest.json"</li>
+      <li>Install webapp.</li>
+      <li>Check result in App Manager</li>
+      <li>Click icon to launch.</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully, illegal character is replaced with "_"</li>
+      <li>The webapp be installed successfully</li>
+      <li>The value of "name" is correct,such as ""name":"tailwithspace_""</li>
+      <li>The app launched successfully.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailWithStrike.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailWithStrike.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailWithStrike.</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>Build app by "python make_apk.py localpath/manifest_name_tailwithStrike_tests/manifest.json"</li>
+      <li>Install webapp.</li>
+      <li>Check result in App Manager</li>
+      <li>Click icon to launch.</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app packed successfully, illegal character is replaced with "_"</li>
+      <li>The webapp be installed successfully</li>
+      <li>The value of "name" is correct,such as ""name":"tailwithStrike_""</li>
+      <li>The app launched successfully.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailWithTab.html
+++ b/wrt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailWithTab.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+      linx.a.shen@intel.com
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Manifest_Name_TailWithTab.</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>python make_apk.py --manifest=path/manifest_name_TailWithTab_tests/manifest.json</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>The app shoulde be build failure, There is a parser error in manifest.json file.</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-rtcore-android-tests/tests.full.xml
+++ b/wrt/wrt-rtcore-android-tests/tests.full.xml
@@ -680,6 +680,1041 @@
           <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Icon_ThreeIcon.html</test_script_entry>
         </description>
       </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with double quotation marks" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_HeadDoubleQuotationMarks">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadDoubleQuotationMarks.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with single quotation marks" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_HeadSingleQuotationMarks">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadSingleQuotationMarks.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with dot" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_HeadWithDot">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadWithDot.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with space" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_HeadWithSpace">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadWithSpace.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with strike" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_HeadWithStrike">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadWithStrike.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Tab" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_HeadWithTab">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadWithTab.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is long string" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_LongString">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_LongString.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is middle with double quotation marks" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_MiddleDoubleQuotationMarks">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleDoubleQuotationMarks.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is middle with single quotation marks" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_MiddleSingleQuotationMarks">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleSingleQuotationMarks.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is middle with Tab" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_MiddleWithTab">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleWithTab.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is number" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P1" id="Crosswalk_Manifest_Name_Number">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_Number.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is tail with double quotation marks" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_TailDoubleQuotationMarks">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailDoubleQuotationMarks.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is tail with single quotation marks" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_TailSingleQuotationMarks">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailSingleQuotationMarks.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is tail with dot" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_TailWithDot">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailWithDot.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is tail with space" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_TailWithSpace">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailWithSpace.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is tail with strike" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_TailWithStrike">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailWithStrike.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is tail with Tab" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_TailWithTab">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailWithTab.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Combination Value" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_CombinationValue">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_CombinationValue.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Encode Chinese" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_EncodeChinese">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_EncodeChinese.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Encode Punctuation AngleBracket" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadEncodePunctuationAngleBracket">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationAngleBracket.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Encode Punctuation Brace" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadEncodePunctuationBrace">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationBrace.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Encode Punctuation Caesura" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadEncodePunctuationCaesura">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationCaesura.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Encode Punctuation Colon" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadEncodePunctuationColon">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationColon.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Encode Punctuation Comma" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadEncodePunctuationComma">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationComma.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Encode Punctuation Dash" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadEncodePunctuationDash">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationDash.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Encode Punctuation DOT" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadEncodePunctuationDOT">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationDOT.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Encode Punctuation DoubqQuot" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadEncodePunctuationDoubqQuot">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationDoubqQuot.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Encode Punctuation Exclamatory" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadEncodePunctuationExclamatory">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationExclamatory.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Encode Punctuation Interrogat" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadEncodePunctuationInterrogat">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationInterrogat.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Encode Punctuation MidBracket" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadEncodePunctuationMidBracket">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationMidBracket.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Encode Punctuation Midpoint" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadEncodePunctuationMidpoint">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationMidpoint.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Encode Punctuation RoundBracket" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadEncodePunctuationRoundBracket">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationRoundBracket.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Encode Punctuation Semicolon" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadEncodePunctuationSemicolon">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationSemicolon.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Encode Punctuation SingleQuot" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadEncodePunctuationSingleQuot">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationSingleQuot.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Encode Unit Dollar" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadEncodeUnitDollar">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodeUnitDollar.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Escape Char BackSlash" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_HeadEscapeCharBackSlash">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEscapeCharBackSlash.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Escape Char Linefeed" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadEscapeCharLinefeed">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEscapeCharLinefeed.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Escape Char Slash" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadEscapeCharSlash">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEscapeCharSlash.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Escape Char Tab" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadEscapeCharTab">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEscapeCharTab.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Match Operator Angle" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadMatchOperatorAngle">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadMatchOperatorAngle.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Match Operator Asterisk" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_HeadMatchOperatorAsterisk">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadMatchOperatorAsterisk.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Match Operator Interrogat" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_HeadMatchOperatorInterrogat">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadMatchOperatorInterrogat.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Other At" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadOtherAt">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadOtherAt.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Other Div" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_HeadOtherDiv">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadOtherDiv.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Other Minus" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_HeadOtherMinus">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadOtherMinus.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Other Number" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadOtherNumber">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadOtherNumber.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Other Plus" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadOtherPlus">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadOtherPlus.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Punctuation AngleBracket" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_HeadPunctuationAngleBracket">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationAngleBracket.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Punctuation Brace" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadPunctuationBrace">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationBrace.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Punctuation Colon" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_HeadPunctuationColon">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationColon.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Punctuation Camma" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadPunctuationComma">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationComma.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Punctuation MidBracket" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadPunctuationMidBracket">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationMidBracket.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Punctuation RoundBracket" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadPunctuationRoundBracket">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationRoundBracket.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Punctuation Semicolon" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadPunctuationSemicolon">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationSemicolon.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Punctuation Tilde" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadPunctuationTilde">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationTilde.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Relational Operator And" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadRelationalOperatorAnd">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadRelationalOperatorAnd.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Relational Operator Equal" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadRelationalOperatorEqual">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadRelationalOperatorEqual.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Relational Operator Not Equal" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadRelationalOperatorNotEqual">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadRelationalOperatorNotEqual.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Relational Operator Vertical" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_HeadRelationalOperatorVertical">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadRelationalOperatorVertical.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Unit Dollar" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadUnitDollar">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadUnitDollar.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Unit Exclamatory" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadUnitExclamatory">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadUnitExclamatory.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Head Unit Percent" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_HeadUnitPercent">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadUnitPercent.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Middle Encode Punctuation Comma" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_MiddleEncodePunctuationComma">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEncodePunctuationComma.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Middle Encode Punctuation DOT" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_MiddleEncodePunctuationDOT">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEncodePunctuationDOT.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Middle Encode Punctuation DoubqQuot" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_MiddleEncodePunctuationDoubqQuot">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEncodePunctuationDoubqQuot.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Middle Encode Punctuation Interrogat" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_MiddleEncodePunctuationInterrogat">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEncodePunctuationInterrogat.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Middle Encode Punctuation RoundBracket" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_MiddleEncodePunctuationRoundBracket">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEncodePunctuationRoundBracket.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Middle Encode Punctuation Semicolon" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_MiddleEncodePunctuationSemicolon">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEncodePunctuationSemicolon.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Middle Escape Char BackSlash" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_MiddleEscapeCharBackSlash">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEscapeCharBackSlash.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Middle Escape Char Linefeed" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_MiddleEscapeCharLinefeed">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEscapeCharLinefeed.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Middle Match Operator Angle" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_MiddleMatchOperatorAngle">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleMatchOperatorAngle.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Middle Match Operator Asterisk" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_MiddleMatchOperatorAsterisk">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleMatchOperatorAsterisk.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Middle Match Operator Interrogat" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_MiddleMatchOperatorInterrogat">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleMatchOperatorInterrogat.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Middle Punctuation AngleBracket" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_MiddlePunctuationAngleBracket">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationAngleBracket.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Middle Punctuation Brace" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_MiddlePunctuationBrace">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationBrace.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Middle Punctuation Colon" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_MiddlePunctuationColon">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationColon.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Middle Punctuation Comma" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_MiddlePunctuationComma">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationComma.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Middle Punctuation MidBracket" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_MiddlePunctuationMidBracket">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationMidBracket.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Middle Punctuation RoundBracket" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_MiddlePunctuationRoundBracket">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationRoundBracket.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Middle Punctuation Semicolon" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_MiddlePunctuationSemicolon">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationSemicolon.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Middle Punctuation Tilde" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_MiddlePunctuationTilde">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationTilde.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Middle Relational Operator And" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_MiddleRelationalOperatorAnd">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleRelationalOperatorAnd.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Middle Relational Operator Equal" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_MiddleRelationalOperatorEqual">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleRelationalOperatorEqual.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Middle Relational Operator NotEqual" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_MiddleRelationalOperatorNotEqual">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleRelationalOperatorNotEqual.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Middle Relational Operator Vertical" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_MiddleRelationalOperatorVertical">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleRelationalOperatorVertical.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Middle Unit Dollar" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_MiddleUnitDollar">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleUnitDollar.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Middle Unit Exclamatory" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_MiddleUnitExclamatory">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleUnitExclamatory.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Middle Unit Percent" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_MiddleUnitPercent">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleUnitPercent.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Null Value" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_NullValue">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_NullValue.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Tail Encode Punctuation Comma" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_TailEncodePunctuationComma">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEncodePunctuationComma.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Tail Encode Punctuation DOT" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_TailEncodePunctuationDOT">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEncodePunctuationDOT.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Tail Encode Punctuation DoubqQuot" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_TailEncodePunctuationDoubqQuot">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEncodePunctuationDoubqQuot.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Tail Encode Punctuation Interrogat" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_TailEncodePunctuationInterrogat">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEncodePunctuationInterrogat.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Tail Encode Punctuation RoundBracket" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_TailEncodePunctuationRoundBracket">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEncodePunctuationRoundBracket.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Tail Encode Punctuation Semicolon" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_TailEncodePunctuationSemicolon">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEncodePunctuationSemicolon.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Tail Escape Char BackSlash" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_TailEscapeCharBackSlash">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEscapeCharBackSlash.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Tail Escape Char Tab" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_TailEscapeCharTab">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEscapeCharTab.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Tail Match Operator Angle" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_TailMatchOperatorAngle">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailMatchOperatorAngle.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Tail Match Operator Asterisk" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_TailMatchOperatorAsterisk">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailMatchOperatorAsterisk.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Tail Match Operator Interrogat" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_TailMatchOperatorInterrogat">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailMatchOperatorInterrogat.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Tail Match Operator AngleBracket" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_TailPunctuationAngleBracket">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationAngleBracket.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Tail Punctuation Brace" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_TailPunctuationBrace">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationBrace.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Tail Punctuation Colon" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_TailPunctuationColon">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationColon.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Tail Punctuation Comma" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_TailPunctuationComma">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationComma.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Tail Punctuation MidBracket" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_TailPunctuationMidBracket">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationMidBracket.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Tail Punctuation RoundBracket" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_TailPunctuationRoundBracket">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationRoundBracket.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Tail Punctuation Semicolon" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_TailPunctuationSemicolon">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationSemicolon.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Tail Punctuation Tilde" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_TailPunctuationTilde">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationTilde.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Tail Relational Operator And" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_TailRelationalOperatorAnd">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailRelationalOperatorAnd.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Tail Relational Operator Equal" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_TailRelationalOperatorEqual">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailRelationalOperatorEqual.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Tail Relational Operator RBracket" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_TailRelationalOperatorRBracket">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailRelationalOperatorRBracket.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Tail Relational Operator Vertical" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P2" id="Crosswalk_Manifest_Name_TailRelationalOperatorVertical">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailRelationalOperatorVertical.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Tail Unit Dollar" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_TailUnitDollar">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailUnitDollar.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Tail Unit Exclamatory" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_TailUnitExclamatory">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailUnitExclamatory.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate the Manifest name of web app is head with Tail Unit Percent" type="Functional" status="approved" component="Runtime Core" execution_type="manual" priority="P3" id="Crosswalk_Manifest_Name_TailUnitPercent">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <post_condition/>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailUnitPercent.html </test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>

--- a/wrt/wrt-rtcore-android-tests/tests.xml
+++ b/wrt/wrt-rtcore-android-tests/tests.xml
@@ -602,6 +602,926 @@
           <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Icon_ThreeIcon.html</test_script_entry>
         </description>
       </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadDoubleQuotationMarks" purpose="Validate the Manifest name of web app is head with double quotation marks">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadDoubleQuotationMarks.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadSingleQuotationMarks" purpose="Validate the Manifest name of web app is head with single quotation marks">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadSingleQuotationMarks.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadWithDot" purpose="Validate the Manifest name of web app is head with dot">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadWithDot.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadWithSpace" purpose="Validate the Manifest name of web app is head with space">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadWithSpace.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadWithStrike" purpose="Validate the Manifest name of web app is head with strike">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadWithStrike.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadWithTab" purpose="Validate the Manifest name of web app is head with Tab">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadWithTab.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_LongString" purpose="Validate the Manifest name of web app is long string">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_LongString.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_MiddleDoubleQuotationMarks" purpose="Validate the Manifest name of web app is middle with double quotation marks">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleDoubleQuotationMarks.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_MiddleSingleQuotationMarks" purpose="Validate the Manifest name of web app is middle with single quotation marks">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleSingleQuotationMarks.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_MiddleWithTab" purpose="Validate the Manifest name of web app is middle with Tab">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleWithTab.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_Number" purpose="Validate the Manifest name of web app is number">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_Number.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailDoubleQuotationMarks" purpose="Validate the Manifest name of web app is tail with double quotation marks">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailDoubleQuotationMarks.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailSingleQuotationMarks" purpose="Validate the Manifest name of web app is tail with single quotation marks">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailSingleQuotationMarks.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailWithDot" purpose="Validate the Manifest name of web app is tail with dot">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailWithDot.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailWithSpace" purpose="Validate the Manifest name of web app is tail with space">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailWithSpace.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailWithStrike" purpose="Validate the Manifest name of web app is tail with strike">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailWithStrike.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailWithTab" purpose="Validate the Manifest name of web app is tail with Tab">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailWithTab.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_CombinationValue" purpose="Validate the Manifest name of web app is head with Combination Value">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_CombinationValue.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_EncodeChinese" purpose="Validate the Manifest name of web app is head with Encode Chinese">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_EncodeChinese.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadEncodePunctuationAngleBracket" purpose="Validate the Manifest name of web app is head with Head Encode Punctuation AngleBracket">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationAngleBracket.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadEncodePunctuationBrace" purpose="Validate the Manifest name of web app is head with Head Encode Punctuation Brace">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationBrace.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadEncodePunctuationCaesura" purpose="Validate the Manifest name of web app is head with Head Encode Punctuation Caesura">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationCaesura.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadEncodePunctuationColon" purpose="Validate the Manifest name of web app is head with Head Encode Punctuation Colon">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationColon.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadEncodePunctuationComma" purpose="Validate the Manifest name of web app is head with Head Encode Punctuation Comma">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationComma.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadEncodePunctuationDash" purpose="Validate the Manifest name of web app is head with Head Encode Punctuation Dash">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationDash.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadEncodePunctuationDOT" purpose="Validate the Manifest name of web app is head with Head Encode Punctuation DOT">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationDOT.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadEncodePunctuationDoubqQuot" purpose="Validate the Manifest name of web app is head with Head Encode Punctuation DoubqQuot">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationDoubqQuot.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadEncodePunctuationExclamatory" purpose="Validate the Manifest name of web app is head with Head Encode Punctuation Exclamatory">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationExclamatory.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadEncodePunctuationInterrogat" purpose="Validate the Manifest name of web app is head with Head Encode Punctuation Interrogat">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationInterrogat.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadEncodePunctuationMidBracket" purpose="Validate the Manifest name of web app is head with Head Encode Punctuation MidBracket">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationMidBracket.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadEncodePunctuationMidpoint" purpose="Validate the Manifest name of web app is head with Head Encode Punctuation Midpoint">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationMidpoint.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadEncodePunctuationRoundBracket" purpose="Validate the Manifest name of web app is head with Head Encode Punctuation RoundBracket">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationRoundBracket.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadEncodePunctuationSemicolon" purpose="Validate the Manifest name of web app is head with Head Encode Punctuation Semicolon">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationSemicolon.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadEncodePunctuationSingleQuot" purpose="Validate the Manifest name of web app is head with Head Encode Punctuation SingleQuot">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodePunctuationSingleQuot.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadEncodeUnitDollar" purpose="Validate the Manifest name of web app is head with Head Encode Unit Dollar">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEncodeUnitDollar.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadEscapeCharBackSlash" purpose="Validate the Manifest name of web app is head with Head Escape Char BackSlash">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEscapeCharBackSlash.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadEscapeCharLinefeed" purpose="Validate the Manifest name of web app is head with Head Escape Char Linefeed">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEscapeCharLinefeed.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadEscapeCharSlash" purpose="Validate the Manifest name of web app is head with Head Escape Char Slash">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEscapeCharSlash.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadEscapeCharTab" purpose="Validate the Manifest name of web app is head with Head Escape Char Tab">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadEscapeCharTab.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadMatchOperatorAngle" purpose="Validate the Manifest name of web app is head with Head Match Operator Angle">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadMatchOperatorAngle.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadMatchOperatorAsterisk" purpose="Validate the Manifest name of web app is head with Head Match Operator Asterisk">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadMatchOperatorAsterisk.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadMatchOperatorInterrogat" purpose="Validate the Manifest name of web app is head with Head Match Operator Interrogat">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadMatchOperatorInterrogat.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadOtherAt" purpose="Validate the Manifest name of web app is head with Head Other At">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadOtherAt.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadOtherDiv" purpose="Validate the Manifest name of web app is head with Head Other Div">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadOtherDiv.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadOtherMinus" purpose="Validate the Manifest name of web app is head with Head Other Minus">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadOtherMinus.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadOtherNumber" purpose="Validate the Manifest name of web app is head with Head Other Number">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadOtherNumber.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadOtherPlus" purpose="Validate the Manifest name of web app is head with Head Other Plus">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadOtherPlus.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadPunctuationAngleBracket" purpose="Validate the Manifest name of web app is head with Head Punctuation AngleBracket">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationAngleBracket.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadPunctuationBrace" purpose="Validate the Manifest name of web app is head with Head Punctuation Brace">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationBrace.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadPunctuationColon" purpose="Validate the Manifest name of web app is head with Head Punctuation Colon">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationColon.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadPunctuationComma" purpose="Validate the Manifest name of web app is head with Head Punctuation Camma">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationComma.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadPunctuationMidBracket" purpose="Validate the Manifest name of web app is head with Head Punctuation MidBracket">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationMidBracket.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadPunctuationRoundBracket" purpose="Validate the Manifest name of web app is head with Head Punctuation RoundBracket">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationRoundBracket.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadPunctuationSemicolon" purpose="Validate the Manifest name of web app is head with Head Punctuation Semicolon">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationSemicolon.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadPunctuationTilde" purpose="Validate the Manifest name of web app is head with Head Punctuation Tilde">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadPunctuationTilde.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadRelationalOperatorAnd" purpose="Validate the Manifest name of web app is head with Head Relational Operator And">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadRelationalOperatorAnd.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadRelationalOperatorEqual" purpose="Validate the Manifest name of web app is head with Head Relational Operator Equal">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadRelationalOperatorEqual.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadRelationalOperatorNotEqual" purpose="Validate the Manifest name of web app is head with Head Relational Operator Not Equal">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadRelationalOperatorNotEqual.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadRelationalOperatorVertical" purpose="Validate the Manifest name of web app is head with Head Relational Operator Vertical">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadRelationalOperatorVertical.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadUnitDollar" purpose="Validate the Manifest name of web app is head with Head Unit Dollar">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadUnitDollar.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadUnitExclamatory" purpose="Validate the Manifest name of web app is head with Head Unit Exclamatory">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadUnitExclamatory.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_HeadUnitPercent" purpose="Validate the Manifest name of web app is head with Head Unit Percent">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_HeadUnitPercent.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_MiddleEncodePunctuationComma" purpose="Validate the Manifest name of web app is head with Middle Encode Punctuation Comma">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEncodePunctuationComma.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_MiddleEncodePunctuationDOT" purpose="Validate the Manifest name of web app is head with Middle Encode Punctuation DOT">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEncodePunctuationDOT.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_MiddleEncodePunctuationDoubqQuot" purpose="Validate the Manifest name of web app is head with Middle Encode Punctuation DoubqQuot">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEncodePunctuationDoubqQuot.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_MiddleEncodePunctuationInterrogat" purpose="Validate the Manifest name of web app is head with Middle Encode Punctuation Interrogat">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEncodePunctuationInterrogat.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_MiddleEncodePunctuationRoundBracket" purpose="Validate the Manifest name of web app is head with Middle Encode Punctuation RoundBracket">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEncodePunctuationRoundBracket.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_MiddleEncodePunctuationSemicolon" purpose="Validate the Manifest name of web app is head with Middle Encode Punctuation Semicolon">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEncodePunctuationSemicolon.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_MiddleEscapeCharBackSlash" purpose="Validate the Manifest name of web app is head with Middle Escape Char BackSlash">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEscapeCharBackSlash.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_MiddleEscapeCharLinefeed" purpose="Validate the Manifest name of web app is head with Middle Escape Char Linefeed">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleEscapeCharLinefeed.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_MiddleMatchOperatorAngle" purpose="Validate the Manifest name of web app is head with Middle Match Operator Angle">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleMatchOperatorAngle.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_MiddleMatchOperatorAsterisk" purpose="Validate the Manifest name of web app is head with Middle Match Operator Asterisk">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleMatchOperatorAsterisk.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_MiddleMatchOperatorInterrogat" purpose="Validate the Manifest name of web app is head with Middle Match Operator Interrogat">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleMatchOperatorInterrogat.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_MiddlePunctuationAngleBracket" purpose="Validate the Manifest name of web app is head with Middle Punctuation AngleBracket">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationAngleBracket.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_MiddlePunctuationBrace" purpose="Validate the Manifest name of web app is head with Middle Punctuation Brace">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationBrace.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_MiddlePunctuationColon" purpose="Validate the Manifest name of web app is head with Middle Punctuation Colon">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationColon.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_MiddlePunctuationComma" purpose="Validate the Manifest name of web app is head with Middle Punctuation Comma">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationComma.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_MiddlePunctuationMidBracket" purpose="Validate the Manifest name of web app is head with Middle Punctuation MidBracket">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationMidBracket.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_MiddlePunctuationRoundBracket" purpose="Validate the Manifest name of web app is head with Middle Punctuation RoundBracket">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationRoundBracket.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_MiddlePunctuationSemicolon" purpose="Validate the Manifest name of web app is head with Middle Punctuation Semicolon">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationSemicolon.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_MiddlePunctuationTilde" purpose="Validate the Manifest name of web app is head with Middle Punctuation Tilde">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddlePunctuationTilde.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_MiddleRelationalOperatorAnd" purpose="Validate the Manifest name of web app is head with Middle Relational Operator And">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleRelationalOperatorAnd.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_MiddleRelationalOperatorEqual" purpose="Validate the Manifest name of web app is head with Middle Relational Operator Equal">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleRelationalOperatorEqual.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_MiddleRelationalOperatorNotEqual" purpose="Validate the Manifest name of web app is head with Middle Relational Operator NotEqual">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleRelationalOperatorNotEqual.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_MiddleRelationalOperatorVertical" purpose="Validate the Manifest name of web app is head with Middle Relational Operator Vertical">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleRelationalOperatorVertical.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_MiddleUnitDollar" purpose="Validate the Manifest name of web app is head with Middle Unit Dollar">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleUnitDollar.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_MiddleUnitExclamatory" purpose="Validate the Manifest name of web app is head with Middle Unit Exclamatory">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleUnitExclamatory.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_MiddleUnitPercent" purpose="Validate the Manifest name of web app is head with Middle Unit Percent">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_MiddleUnitPercent.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_NullValue" purpose="Validate the Manifest name of web app is head with Null Value">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_NullValue.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailEncodePunctuationComma" purpose="Validate the Manifest name of web app is head with Tail Encode Punctuation Comma">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEncodePunctuationComma.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailEncodePunctuationDOT" purpose="Validate the Manifest name of web app is head with Tail Encode Punctuation DOT">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEncodePunctuationDOT.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailEncodePunctuationDoubqQuot" purpose="Validate the Manifest name of web app is head with Tail Encode Punctuation DoubqQuot">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEncodePunctuationDoubqQuot.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailEncodePunctuationInterrogat" purpose="Validate the Manifest name of web app is head with Tail Encode Punctuation Interrogat">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEncodePunctuationInterrogat.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailEncodePunctuationRoundBracket" purpose="Validate the Manifest name of web app is head with Tail Encode Punctuation RoundBracket">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEncodePunctuationRoundBracket.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailEncodePunctuationSemicolon" purpose="Validate the Manifest name of web app is head with Tail Encode Punctuation Semicolon">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEncodePunctuationSemicolon.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailEscapeCharBackSlash" purpose="Validate the Manifest name of web app is head with Tail Escape Char BackSlash">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEscapeCharBackSlash.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailEscapeCharTab" purpose="Validate the Manifest name of web app is head with Tail Escape Char Tab">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailEscapeCharTab.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailMatchOperatorAngle" purpose="Validate the Manifest name of web app is head with Tail Match Operator Angle">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailMatchOperatorAngle.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailMatchOperatorAsterisk" purpose="Validate the Manifest name of web app is head with Tail Match Operator Asterisk">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailMatchOperatorAsterisk.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailMatchOperatorInterrogat" purpose="Validate the Manifest name of web app is head with Tail Match Operator Interrogat">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailMatchOperatorInterrogat.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailPunctuationAngleBracket" purpose="Validate the Manifest name of web app is head with Tail Match Operator AngleBracket">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationAngleBracket.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailPunctuationBrace" purpose="Validate the Manifest name of web app is head with Tail Punctuation Brace">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationBrace.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailPunctuationColon" purpose="Validate the Manifest name of web app is head with Tail Punctuation Colon">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationColon.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailPunctuationComma" purpose="Validate the Manifest name of web app is head with Tail Punctuation Comma">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationComma.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailPunctuationMidBracket" purpose="Validate the Manifest name of web app is head with Tail Punctuation MidBracket">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationMidBracket.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailPunctuationRoundBracket" purpose="Validate the Manifest name of web app is head with Tail Punctuation RoundBracket">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationRoundBracket.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailPunctuationSemicolon" purpose="Validate the Manifest name of web app is head with Tail Punctuation Semicolon">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationSemicolon.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailPunctuationTilde" purpose="Validate the Manifest name of web app is head with Tail Punctuation Tilde">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailPunctuationTilde.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailRelationalOperatorAnd" purpose="Validate the Manifest name of web app is head with Tail Relational Operator And">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailRelationalOperatorAnd.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailRelationalOperatorEqual" purpose="Validate the Manifest name of web app is head with Tail Relational Operator Equal">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailRelationalOperatorEqual.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailRelationalOperatorRBracket" purpose="Validate the Manifest name of web app is head with Tail Relational Operator RBracket">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailRelationalOperatorRBracket.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailRelationalOperatorVertical" purpose="Validate the Manifest name of web app is head with Tail Relational Operator Vertical">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailRelationalOperatorVertical.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailUnitDollar" purpose="Validate the Manifest name of web app is head with Tail Unit Dollar">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailUnitDollar.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailUnitExclamatory" purpose="Validate the Manifest name of web app is head with Tail Unit Exclamatory">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailUnitExclamatory.html </test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Runtime Core" execution_type="manual" id="Crosswalk_Manifest_Name_TailUnitPercent" purpose="Validate the Manifest name of web app is head with Tail Unit Percent">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed on device;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-rtcore-android-tests/rtcore/Crosswalk_Manifest_Name_TailUnitPercent.html </test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>


### PR DESCRIPTION
Impacted TCs num[approved]: New 115,update 0,deleted 0
Unit test platform:android
Unit test result summary: Pass 109,Fail 9, Blocked 0

Fail reason: 1. all Chinese characters(汉字) or all number(123456) characters, can not be packaged
                    2. head with space(" ") or dot(.name) , can not be packaged
                    3. tail with dot(name.), can not be packaged
                    4. include single('') or double("") quotation marks, can not be packaged
