### PR TITLE
[webapi] Add basic Messaging TCs instead of IDL for existent checkpoint

### DIFF
--- a/webapi/webapi-messaging-sysapps-tests/messaging/MessagingManager_basic.html
+++ b/webapi/webapi-messaging-sysapps-tests/messaging/MessagingManager_basic.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Jianfeng.Xu <jianfengx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>Messaging Test: MessagingManager_basic</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="http://www.w3.org/2012/sysapps/messaging/#idl-def-MessagingManager">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="support/support.js"></script>
+<div id="log"></div>
+<script>
+  [
+    ["object", "sms", "readonly"],
+    ["object", "mms", "readonly"],
+    ["function", "findMessages", ""],
+    ["function", "findConversations", ""],
+    ["function", "getMessage", ""],
+    ["function", "deleteMessage", ""],
+    ["function", "deleteConversation", ""],
+    ["function", "markMessageRead", ""],
+    ["function", "markConversationRead", ""],
+  ].forEach(function(attr) {
+            var type = attr[0];
+            var name = attr[1];
+            var read = attr[2];
+            test(function() {
+              assert_true(name in message, name + " attribute in MessageManager");
+              switch(type) {
+                case "object":
+                  assert_equals(typeof message[name], "object", name + " attribute of type");
+                break;
+                case "function":
+                   assert_equals(typeof message[name], "function", name + " attribute of type");
+                break;
+                default:
+                  break;
+              }
+              switch(read) {
+                case "readonly":
+                  if (type == "object") {
+                    var dc = message[name];
+                    message[name] = null;
+                    assert_equals(message[name], dc, "the value of " + name);
+                  }
+                break;
+                default:
+                  break;
+              }
+            }, "Check if " + read + " message." + name + " exists and type of " + type);
+  });
+</script>

--- a/webapi/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html
+++ b/webapi/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Jianfeng.Xu <jianfengx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>Messaging Test: MmsManager_Basic</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsManager">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="support/support.js"></script>
+<div id="log"></div>
+<script>
+  [
+    ["string", "type", "readonly"],
+    ["array", "serviceIDs", "readonly"],
+    ["event", "onreceived", ""],
+    ["event", "onsent", ""],
+    ["event", "ondeliverysuccess", ""],
+    ["event", "ondeliveryerror", ""],
+    ["event", "onreadsuccess", ""],
+    ["event", "onreaderror", ""],
+    ["event", "onserviceadded", ""],
+    ["event", "onserviceremoved", ""],
+    ["function", "getFetchMode", ""],
+    ["function", "setFetchMode", ""],
+    ["function", "send", ""],
+    ["function", "fetch", ""],
+    ["function", "clear", ""],
+  ].forEach(function(attr) {
+            var type = attr[0];
+            var name = attr[1];
+            var read = attr[2];
+            test(function() {
+              assert_true(name in message.mms, name + " attribute in MmsManager");
+              switch(type) {
+                case "string":
+                  assert_equals(typeof message.mms[name], "string", name + " attribute of type");
+                break;
+                case "function":
+                  assert_equals(typeof message.mms[name], "function", name + " attribute of type");
+                break;
+                case "array":
+                  assert_equals(Object.prototype.toString.call(message.mms[name]), "[object Array]", name + " attribute of type");
+                break;
+                default:
+                  break;
+              }
+              switch(read) {
+                case "readonly":
+                  var dc = message.mms[name];
+                  if(type == "string") {                 
+                    message.mms[name] = dc + "test";
+                  } else if (type == "array") {
+                    message.mms[name] = ["test"];
+                  }
+                  assert_equals(message.mms[name], dc, "the value of " + name);
+                break;
+                default:
+                  break;
+              }
+            }, "Check if " + read + " message.mms." + name + " exists and type of " + type);
+  });
+</script>

--- a/webapi/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html
+++ b/webapi/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html
@@ -1,0 +1,460 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Jianfeng.Xu <jianfengx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>Messaging Test: MmsMessage_Basic</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsMessager">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="support/support.js"></script>
+<div id="log"></div>
+<script>
+var testNumber = "5556";
+var filter = {
+  type: "mms",
+};
+var filterOption = {
+  sortBy: "date",
+  sortBy: "descending",
+  limit: 3
+};
+var t1 = async_test("Check if the readonly attribute messageID of MmsMessage exists and type of string", {timeout: 2000});
+var t2 = async_test("Check if the readonly attribute type of MmsMessage exists and type of string", {timeout: 2000});
+var t3 = async_test("Check if the readonly attribute serviceID of MmsMessage exists and type of string", {timeout: 2000});
+var t4 = async_test("Check if the readonly attribute from of MmsMessage exists and type of string", {timeout: 2000});
+var t5 = async_test("Check if the readonly attribute timestamp of MmsMessage exists and type of Date", {timeout: 2000});
+var t6 = async_test("Check if the readonly attribute read of MmsMessage exists and type of boolean", {timeout: 2000});
+var t7 = async_test("Check if the readonly attribute to of MmsMessage exists and type of array", {timeout: 2000});
+var t8 = async_test("Check if the readonly attribute expiry of MmsMessage exists and type of string", {timeout: 2000});
+var t9 = async_test("Check if the readonly attribute cc of MmsMessage exists and type of array", {timeout: 2000});
+var t10 = async_test("Check if the readonly attribute bcc of MmsMessage exists and type of array", {timeout: 2000});
+var t11 = async_test("Check if the readonly attribute subject of MmsMessage exists and type of string", {timeout: 2000});
+var t12 = async_test("Check if the readonly attribute smil of MmsMessage exists and type of  string", {timeout: 2000});
+var t13 = async_test("Check if the readonly attribute attachments of MmsMessage exists and type of  array", {timeout: 2000});
+var t14 = async_test("Check if the readonly attribute state of MmsMessage exists and type of  string", {timeout: 2000});
+var t15 = async_test("Check if the readonly attribute deliveryInfo of MmsMessage exists and type of  string", {timeout: 2000});
+var t16 = async_test("Check if the readonly attribute readReportRequested of MmsMessage exists and type of  boolean", {timeout: 2000});
+
+
+t1.step(function () {
+  assert_true(!!message, "The define of message");
+  message.findMessages(filter, filterOption).then(
+    function (msg) {
+      t1.step(function () {
+        assert_true(msg.element.length > 0, "no mms message");
+        var mmsMessage = msg.element[0];
+        assert_true("messageID" in mmsMessage, "The messageID attribute of MmsMessage exists");
+        var dc = mmsMessage.messageID;
+        assert_equals(Object.prototype.toString.call(dc), "[object String]", " The type messageID of MmsMessage should be string");
+        mmsMessage.messageID = dc + "test";
+        assert_equals(mmsMessage.messageID, dc, "The value of messageID");
+      });
+      t1.done();
+    },
+    function (error) {
+      t1.step(function () {
+        assert_unreached(error.message);
+      });
+      t1.done();
+    }
+  );
+});
+
+t2.step(function () {
+  assert_true(!!message, "The define of message");
+  message.findMessages(filter, filterOption).then(
+    function (msg) {
+      t2.step(function () {
+        assert_true(msg.element.length > 0, "no mms message");
+        var mmsMessage = msg.element[0];
+        assert_true("type" in mmsMessage, "The type attribute of MmsMessage exists");
+        var dc = mmsMessage.type;
+        assert_equals(Object.prototype.toString.call(dc), "[object String]", "The type of mmsMessage.type should be string");
+        mmsMessage.type = dc + "test";
+        assert_equals(mmsMessage.type, dc, "The value of type");
+      });
+      t2.done();
+    },
+    function (error) {
+      t2.step(function () {
+        assert_unreached(error.message);
+      });
+      t2.done();
+    }
+  );
+});
+
+t3.step(function () {
+  assert_true(!!message, "The define of message");
+  message.findMessages(filter, filterOption).then(
+    function (msg) {
+      t3.step(function () {
+        assert_true(msg.element.length > 0, "no mms message");
+        var mmsMessage = msg.element[0];
+        assert_true("serviceID" in mmsMessage, "The attribute of MmsMessage exists");
+        var dc = mmsMessage.serviceID;
+        assert_equals(Object.prototype.toString.call(dc), "[object String]", "The type of mmsMessage.serviceID should be string");
+        mmsMessage.serviceID = dc + "test";
+        assert_equals(mmsMessage.serviceID, dc, "The value of  serviceID");
+      });
+      t3.done();
+    },
+    function (error) {
+      t3.step(function () {
+        assert_unreached(error.message);
+      });
+      t3.done();
+    }
+  );
+});
+
+t4.step(function () {
+  assert_true(!!message, "The define of message");
+  message.findMessages(filter, filterOption).then(
+    function (msg) {
+      t4.step(function () {
+        assert_true(msg.element.length > 0, "no mms message");
+        var mmsMessage = msg.element[0];
+        assert_true("from" in mmsMessage, "The from attribute of MmsMessage exists");
+        var dc = mmsMessage.from;
+        assert_equals(Object.prototype.toString.call(dc), "[object String]", "type of mmsMessage.from should be string");
+        mmsMessage.from = dc + "test";
+        assert_equals(mmsMessage.from, dc, "The value of from");
+      });
+      t4.done();
+    },
+    function (error) {
+      t4.step(function () {
+        assert_unreached(error.message);
+      });
+      t4.done();
+    }
+  );
+});
+
+t5.step(function () {
+  assert_true(!!message, "The define of message");
+  message.findMessages(filter, filterOption).then(
+    function (msg) {
+      t5.step(function () {
+        assert_true(msg.element.length > 0, "no mms message");
+        var mmsMessage = msg.element[0];
+        assert_true("timestamp" in mmsMessage, "The timestamp attribute of MmsMessage exists");
+        var dc = mmsMessage.timestamp;
+        assert_equals(Object.prototype.toString.call(dc), "[object String]", "The type of mmsMessage.timestamp should be string");
+        mmsMessage.timestamp = dc + "test";
+        assert_equals(mmsMessage.serviceID, dc, "The value of timestamp");
+      });
+      t5.done();
+    },
+    function (error) {
+      t5.step(function () {
+        assert_unreached(error.message);
+      });
+      t5.done();
+    }
+  );
+});
+
+t6.step(function () {
+  assert_true(!!message, "The define of message");
+  message.findMessages(filter, filterOption).then(
+    function (msg) {
+      t6.step(function () {
+        assert_true(msg.element.length > 0, "no mms message");
+        var mmsMessage = msg.element[0];
+        assert_true("read" in mmsMessage, "The read attribute of MmsMessage exists");
+        var dc = mmsMessage.read;
+        assert_equals(Object.prototype.toString.call(dc), "[object boolean]", "The type of mmsMessage.read should be boolean");
+        if(dc) {
+          mmsMessage.read = false;
+        } else {
+          mmsMessage.read = true;
+        }
+        assert_equals(mmsMessage.read, dc, "The value of read");
+      });
+      t6.done();
+    },
+    function (error) {
+      t6.step(function () {
+        assert_unreached(error.message);
+      });
+      t6.done();
+    }
+  );
+});
+
+t7.step(function () {
+  assert_true(!!message, "The define of message");
+  message.findMessages(filter, filterOption).then(
+    function (msg) {
+      t7.step(function () {
+        assert_true(msg.element.length > 0, "no mms message");
+        var mmsMessage = msg.element[0];
+        assert_true("to" in mmsMessage, "The to attribute of MmsMessage exists");
+        var dc = mmsMessage.to;
+        assert_equals(Object.prototype.toString.call(dc), "[object Array]", "The type of mmsMessage.to should be string");
+        mmsMessage.to = [];
+        assert_equals(mmsMessage.to, dc, "The value of to");
+      });
+      t7.done();
+    },
+    function (error) {
+      t7.step(function () {
+        assert_unreached(error.message);
+      });
+      t7.done();
+    }
+  );
+});
+
+t8.step(function () {
+  assert_true(!!message, "The define of message");
+  message.findMessages(filter, filterOption).then(
+    function (msg) {
+      t8.step(function () {
+        assert_true(msg.element.length > 0, "no mms message");
+        var mmsMessage = msg.element[0];
+        assert_true("expiry" in mmsMessage, "The expiry attribute of MmsMessage exists");
+        var dc = mmsMessage.expiry;
+        assert_equals(Object.prototype.toString.call(dc), "[object String]", "The type of mmsMessage.expiry should be string");
+        mmsMessage.body = dc + "test";
+        assert_equals(mmsMessage.expiry, dc, "The value of expiry");
+      });
+      t8.done();
+    },
+    function (error) {
+      t8.step(function () {
+        assert_unreached(error.message);
+      });
+      t8.done();
+    }
+  );
+});
+
+t9.step(function () {
+  assert_true(!!message, "The define of message");
+  message.findMessages(filter, filterOption).then(
+    function (msg) {
+      t9.step(function () {
+        assert_true(msg.element.length > 0, "no mms message");
+        var mmsMessage = msg.element[0];
+        assert_true("cc" in mmsMessage, "The cc attribute of MmsMessage exists");
+        var dc = mmsMessage.cc;
+        assert_equals(Object.prototype.toString.call(dc), "[object Array]", "The type of mmsMessage.cc should be Array");
+        mmsMessage.cc = ["test"];
+        assert_equals(mmsMessage.cc, dc, "The value of cc");
+      });
+      t9.done();
+    },
+    function (error) {
+      t9.step(function () {
+        assert_unreached(error.message);
+      });
+      t9.done();
+    }
+  );
+});
+
+t10.step(function () {
+  assert_true(!!message, "The define of message");
+  message.findMessages(filter, filterOption).then(
+    function (msg) {
+      t10.step(function () {
+        assert_true(msg.element.length > 0, "no mms message");
+        var mmsMessage = msg.element[0];
+        assert_true("bcc" in mmsMessage, "The bcc attribute of MmsMessage exists");
+        var dc = mmsMessage.bcc;
+        assert_equals(Object.prototype.toString.call(dc), "[object Array]", "type of mmsMessage.bcc should be Array");
+        mmsMessage.bcc = ["test"];
+        assert_equals(mmsMessage.bcc, dc, "The value of bcc");
+      });
+      t10.done();
+    },
+    function (error) {
+      t10.step(function () {
+        assert_unreached(error.message);
+      });
+      t10.done();
+    }
+  );
+});
+
+t11.step(function () {
+  assert_true(!!message, "The define of message");
+  message.findMessages(filter, filterOption).then(
+    function (msg) {
+      t11.step(function () {
+        assert_true(msg.element.length > 0, "no mms message");
+        var mmsMessage = msg.element[0];
+        assert_true("subject" in mmsMessage, "The subject attribute of MmsMessage exists");
+        var dc = mmsMessage.subject;
+        assert_equals(Object.prototype.toString.call(dc), "[object String]", "The type of mmsMessage.subject should be string");
+        mmsMessage.subject = dc + "test";
+        assert_equals(mmsMessage.subject, dc, "The value of subject ");
+      });
+      t11.done();
+    },
+    function (error) {
+      t11.step(function () {
+        assert_unreached(error.message);
+      });
+      t11.done();
+    }
+  );
+});
+
+t12.step(function () {
+  assert_true(!!message, "The define of message");
+  message.findMessages(filter, filterOption).then(
+    function (msg) {
+      t12.step(function () {
+        assert_true(msg.element.length > 0, "no mms message");
+        var mmsMessage = msg.element[0];
+        assert_true("smil" in mmsMessage, "The smil attribute of MmsMessage exists");
+        var dc = mmsMessage.smil;
+        assert_equals(Object.prototype.toString.call(dc), "[object String]", "The type of mmsMessage.smil should be string");
+        mmsMessage.smil = dc + "test";
+        assert_equals(mmsMessage.smil, dc, "The smil attribute should be readonly");
+      });
+      t12.done();
+    },
+    function (error) {
+      t12.step(function () {
+        assert_unreached(error.message);
+      });
+      t12.done();
+    }
+  );
+});
+
+t13.step(function () {
+  assert_true(!!message, "The define of message");
+  message.findMessages(filter, filterOption).then(
+    function (msg) {
+      t13.step(function () {
+        assert_true(msg.element.length > 0, "no mms message");
+        var mmsMessage = msg.element[0];
+        assert_true("attachments" in mmsMessage, "The attachments attribute of MmsMessage exists");
+        var dc = mmsMessage.attachments;
+        assert_equals(Object.prototype.toString.call(dc), "[object Array]", "The type of mmsMessage.attachments should be array");
+        mmsMessage.attachments = ["test"];
+        assert_equals(mmsMessage.attachments, dc, "The value of attachments");
+      });
+      t13.done();
+    },
+    function (error) {
+      t13.step(function () {
+        assert_unreached(error.message);
+      });
+      t13.done();
+    }
+  );
+});
+
+t14.step(function () {
+  assert_true(!!message, "The define of message");
+  message.findMessages(filter, filterOption).then(
+    function (msg) {
+      t14.step(function () {
+        assert_true(msg.element.length > 0, "no mms message");
+        var mmsMessage = msg.element[0];
+        assert_true("state" in mmsMessage, "The state attribute of MmsMessage exists");
+        var dc = mmsMessage.state;
+        assert_equals(Object.prototype.toString.call(dc), "[object String]", "The type of mmsMessage.state should be string");
+        mmsMessage.state = dc + "test";
+        assert_equals(mmsMessage.state, dc, "The value of state");
+      });
+      t14.done();
+    },
+    function (error) {
+      t14.step(function () {
+        assert_unreached(error.message);
+      });
+      t14.done();
+    }
+  );
+});
+
+t15.step(function () {
+  assert_true(!!message, "The define of message");
+  message.findMessages(filter, filterOption).then(
+    function (msg) {
+      t15.step(function () {
+        assert_true(msg.element.length > 0, "no mms message");
+        var mmsMessage = msg.element[0];
+        assert_true("deliveryInfo" in mmsMessage, "The deliveryInfo attribute of MmsMessage exists");
+        var dc = mmsMessage.deliveryInfo;
+        assert_equals(Object.prototype.toString.call(dc), "[object Array]", "The type of mmsMessage.deliveryInfo should be array");
+        mmsMessage.deliveryInfo = ["test"];
+        assert_equals(mmsMessage.deliveryInfo, dc, "The value of deliveryInfo");
+      });
+      t15.done();
+    },
+    function (error) {
+      t15.step(function () {
+        assert_unreached(error.message);
+      });
+      t15.done();
+    }
+  );
+});
+
+t16.step(function () {
+  assert_true(!!message, "The define of message");
+  message.findMessages(filter, filterOption).then(
+    function (msg) {
+      t16.step(function () {
+        assert_true(msg.element.length > 0, "no mms message");
+        var mmsMessage = msg.element[0];
+        assert_true("readReportRequested" in mmsMessage, "The readReportRequested attribute of MmsMessage exists");
+        var dc = mmsMessage.readReportRequested;
+        assert_equals(Object.prototype.toString.call(dc), "[object boolean]", "The type of mmsMessage.readReportRequested should be boolean");
+        if(dc) {
+          mmsMessage.readReportRequested = false;
+        } else {
+          mmsMessage.readReportRequested = true;
+        }
+        assert_equals(mmsMessage.readReportRequested, dc, "The value of readReportRequested");
+      });
+      t16.done();
+    },
+    function (error) {
+      t16.step(function () {
+        assert_unreached(error.message);
+      });
+      t16.done();
+    }
+  );
+});
+</script>

--- a/webapi/webapi-messaging-sysapps-tests/messaging/SmsManager_basic.html
+++ b/webapi/webapi-messaging-sysapps-tests/messaging/SmsManager_basic.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Jianfeng.Xu <jianfengx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>Messaging Test: SmsManager_Basic</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="http://www.w3.org/2012/sysapps/messaging/#idl-def-SmsManager">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="support/support.js"></script>
+<div id="log"></div>
+<script>
+  [
+    ["string", "type", "readonly"],
+    ["array", "serviceIDs", "readonly"],
+    ["event", "onreceived", ""],
+    ["event", "onsent", ""],
+    ["event", "ondeliverysuccess", ""],
+    ["event", "ondeliveryerror", ""],
+    ["event", "onserviceadded", ""],
+    ["event", "onserviceremoved", ""],
+    ["function", "segmentInfo", ""],
+    ["function", "send", ""],
+    ["function", "clear", ""],
+  ].forEach(function(attr) {
+            var type = attr[0];
+            var name = attr[1];
+            var read = attr[2];
+            test(function() {
+              assert_true(name in message.sms, name + " attribute in SmsManager");
+              switch(type) {
+                case "string":
+                  assert_equals(typeof message.sms[name], "string", name + " attribute of type");
+                break;
+                case "function":
+                  assert_equals(typeof message.sms[name], "function", name + " attribute of type");
+                break;
+                case "array":
+                  assert_equals(Object.prototype.toString.call(message.sms[name]), "[object Array]", name + " attribute of type");
+                break;
+                default:
+                  break;
+              }
+              switch(read) {
+                case "readonly":
+                  var dc = message.sms[name];
+                  if(type == "string") {                 
+                    message.sms[name] = dc + "test";
+                  } else if (type == "array") {
+                    message.sms[name] = ["test"];
+                  }
+                  assert_equals(message.sms[name], dc, "the value of " + name);
+                break;
+                default:
+                  break;
+              }
+            }, "Check if " + read + " message.sms." + name + " exists and type of " + type);
+  });
+</script>

--- a/webapi/webapi-messaging-sysapps-tests/messaging/SmsMessage_basic.html
+++ b/webapi/webapi-messaging-sysapps-tests/messaging/SmsMessage_basic.html
@@ -1,0 +1,357 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Jianfeng.Xu <jianfengx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>Messaging Test: SmsMessage_Basic</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="http://www.w3.org/2012/sysapps/messaging/#idl-def-SmsMessage">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="support/support.js"></script>
+<div id="log"></div>
+<script>
+var testNumber = "5556";
+var filter = {
+  type: "sms",
+};
+var filterOption = {
+  sortBy: "date",
+  sortBy: "descending",
+  limit: 3
+};
+var t1 = async_test("Check if the readonly attribute messageID of SmsMessage exists and type of string", {timeout: 2000});
+var t2 = async_test("Check if the readonly attribute type of SmsMessage exists and type of string", {timeout: 2000});
+var t3 = async_test("Check if the readonly attribute serviceID of SmsMessage exists and type of string", {timeout: 2000});
+var t4 = async_test("Check if the readonly attribute from of SmsMessage exists and type of string", {timeout: 2000});
+var t5 = async_test("Check if the readonly attribute timestamp of SmsMessage exists and type of string", {timeout: 2000});
+var t6 = async_test("Check if the readonly attribute read of SmsMessage exists and type of boolean", {timeout: 2000});
+var t7 = async_test("Check if the readonly attribute to of SmsMessage exists and type of string", {timeout: 2000});
+var t8 = async_test("Check if the readonly attribute body of SmsMessage exists and type of string", {timeout: 2000});
+var t9 = async_test("Check if the readonly attribute state of SmsMessage exists and type of string", {timeout: 2000});
+var t10 = async_test("Check if the readonly attribute deliveryStatus of SmsMessage exists and type of string", {timeout: 2000});
+var t11 = async_test("Check if the readonly attribute deliveryTimestamp of SmsMessage exists and type of Date", {timeout: 2000});
+var t12 = async_test("Check if the readonly attribute messageClass of SmsMessage exists and type of  string", {timeout: 2000});
+
+
+t1.step(function () {
+  assert_true(!!message, "The define of message");
+  message.findMessages(filter, filterOption).then(
+    function (msg) {
+      t1.step(function () {
+        assert_true(msg.element.length > 0, "no sms message");
+        var smsmessage = msg.element[0];
+        assert_true("messageID" in smsmessage, "The messageID attribute of SmsMessage exists");
+        var dc = smsmessage.messageID;
+        assert_equals(Object.prototype.toString.call(dc), "[object String]", "The type messageID of SmsMessage should be string");
+        smsmessage.messageID = dc + "test";
+        assert_equals(smsmessage.messageID, dc, "The value of messageID");
+      });
+      t1.done();
+    },
+    function (error) {
+      t1.step(function () {
+        assert_unreached(error.message);
+      });
+      t1.done();
+    }
+  );
+});
+
+t2.step(function () {
+  assert_true(!!message, "The define of message");
+  message.findMessages(filter, filterOption).then(
+    function (msg) {
+      t2.step(function () {
+        assert_true(msg.element.length > 0, "no sms message");
+        var smsmessage = msg.element[0];
+        assert_true("type" in smsmessage, "The type attribute of SmsMessage exists");
+        var dc = smsmessage.type;
+        assert_equals(Object.prototype.toString.call(dc), "[object String]", "The type of SmsMessage.type should be string");
+        smsmessage.type = dc + "test";
+        assert_equals(smsmessage.type, dc, "The value of type");
+      });
+      t2.done();
+    },
+    function (error) {
+      t2.step(function () {
+        assert_unreached(error.message);
+      });
+      t2.done();
+    }
+  );
+});
+
+t3.step(function () {
+  assert_true(!!message, "The define of message");
+  message.findMessages(filter, filterOption).then(
+    function (msg) {
+      t3.step(function () {
+        assert_true(msg.element.length > 0, "no sms message");
+        var smsmessage = msg.element[0];
+        assert_true("serviceID" in smsmessage, "The serviceID attribute of SmsMessage exists");
+        var dc = smsmessage.serviceID;
+        assert_equals(Object.prototype.toString.call(dc), "[object String]", "type of SmsMessage.serviceID should be string");
+        smsmessage.serviceID = dc + "test";
+        assert_equals(smsmessage.serviceID, dc, "The value of serviceID");
+      });
+      t3.done();
+    },
+    function (error) {
+      t3.step(function () {
+        assert_unreached(error.message);
+      });
+      t3.done();
+    }
+  );
+});
+
+t4.step(function () {
+  assert_true(!!message, "The define of message");
+  message.findMessages(filter, filterOption).then(
+    function (msg) {
+      t4.step(function () {
+        assert_true(msg.element.length > 0, "no sms message");
+        var smsmessage = msg.element[0];
+        assert_true("from" in smsmessage, "The from attribute of SmsMessage exists");
+        var dc = smsmessage.from;
+        assert_equals(Object.prototype.toString.call(dc), "[object String]", "The type of SmsMessage.from should be string");
+        smsmessage.from = dc + "test";
+        assert_equals(smsmessage.from, dc, "The value of from");
+      });
+      t4.done();
+    },
+    function (error) {
+      t4.step(function () {
+        assert_unreached(error.message);
+      });
+      t4.done();
+    }
+  );
+});
+
+t5.step(function () {
+  assert_true(!!message, "The define of message");
+  message.findMessages(filter, filterOption).then(
+    function (msg) {
+      t5.step(function () {
+        assert_true(msg.element.length > 0, "no sms message");
+        var smsmessage = msg.element[0];
+        assert_true("timestamp" in smsmessage, "The timestamp attribute of SmsMessage exists");
+        var dc = smsmessage.timestamp;
+        assert_equals(Object.prototype.toString.call(dc), "[object String]", "The type of SmsMessage.timestamp should be string");
+        smsmessage.timestamp = dc + "test";
+        assert_equals(smsmessage.serviceID, dc, "The value of timestamp");
+      });
+      t5.done();
+    },
+    function (error) {
+      t5.step(function () {
+        assert_unreached(error.message);
+      });
+      t5.done();
+    }
+  );
+});
+
+t6.step(function () {
+  assert_true(!!message, "The define of message");
+  message.findMessages(filter, filterOption).then(
+    function (msg) {
+      t6.step(function () {
+        assert_true(msg.element.length > 0, "no sms message");
+        var smsmessage = msg.element[0];
+        assert_true("read" in smsmessage, "The read attribute of SmsMessage exists");
+        var dc = smsmessage.read;
+        assert_equals(Object.prototype.toString.call(dc), "[object boolean]", "The type of SmsMessage.read should be boolean");
+        if(dc) {
+          smsMessage.read = false;
+        } else {
+          smsMessage.read = true;
+        }
+        assert_equals(smsmessage.read, dc, "The value of read");
+      });
+      t6.done();
+    },
+    function (error) {
+      t6.step(function () {
+        assert_unreached(error.message);
+      });
+      t6.done();
+    }
+  );
+});
+
+t7.step(function () {
+  assert_true(!!message, "The define of message");
+  message.findMessages(filter, filterOption).then(
+    function (msg) {
+      t7.step(function () {
+        assert_true(msg.element.length > 0, "no sms message");
+        var smsmessage = msg.element[0];
+        assert_true("to" in smsmessage, "The to attribute of SmsMessage exists");
+        var dc = smsmessage.to;
+        assert_equals(Object.prototype.toString.call(dc), "[object String]", "The type of SmsMessage.to should be string");
+        smsmessage.to = dc + "test";
+        assert_equals(smsmessage.to, dc, "The value of to");
+      });
+      t7.done();
+    },
+    function (error) {
+      t7.step(function () {
+        assert_unreached(error.message);
+      });
+      t7.done();
+    }
+  );
+});
+
+t8.step(function () {
+  assert_true(!!message, "The define of message");
+  message.findMessages(filter, filterOption).then(
+    function (msg) {
+      t8.step(function () {
+        assert_true(msg.element.length > 0, "no sms message");
+        var smsmessage = msg.element[0];
+        assert_true("body" in smsmessage, "The body attribute of SmsMessage exists");
+        var dc = smsmessage.body;
+        assert_equals(Object.prototype.toString.call(dc), "[object String]", "The type of SmsMessage.body should be string");
+        smsmessage.body = dc + "test";
+        assert_equals(smsmessage.body, dc, "The value of body");
+      });
+      t8.done();
+    },
+    function (error) {
+      t8.step(function () {
+        assert_unreached(error.message);
+      });
+      t8.done();
+    }
+  );
+});
+
+t9.step(function () {
+  assert_true(!!message, "The define of message");
+  message.findMessages(filter, filterOption).then(
+    function (msg) {
+      t9.step(function () {
+        assert_true(msg.element.length > 0, "no sms message");
+        var smsmessage = msg.element[0];
+        assert_true("state" in smsmessage, "The state attribute of SmsMessage exists");
+        var dc = smsmessage.state;
+        assert_equals(Object.prototype.toString.call(dc), "[object String]", "The type of SmsMessage.state should be string");
+        smsmessage.state = dc + "test";
+        assert_equals(smsmessage.state, "test", "The value of state");
+      });
+      t9.done();
+    },
+    function (error) {
+      t9.step(function () {
+        assert_unreached(error.message);
+      });
+      t9.done();
+    }
+  );
+});
+
+t10.step(function () {
+  assert_true(!!message, "The define of message");
+  message.findMessages(filter, filterOption).then(
+    function (msg) {
+      t10.step(function () {
+        assert_true(msg.element.length > 0, "no sms message");
+        var smsmessage = msg.element[0];
+        assert_true("deliveryStatus" in smsmessage, "The serviceID attribute of SmsMessage exists");
+        var dc = smsmessage.deliveryStatus;
+        assert_equals(Object.prototype.toString.call(dc), "[object String]", "The type of SmsMessage.deliveryStatus should be string");
+        smsmessage.deliveryStatus = dc + "test";
+        assert_equals(smsmessage.deliveryStatus, dc, "The value of deliveryStatus");
+      });
+      t10.done();
+    },
+    function (error) {
+      t10.step(function () {
+        assert_unreached(error.message);
+      });
+      t10.done();
+    }
+  );
+});
+
+t11.step(function () {
+  assert_true(!!message, "The define of message");
+  message.findMessages(filter, filterOption).then(
+    function (msg) {
+      t11.step(function () {
+        assert_true(msg.element.length > 0, "no sms message");
+        var smsmessage = msg.element[0];
+        assert_true("deliveryTimestamp" in smsmessage, "The deliveryTimestamp attribute of SmsMessage exists");
+        var dc = smsmessage.deliveryTimestamp;
+        assert_equals(Object.prototype.toString.call(dc), "[object String]", "The type of SmsMessage.deliveryTimestamp should be string");
+        smsmessage.deliveryTimestamp = dc + "test";
+        assert_equals(smsmessage.deliveryTimestamp, dc, "The value of deliveryTimestamp");
+      });
+      t11.done();
+    },
+    function (error) {
+      t11.step(function () {
+        assert_unreached(error.message);
+      });
+      t11.done();
+    }
+  );
+});
+
+t12.step(function () {
+  assert_true(!!message, "The define of message");
+  message.findMessages(filter, filterOption).then(
+    function (msg) {
+      t12.step(function () {
+        assert_true(msg.element.length > 0, "no sms message");
+        var smsmessage = msg.element[0];
+        assert_true("messageClass" in smsmessage, "The messageClass attribute of SmsMessage exists");
+        var dc = smsmessage.messageClass;
+        assert_equals(Object.prototype.toString.call(dc), "[object String]", "The type of SmsMessage.messageClass should be string");
+        smsmessage.messageClass = dc + "test";
+        assert_equals(smsmessage.messageClass, dc, "The value of messageClass");
+      });
+      t12.done();
+    },
+    function (error) {
+      t12.step(function () {
+        assert_unreached(error.message);
+      });
+      t12.done();
+    }
+  );
+});
+
+</script>

--- a/webapi/webapi-messaging-sysapps-tests/tests.full.xml
+++ b/webapi/webapi-messaging-sysapps-tests/tests.full.xml
@@ -1157,7 +1157,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if the send method of SmsManager which has no param can not work normally" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P2" id="SmsMessage_send_zero" onload_delay="20">
+      <testcase purpose="Check if the send method of SmsManager which has no param can not work normally" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P2" id="SmsManager_send_zero" onload_delay="20">
         <description>
           <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
@@ -1169,7 +1169,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if the segmentInfo method of SmsManager which has no params can not work normally" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P2" id="SmsMessage_segmentInfo_zero" onload_delay="20">
+      <testcase purpose="Check if the send method of SmsManager which has one param can not work normally" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P2" id="SmsManager_send_one" onload_delay="20">
         <description>
           <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
@@ -1181,19 +1181,19 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if the send method of MmsManager which has no params can not work normally" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P2" id="MmsManager_send_zero" onload_delay="20">
+      <testcase purpose="Check if the segmentInfo method of SmsManager which has no params can not work normally" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P2" id="SmsManager_segmentInfo_zero" onload_delay="20">
         <description>
           <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="attribute" element_name="MmsManager" interface="MmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_assertion element_type="attribute" element_name="segmentInfo" interface="SmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
             <spec_url>http://www.w3.org/2012/sysapps/messaging/#smsmanager-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if the fetch method of MmsManager which has no params can not work normally" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P2" id="MmsManager_fetch_zero" onload_delay="20">
+      <testcase purpose="Check if the send method of MmsManager which has no params can not work normally" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P2" id="MmsManager_send_zero" onload_delay="20">
         <description>
           <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
         </description>
@@ -1205,9 +1205,21 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if the findConversations method which has only one params can not work normally" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P2" id="findConversations_one">
+      <testcase purpose="Check if the fetch method of MmsManager which has no params can not work normally" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P2" id="MmsManager_fetch_zero" onload_delay="20">
         <description>
           <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="MmsManager" interface="MmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#smsmanager-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the findConversations method which has only one params can not work normally" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P2" id="findConversations_one">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1219,7 +1231,7 @@
       </testcase>
       <testcase purpose="CCheck if the markConversationRead method which has only one params can not work normally" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P2" id="markConversationRead_one">
         <description>
-          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1231,7 +1243,7 @@
       </testcase>
       <testcase purpose="Check if the deleteConversation method which has no params can not work normally" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P2" id="deleteConversation_zero">
         <description>
-          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1243,7 +1255,7 @@
       </testcase>
       <testcase purpose="Check if the findMessages method which has only one params can not work normally" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P2" id="findMessages_one">
         <description>
-          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1255,7 +1267,7 @@
       </testcase>
       <testcase purpose="Check if the markMessageRead method which has only one params can not work normally." type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P2" id="markMessageRead_one">
         <description>
-          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1267,7 +1279,7 @@
       </testcase>
       <testcase purpose="Check if the getMessage method which has no params can not work normally" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P2" id="getMessage_zero">
         <description>
-          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1279,24 +1291,12 @@
       </testcase>
       <testcase purpose="Check if the deleteMessage method which has no params can not work normally" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P2" id="deleteMessage_zero">
         <description>
-          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
         </description>
         <specs>
           <spec>
             <spec_assertion element_type="attribute" element_name="deleteMessage" interface="MessagingManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
             <spec_url>http://www.w3.org/2012/sysapps/messaging/#messagingmanager-interface</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="Check if the send method of SmsManager which has no params can not work normally" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P2" id="SmsManager_send_type">
-        <description>
-          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="attribute" element_name="SmsManager" interface="SmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/2012/sysapps/messaging/#smsmanager-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
@@ -1307,7 +1307,7 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="attribute" element_name="SmsManager" interface="SmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_assertion element_type="attribute" element_name="send" interface="SmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
             <spec_url>http://www.w3.org/2012/sysapps/messaging/#smsmanager-interface</spec_url>
             <spec_statement/>
           </spec>
@@ -1319,8 +1319,764 @@
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="attribute" element_name="MmsManager" interface="SmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_assertion element_type="attribute" element_name="send" interface="MmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
             <spec_url>http://www.w3.org/2012/sysapps/messaging/#smsmanager-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute sms of MessagingManager exists and type of object" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MessagingManager_sms_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MessagingManager_basic.html?total_num=9&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="sms" interface="MessagingManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MessagingManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute mms of MessagingManager exists and type of object" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MessagingManager_mms_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MessagingManager_basic.html?total_num=9&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="mms" interface="MessagingManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MessagingManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the findMessages function of MessagingManager exists and type of function" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MessagingManager_findMessages_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MessagingManager_basic.html?total_num=9&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="findMessages" interface="MessagingManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MessagingManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the findConversations function of MessagingManager exists and type of function" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MessagingManager_findConversations_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MessagingManager_basic.html?total_num=9&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="findConversations" interface="MessagingManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MessagingManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the getMessage function of MessagingManager exists and type of function" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MessagingManager_getMessage_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MessagingManager_basic.html?total_num=9&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="getMessage" interface="MessagingManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MessagingManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the deleteMessage function of MessagingManager exists and type of function" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MessagingManager_deleteMessage_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MessagingManager_basic.html?total_num=9&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="deleteMessage" interface="MessagingManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MessagingManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the deleteConversation function of MessagingManager exists and type of function" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MessagingManager_deleteConversation_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MessagingManager_basic.html?total_num=9&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="deleteConversation" interface="MessagingManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MessagingManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the markMessageRead function of MessagingManager exists and type of function" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MessagingManager_markMessageRead_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MessagingManager_basic.html?total_num=9&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="markMessageRead" interface="MessagingManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MessagingManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the markConversationRead function of MessagingManager exists and type of function" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MessagingManager_markConversationRead_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MessagingManager_basic.html?total_num=9&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="markConversationRead" interface="MessagingManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MessagingManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute type of SmsManager exists and type of string" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="SmsManager_type_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsManager_basic.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="type" interface="SmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-SmsManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute serviceIDs of SmsManager exists and type of array" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="SmsManager_serviceIDs_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsManager_basic.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="serviceIDs" interface="SmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-SmsManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the onreceived event of SmsManager exists" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="SmsManager_onreceived_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsManager_basic.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="onreceived" interface="SmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-SmsManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the onsent event of SmsManager exists" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="SmsManager_onsent_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsManager_basic.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="onsent" interface="SmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-SmsManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the ondeliverysuccess event of SmsManager exists" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="SmsManager_ondeliverysuccess_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsManager_basic.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="ondeliverysuccess" interface="SmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-SmsManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the ondeliveryerror event of SmsManager exists" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="SmsManager_ondeliveryerror_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsManager_basic.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="ondeliveryerror" interface="SmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-SmsManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the onserviceadded event of SmsManager exists" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="SmsManager_onserviceadded_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsManager_basic.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="onserviceadded" interface="SmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-SmsManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the onserviceremoved event of SmsManager exists" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="SmsManager_onserviceremoved_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsManager_basic.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="onserviceremoved" interface="SmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-SmsManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the segmentInfo function of SmsManager exists and type of function" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="SmsManager_segmentInfo_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsManager_basic.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="segmentInfo" interface="SmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-SmsManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the send function of SmsManager exists and type of function" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="SmsManager_send_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsManager_basic.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="send" interface="SmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-SmsManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the clear function of SmsManager exists and type of function" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="SmsManager_clear_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsManager_basic.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="clear" interface="SmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-SmsManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute type of MmsManager is exists and type of string" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsManager_type_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="type" interface="MmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute serviceIDs of MmsManager exists and type of array" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsManager_serviceIDs_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="serviceIDs" interface="MmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the onreceived event of MmsManager is exists" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsManager_onreceived_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="onreceived" interface="MmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the onsent event of MmsManager is exists" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsManager_onsent_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="onsent" interface="MmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the ondeliverysuccess event of MmsManager is exists" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsManager_ondeliverysuccess_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="ondeliverysuccess" interface="MmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the ondeliveryerror event of MmsManager is exists" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsManager_ondeliveryerror_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="ondeliveryerror" interface="MmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the onreadsuccess event of MmsManager is exists" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsManager_onreadsuccess_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="onreadsuccess" interface="MmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the onreaderror event of MmsManager is exists" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsManager_onreaderror_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="onreaderror" interface="MmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the onserviceadded event of MmsManager is exists" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsManager_onserviceadded_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="onserviceadded" interface="MmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the onserviceremoved event of MmsManager is exists" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsManager_onserviceremoved_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="onserviceremoved" interface="MmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the getFetchMode function of MmsManager exists and type of function" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsManager_getFetchMode_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="getFetchMode" interface="MmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the setFetchMode function of MmsManager exists and type of function" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsManager_setFetchMode_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="setFetchMode" interface="MmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the send function of MmsManager exists and type of function" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsManager_send_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="send" interface="MmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the fetch function of MmsManager exists and type of function" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsManager_fetch_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="fetch" interface="MmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the clear function of MmsManager exists and type of function" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsManager_clear_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="clear" interface="MmsManager" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsManager</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute messageID of SmsMessage exists and type of string" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="SmsMessage_messageID_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsMessage_basic.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="messageID" interface="SmsMessage" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-SmsMessage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute type of SmsMessage exists and type of string" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="SmsMessage_type_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsMessage_basic.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="type" interface="SmsMessage" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-SmsMessage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute serviceID of SmsMessage exists and type of string" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="SmsMessage_serviceID_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsMessage_basic.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="serviceID" interface="SmsMessage" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-SmsMessage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute from of SmsMessage exists and type of string" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="SmsMessage_from_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsMessage_basic.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="from" interface="SmsMessage" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-SmsMessage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute timestamp of SmsMessage exists and type of Date" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="SmsMessage_timestamp_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsMessage_basic.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="timestamp" interface="SmsMessage" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-SmsMessage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute read of SmsMessage exists and type of boolean" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="SmsMessage_read_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsMessage_basic.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="read" interface="SmsMessage" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-SmsMessage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute to of SmsMessage exists and type of string" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="SmsMessage_to_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsMessage_basic.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="to" interface="SmsMessage" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-SmsMessage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute body of SmsMessage exists and type of String" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="SmsMessage_body_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsMessage_basic.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="body" interface="SmsMessage" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-SmsMessage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute state of SmsMessage exists and type of String" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="SmsMessage_state_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsMessage_basic.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="state" interface="SmsMessage" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-SmsMessage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute deliveryStatus of SmsMessage exists and type of String" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="SmsMessage_deliveryStatus_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsMessage_basic.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="deliveryStatus" interface="SmsMessage" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-SmsMessage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute deliveryTimestamp of SmsMessage exists and type of String" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="SmsMessage_deliveryTimestamp_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsMessage_basic.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="deliveryTimestamp" interface="SmsMessage" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-SmsMessage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute messageClass of SmsMessage exists and type of String" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="SmsMessage_messageClass_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsMessage_basic.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="messageClass" interface="SmsMessage" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-SmsMessage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute messageID of MmsMessage exists and type of String" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsMessage_messageID_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="messageID" interface="MmsMessage" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsMessage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute type of MmsMessage exists and type of String" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsMessage_type_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="type" interface="MmsMessage" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsMessage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute serviceID of MmsMessage exists and type of String" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsMessage_serviceID_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="serviceID" interface="MmsMessage" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsMessage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute from of MmsMessage exists and type of String" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsMessage_from_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="from" interface="MmsMessage" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsMessage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute timestamp of MmsMessage exists and type of date" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsMessage_timestamp_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="timestamp" interface="MmsMessage" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsMessage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute read of MmsMessage exists and type of boolean" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsMessage_read_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="read" interface="MmsMessage" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsMessage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute to of MmsMessage exists and type of array" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsMessage_to_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="to" interface="MmsMessage" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsMessage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute expiry of MmsMessage exists and type of String" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsMessage_expiry_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="expiry" interface="MmsMessage" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsMessage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute cc of MmsMessage exists and type of array" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsMessage_cc_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="cc" interface="MmsMessage" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsMessage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute bcc of MmsMessage exists and type of array" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsMessage_bcc_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="bcc" interface="MmsMessage" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsMessage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute subject of MmsMessage exists and type of String" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsMessage_subject_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="subject" interface="MmsMessage" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsMessage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute smil of MmsMessage exists and type of String" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsMessage_smil_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="smil" interface="MmsMessage" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsMessage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute attachments of MmsMessage exists and type of array" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsMessage_attachments_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="attachments" interface="MmsMessage" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsMessage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute state of MmsMessage exists and type of String" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsMessage_state_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="state" interface="MmsMessage" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsMessage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute deliveryInfo of MmsMessage exists and type of array" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsMessage_deliveryInfo_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="deliveryInfo" interface="MmsMessage" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsMessage</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute readReportRequested of MmsMessage exists and type of boolean" type="compliance" status="approved" component="WebAPI/System-level APIs/Messaging" execution_type="auto" priority="P1" id="MmsMessage_readReportRequested_basic">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=16</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="readReportRequested" interface="MmsMessage" specification="Messaging" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/messaging/#idl-def-MmsMessage</spec_url>
             <spec_statement/>
           </spec>
         </specs>

--- a/webapi/webapi-messaging-sysapps-tests/tests.xml
+++ b/webapi/webapi-messaging-sysapps-tests/tests.xml
@@ -485,62 +485,62 @@
           <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsMessage.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="SmsMessage_send_zero" onload_delay="20" purpose="Check if the send method of SmsManager which has no param can not work normally">
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="SmsManager_send_zero" onload_delay="20" purpose="Check if the send method of SmsManager which has no param can not work normally">
         <description>
           <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="SmsMessage_segmentInfo_zero" onload_delay="20" purpose="Check if the segmentInfo method of SmsManager which has no params can not work normally">
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="SmsManager_send_one" onload_delay="20" purpose="Check if the send method of SmsManager which has one param can not work normally">
         <description>
           <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsManager_send_zero" onload_delay="20" purpose="Check if the send method of MmsManager which has no params can not work normally">
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="SmsManager_segmentInfo_zero" onload_delay="20" purpose="Check if the segmentInfo method of SmsManager which has no params can not work normally">
         <description>
           <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsManager_fetch_zero" onload_delay="20" purpose="Check if the fetch method of MmsManager which has no params can not work normally">
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsManager_send_zero" onload_delay="20" purpose="Check if the send method of MmsManager which has no params can not work normally">
         <description>
           <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="findConversations_one" purpose="Check if the findConversations method which has only one params can not work normally">
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsManager_fetch_zero" onload_delay="20" purpose="Check if the fetch method of MmsManager which has no params can not work normally">
         <description>
           <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="markConversationRead_one" purpose="CCheck if the markConversationRead method which has only one params can not work normally">
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="findConversations_one" purpose="Check if the findConversations method which has only one params can not work normally">
         <description>
           <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="deleteConversation_zero" purpose="Check if the deleteConversation method which has no params can not work normally">
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="markConversationRead_one" purpose="CCheck if the markConversationRead method which has only one params can not work normally">
         <description>
           <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="findMessages_one" purpose="Check if the findMessages method which has only one params can not work normally">
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="deleteConversation_zero" purpose="Check if the deleteConversation method which has no params can not work normally">
         <description>
           <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="markMessageRead_one" purpose="Check if the markMessageRead method which has only one params can not work normally.">
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="findMessages_one" purpose="Check if the findMessages method which has only one params can not work normally">
         <description>
           <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="getMessage_zero" purpose="Check if the getMessage method which has no params can not work normally">
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="markMessageRead_one" purpose="Check if the markMessageRead method which has only one params can not work normally.">
         <description>
           <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="deleteMessage_zero" purpose="Check if the deleteMessage method which has no params can not work normally">
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="getMessage_zero" purpose="Check if the getMessage method which has no params can not work normally">
         <description>
           <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="SmsManager_send_type" purpose="Check if the send method of SmsManager which has no params can not work normally">
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="deleteMessage_zero" purpose="Check if the deleteMessage method which has no params can not work normally">
         <description>
           <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
         </description>
@@ -553,6 +553,321 @@
       <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsManager_send_type" purpose="Check if the send method of MmsManager which has wrong type params can not work normally">
         <description>
           <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/Messaging_method_reverse.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MessagingManager_sms_basic" purpose="Check if the readonly attribute sms of MessagingManager exists and type of object">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MessagingManager_basic.html?total_num=9&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MessagingManager_mms_basic" purpose="Check if the readonly attribute mms of MessagingManager exists and type of object">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MessagingManager_basic.html?total_num=9&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MessagingManager_findMessages_basic" purpose="Check if the findMessages function of MessagingManager exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MessagingManager_basic.html?total_num=9&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MessagingManager_findConversations_basic" purpose="Check if the findConversations function of MessagingManager exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MessagingManager_basic.html?total_num=9&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MessagingManager_getMessage_basic" purpose="Check if the getMessage function of MessagingManager exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MessagingManager_basic.html?total_num=9&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MessagingManager_deleteMessage_basic" purpose="Check if the deleteMessage function of MessagingManager exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MessagingManager_basic.html?total_num=9&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MessagingManager_deleteConversation_basic" purpose="Check if the deleteConversation function of MessagingManager exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MessagingManager_basic.html?total_num=9&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MessagingManager_markMessageRead_basic" purpose="Check if the markMessageRead function of MessagingManager exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MessagingManager_basic.html?total_num=9&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MessagingManager_markConversationRead_basic" purpose="Check if the markConversationRead function of MessagingManager exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MessagingManager_basic.html?total_num=9&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="SmsManager_type_basic" purpose="Check if the readonly attribute type of SmsManager exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsManager_basic.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="SmsManager_serviceIDs_basic" purpose="Check if the readonly attribute serviceIDs of SmsManager exists and type of array">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsManager_basic.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="SmsManager_onreceived_basic" purpose="Check if the onreceived event of SmsManager exists">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsManager_basic.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="SmsManager_onsent_basic" purpose="Check if the onsent event of SmsManager exists">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsManager_basic.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="SmsManager_ondeliverysuccess_basic" purpose="Check if the ondeliverysuccess event of SmsManager exists">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsManager_basic.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="SmsManager_ondeliveryerror_basic" purpose="Check if the ondeliveryerror event of SmsManager exists">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsManager_basic.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="SmsManager_onserviceadded_basic" purpose="Check if the onserviceadded event of SmsManager exists">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsManager_basic.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="SmsManager_onserviceremoved_basic" purpose="Check if the onserviceremoved event of SmsManager exists">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsManager_basic.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="SmsManager_segmentInfo_basic" purpose="Check if the segmentInfo function of SmsManager exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsManager_basic.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="SmsManager_send_basic" purpose="Check if the send function of SmsManager exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsManager_basic.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="SmsManager_clear_basic" purpose="Check if the clear function of SmsManager exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsManager_basic.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsManager_type_basic" purpose="Check if the readonly attribute type of MmsManager is exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsManager_serviceIDs_basic" purpose="Check if the readonly attribute serviceIDs of MmsManager exists and type of array">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsManager_onreceived_basic" purpose="Check if the onreceived event of MmsManager is exists">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsManager_onsent_basic" purpose="Check if the onsent event of MmsManager is exists">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsManager_ondeliverysuccess_basic" purpose="Check if the ondeliverysuccess event of MmsManager is exists">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsManager_ondeliveryerror_basic" purpose="Check if the ondeliveryerror event of MmsManager is exists">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsManager_onreadsuccess_basic" purpose="Check if the onreadsuccess event of MmsManager is exists">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsManager_onreaderror_basic" purpose="Check if the onreaderror event of MmsManager is exists">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsManager_onserviceadded_basic" purpose="Check if the onserviceadded event of MmsManager is exists">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsManager_onserviceremoved_basic" purpose="Check if the onserviceremoved event of MmsManager is exists">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsManager_getFetchMode_basic" purpose="Check if the getFetchMode function of MmsManager exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsManager_setFetchMode_basic" purpose="Check if the setFetchMode function of MmsManager exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsManager_send_basic" purpose="Check if the send function of MmsManager exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsManager_fetch_basic" purpose="Check if the fetch function of MmsManager exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsManager_clear_basic" purpose="Check if the clear function of MmsManager exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsManager_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="SmsMessage_messageID_basic" purpose="Check if the readonly attribute messageID of SmsMessage exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsMessage_basic.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="SmsMessage_type_basic" purpose="Check if the readonly attribute type of SmsMessage exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsMessage_basic.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="SmsMessage_serviceID_basic" purpose="Check if the readonly attribute serviceID of SmsMessage exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsMessage_basic.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="SmsMessage_from_basic" purpose="Check if the readonly attribute from of SmsMessage exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsMessage_basic.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="SmsMessage_timestamp_basic" purpose="Check if the readonly attribute timestamp of SmsMessage exists and type of Date">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsMessage_basic.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="SmsMessage_read_basic" purpose="Check if the readonly attribute read of SmsMessage exists and type of boolean">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsMessage_basic.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="SmsMessage_to_basic" purpose="Check if the readonly attribute to of SmsMessage exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsMessage_basic.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="SmsMessage_body_basic" purpose="Check if the readonly attribute body of SmsMessage exists and type of String">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsMessage_basic.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="SmsMessage_state_basic" purpose="Check if the readonly attribute state of SmsMessage exists and type of String">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsMessage_basic.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="SmsMessage_deliveryStatus_basic" purpose="Check if the readonly attribute deliveryStatus of SmsMessage exists and type of String">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsMessage_basic.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="SmsMessage_deliveryTimestamp_basic" purpose="Check if the readonly attribute deliveryTimestamp of SmsMessage exists and type of String">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsMessage_basic.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="SmsMessage_messageClass_basic" purpose="Check if the readonly attribute messageClass of SmsMessage exists and type of String">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/SmsMessage_basic.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsMessage_messageID_basic" purpose="Check if the readonly attribute messageID of MmsMessage exists and type of String">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsMessage_type_basic" purpose="Check if the readonly attribute type of MmsMessage exists and type of String">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsMessage_serviceID_basic" purpose="Check if the readonly attribute serviceID of MmsMessage exists and type of String">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsMessage_from_basic" purpose="Check if the readonly attribute from of MmsMessage exists and type of String">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsMessage_timestamp_basic" purpose="Check if the readonly attribute timestamp of MmsMessage exists and type of date">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsMessage_read_basic" purpose="Check if the readonly attribute read of MmsMessage exists and type of boolean">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsMessage_to_basic" purpose="Check if the readonly attribute to of MmsMessage exists and type of array">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsMessage_expiry_basic" purpose="Check if the readonly attribute expiry of MmsMessage exists and type of String">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsMessage_cc_basic" purpose="Check if the readonly attribute cc of MmsMessage exists and type of array">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsMessage_bcc_basic" purpose="Check if the readonly attribute bcc of MmsMessage exists and type of array">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsMessage_subject_basic" purpose="Check if the readonly attribute subject of MmsMessage exists and type of String">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsMessage_smil_basic" purpose="Check if the readonly attribute smil of MmsMessage exists and type of String">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsMessage_attachments_basic" purpose="Check if the readonly attribute attachments of MmsMessage exists and type of array">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsMessage_state_basic" purpose="Check if the readonly attribute state of MmsMessage exists and type of String">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsMessage_deliveryInfo_basic" purpose="Check if the readonly attribute deliveryInfo of MmsMessage exists and type of array">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Messaging" execution_type="auto" id="MmsMessage_readReportRequested_basic" purpose="Check if the readonly attribute readReportRequested of MmsMessage exists and type of boolean">
+        <description>
+          <test_script_entry>/opt/webapi-messaging-sysapps-tests/messaging/MmsMessage_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=16</test_script_entry>
         </description>
       </testcase>
     </set>


### PR DESCRIPTION
Impacted Suites: webapi-messaging-sysapps-tests
Impacted TCs num: New 63, Update 0, Delete 0
Unit test Platform: Andriod
Andriod test result summary: Pass 16, Fail 47 Blocked 0

Comments:
1. The spec is not supported in tizen.
2. MmsManager and MmsMessage interface is not supported.
3. The attribute of SmsManager and SmsMessage is not read only.
