### PR TITLE
[webapi] Add 31 TCs for devicecapabilities

### DIFF
--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/AudioCodec_format_attribute.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/AudioCodec_format_attribute.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>DeviceCapabilities Test: AudioCodec_format_attribute</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="http://www.w3.org/2012/sysapps/device-capabilities/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+var t = async_test("Check if the readonly attribute AudioCodec.format exists and typeof string", {timeout: 2000});
+
+t.step(function () {
+  assert_true(!!system, "The Navigator support system");
+
+  system.getAVCodecs().then(
+    function (info) {
+      t.step(function () {
+        var audio = info.audioCodecs[0];
+        assert_true("format" in audio, "The AudioCodec.format exists");
+        assert_equals(typeof audio.format, "string", "The type of AudioCodec.format");
+        var value = audio.format;
+        audio.format = value + "format";
+        assert_equals(audio.format, value, "The AudioCodec.format");
+      });
+      t.done();
+    }, function (error) {
+      t.step(function () {
+        assert_unreached(error.message);
+      });
+      t.done();
+    }
+  );
+});
+</script>

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DeviceCapabilities_methods.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DeviceCapabilities_methods.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>DeviceCapabilities Test: DeviceCapabilities_methods</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="http://www.w3.org/2012/sysapps/device-capabilities/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+test(function () {
+  assert_true("getCPUInfo" in system, "The DeviceCapabilities.getCPUInfo exists");
+  assert_equals(typeof system.getCPUInfo, "function", "The type of DeviceCapabilities.getCPUInfo");
+}, "Check if the DeviceCapabilities.getCPUInfo exists and typeof function");
+
+test(function () {
+  assert_true("getMemoryInfo" in system, "The DeviceCapabilities.getMemoryInfo exists");
+  assert_equals(typeof system.getMemoryInfo, "function", "The type of DeviceCapabilities.getMemoryInfo");
+}, "Check if the DeviceCapabilities.getMemoryInfo exists and typeof function");
+
+test(function () {
+  assert_true("getStorageInfo" in system, "The DeviceCapabilities.getStorageInfo exists");
+  assert_equals(typeof system.getStorageInfo, "function", "The type of DeviceCapabilities.getStorageInfo");
+}, "Check if the DeviceCapabilities.getStorageInfo exists and typeof function");
+
+test(function () {
+  assert_true("getDisplayInfo" in system, "The DeviceCapabilities.getDisplayInfo exists");
+  assert_equals(typeof system.getDisplayInfo, "function", "The type of DeviceCapabilities.getDisplayInfo");
+}, "Check if the DeviceCapabilities.getDisplayInfo exists and typeof function");
+
+test(function () {
+  assert_true("getAVCodecs" in system, "The DeviceCapabilities.getAVCodecs exists");
+  assert_equals(typeof system.getAVCodecs, "function", "The type of DeviceCapabilities.getAVCodecs");
+}, "Check if the DeviceCapabilities.getAVCodecs exists and typeof function");
+</script>

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DisplayUnit_deviceXDPI_attribute.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DisplayUnit_deviceXDPI_attribute.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>DeviceCapabilities Test: DisplayUnit_deviceXDPI_attribute</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="http://www.w3.org/2012/sysapps/device-capabilities/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+var t = async_test("Check if the readonly attribute DisplayUnit.deviceXDPI exists and typeof number", {timeout: 2000});
+
+t.step(function () {
+  assert_true(!!system, "The Navigator support system");
+
+  system.getDisplayInfo().then(
+    function (info) {
+      t.step(function () {
+        var display = info.displays[0];
+        assert_true("deviceXDPI" in display, "The DisplayUnit.deviceXDPI exists");
+        assert_equals(typeof display.deviceXDPI, "number", "The type of DisplayUnit.deviceXDPI");
+        var value = display.deviceXDPI;
+        display.deviceXDPI = value + 1;
+        assert_equals(display.deviceXDPI, value, "The DisplayUnit.deviceXDPI");
+      });
+      t.done();
+    }, function (error) {
+      t.step(function () {
+        assert_unreached(error.message);
+      });
+      t.done();
+    }
+  );
+});
+</script>

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DisplayUnit_deviceYDPI_attribute.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DisplayUnit_deviceYDPI_attribute.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>DeviceCapabilities Test: DisplayUnit_deviceYDPI_attribute</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="http://www.w3.org/2012/sysapps/device-capabilities/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+var t = async_test("Check if the readonly attribute DisplayUnit.deviceYDPI exists and typeof number", {timeout: 2000});
+
+t.step(function () {
+  assert_true(!!system, "The Navigator support system");
+
+  system.getDisplayInfo().then(
+    function (info) {
+      t.step(function () {
+        var display = info.displays[0];
+        assert_true("deviceYDPI" in display, "The DisplayUnit.deviceYDPI exists");
+        assert_equals(typeof display.deviceYDPI, "number", "The type of DisplayUnit.deviceYDPI");
+        var value = display.deviceYDPI;
+        display.deviceYDPI = value + 1;
+        assert_equals(display.deviceYDPI, value, "The DisplayUnit.deviceYDPI");
+      });
+      t.done();
+    }, function (error) {
+      t.step(function () {
+        assert_unreached(error.message);
+      });
+      t.done();
+    }
+  );
+});
+</script>

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DisplayUnit_external_attribute.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DisplayUnit_external_attribute.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>DeviceCapabilities Test: DisplayUnit_external_attribute</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="http://www.w3.org/2012/sysapps/device-capabilities/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+var t = async_test("Check if the readonly attribute DisplayUnit.external exists and typeof boolean", {timeout: 2000});
+
+t.step(function () {
+  assert_true(!!system, "The Navigator support system");
+
+  system.getDisplayInfo().then(
+    function (info) {
+      t.step(function () {
+        var display = info.displays[0];
+        assert_true("external" in display, "The DisplayUnit.external exists");
+        assert_equals(typeof display.external, "boolean", "The type of DisplayUnit.external");
+        var flag = display.external;
+        display.external = !flag;
+        assert_equals(display.external, flag, "The DisplayUnit.external");
+      });
+      t.done();
+    }, function (error) {
+      t.step(function () {
+        assert_unreached(error.message);
+      });
+      t.done();
+    }
+  );
+});
+</script>

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DisplayUnit_id_attribute.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DisplayUnit_id_attribute.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>DeviceCapabilities Test: DisplayUnit_id_attribute</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="http://www.w3.org/2012/sysapps/device-capabilities/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+var t = async_test("Check if the readonly attribute DisplayUnit.id exists and typeof string", {timeout: 2000});
+
+t.step(function () {
+  assert_true(!!system, "The Navigator support system");
+
+  system.getDisplayInfo().then(
+    function (info) {
+      t.step(function () {
+        var display = info.displays[0];
+        assert_true("id" in display, "The DisplayUnit.id exists");
+        assert_equals(typeof display.id, "string", "The type of DisplayUnit.id");
+        var value = display.id;
+        display.id = value + "id";
+        assert_equals(display.id, value, "The DisplayUnit.id");
+      });
+      t.done();
+    }, function (error) {
+      t.step(function () {
+        assert_unreached(error.message);
+      });
+      t.done();
+    }
+  );
+});
+</script>

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DisplayUnit_name_attribute.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DisplayUnit_name_attribute.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>DeviceCapabilities Test: DisplayUnit_name_attribute</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="http://www.w3.org/2012/sysapps/device-capabilities/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+var t = async_test("Check if the readonly attribute DisplayUnit.name exists and typeof string", {timeout: 2000});
+
+t.step(function () {
+  assert_true(!!system, "The Navigator support system");
+
+  system.getDisplayInfo().then(
+    function (info) {
+      t.step(function () {
+        var display = info.displays[0];
+        assert_true("name" in display, "The DisplayUnit.name exists");
+        assert_equals(typeof display.name, "string", "The type of DisplayUnit.name");
+        var value = display.name;
+        display.name = value + "name";
+        assert_equals(display.name, value, "The DisplayUnit.name");
+      });
+      t.done();
+    }, function (error) {
+      t.step(function () {
+        assert_unreached(error.message);
+      });
+      t.done();
+    }
+  );
+});
+</script>

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DisplayUnit_primary_attribute.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DisplayUnit_primary_attribute.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>DeviceCapabilities Test: DisplayUnit_primary_attribute</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="http://www.w3.org/2012/sysapps/device-capabilities/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+var t = async_test("Check if the readonly attribute DisplayUnit.primary exists and typeof boolean", {timeout: 2000});
+
+t.step(function () {
+  assert_true(!!system, "The Navigator support system");
+
+  system.getDisplayInfo().then(
+    function (info) {
+      t.step(function () {
+        var display = info.displays[0];
+        assert_true("primary" in display, "The DisplayUnit.primary exists");
+        assert_equals(typeof display.primary, "boolean", "The type of DisplayUnit.primary");
+        var flag = display.primary;
+        display.primary = !flag;
+        assert_equals(display.primary, flag, "The DisplayUnit.primary");
+      });
+      t.done();
+    }, function (error) {
+      t.step(function () {
+        assert_unreached(error.message);
+      });
+      t.done();
+    }
+  );
+});
+</script>

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/Navigator_system_attribute.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/Navigator_system_attribute.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>DeviceCapabilities Test: Navigator_system_attribute</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="http://www.w3.org/2012/sysapps/device-capabilities/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+test(function () {
+  var  system = navigator.system || xwalk.experimental.system;
+  assert_true(!!system, "The Navigator.system exists");
+  assert_equals(typeof system, "object", "The type of Navigator.system");
+  var value = system;
+  system = null;
+  assert_equals(system, value, "The Navigator.system");
+}, "Check if the readonly attribute Navigator.system exists and typeof object");
+</script>

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/StorageUnit_capacity_attribute.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/StorageUnit_capacity_attribute.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>DeviceCapabilities Test: StorageUnit_capacity_attribute</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="http://www.w3.org/2012/sysapps/device-capabilities/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+var t = async_test("Check if the readonly attribute StorageUnit.capacity exists and typeof number", {timeout: 2000});
+
+t.step(function () {
+  assert_true(!!system, "The Navigator support system");
+
+  system.getStorageInfo().then(
+    function (info) {
+      t.step(function () {
+        var storage = info.storages[0];
+        assert_true("capacity" in storage, "The StorageUnit.capacity exists");
+        assert_equals(typeof storage.capacity, "number", "The type of StorageUnit.capacity");
+        var value = storage.capacity;
+        storage.capacity = value + 1;
+        assert_equals(storage.id, value, "The StorageUnit.capacity");
+      });
+      t.done();
+    }, function (error) {
+      t.step(function () {
+        assert_unreached(error.message);
+      });
+      t.done();
+    }
+  );
+});
+</script>

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/StorageUnit_id_attribute.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/StorageUnit_id_attribute.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>DeviceCapabilities Test: StorageUnit_id_attribute</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="http://www.w3.org/2012/sysapps/device-capabilities/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+var t = async_test("Check if the readonly attribute StorageUnit.id exists and typeof string", {timeout: 2000});
+
+t.step(function () {
+  assert_true(!!system, "The Navigator support system");
+
+  system.getStorageInfo().then(
+    function (info) {
+      t.step(function () {
+        var storage = info.storages[0];
+        assert_true("id" in storage, "The StorageUnit.id exists");
+        assert_equals(typeof storage.id, "string", "The type of StorageUnit.id");
+        var value = storage.id;
+        storage.id = value + "id";
+        assert_equals(storage.id, value, "The StorageUnit.id");
+      });
+      t.done();
+    }, function (error) {
+      t.step(function () {
+        assert_unreached(error.message);
+      });
+      t.done();
+    }
+  );
+});
+</script>

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/StorageUnit_name_attribute.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/StorageUnit_name_attribute.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>DeviceCapabilities Test: StorageUnit_name_attribute</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="http://www.w3.org/2012/sysapps/device-capabilities/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+var t = async_test("Check if the readonly attribute StorageUnit.name exists and typeof string", {timeout: 2000});
+
+t.step(function () {
+  assert_true(!!system, "The Navigator support system");
+
+  system.getStorageInfo().then(
+    function (info) {
+      t.step(function () {
+        var storage = info.storages[0];
+        assert_true("name" in storage, "The StorageUnit.name exists");
+        assert_equals(typeof storage.name, "string", "The type of StorageUnit.name");
+        var value = storage.name;
+        storage.name = value + "name";
+        assert_equals(storage.name, value, "The StorageUnit.name");
+      });
+      t.done();
+    }, function (error) {
+      t.step(function () {
+        assert_unreached(error.message);
+      });
+      t.done();
+    }
+  );
+});
+</script>

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/StorageUnit_type_attribute.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/StorageUnit_type_attribute.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>DeviceCapabilities Test: StorageUnit_type_attribute</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="http://www.w3.org/2012/sysapps/device-capabilities/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+var t = async_test("Check if the readonly attribute StorageUnit.type exists and typeof string", {timeout: 2000});
+
+t.step(function () {
+  assert_true(!!system, "The Navigator support system");
+
+  system.getStorageInfo().then(
+    function (info) {
+      t.step(function () {
+        var storage = info.storages[0];
+        assert_true("type" in storage, "The StorageUnit.type exists");
+        assert_equals(typeof storage.type, "string", "The type of StorageUnit.type");
+        var value = storage.type;
+        storage.type = value + "type";
+        assert_equals(storage.type, value, "The StorageUnit.type");
+      });
+      t.done();
+    }, function (error) {
+      t.step(function () {
+        assert_unreached(error.message);
+      });
+      t.done();
+    }
+  );
+});
+</script>

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemAVCodecs_audioCodecs_attribute.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemAVCodecs_audioCodecs_attribute.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>DeviceCapabilities Test: SystemAVCodecs_audioCodecs_attribute</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="http://www.w3.org/2012/sysapps/device-capabilities/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+var t = async_test("Check if the readonly attribute SystemAVCodecs.audioCodecs exists and typeof object", {timeout: 2000});
+
+t.step(function () {
+  assert_true(!!system, "The Navigator support system");
+
+  system.getAVCodecs().then(
+    function (info) {
+      t.step(function () {
+        assert_true("audioCodecs" in info, "The SystemAVCodecs.audioCodecs exists");
+        assert_equals(typeof info.audioCodecs, "object", "The type of SystemAVCodecs.audioCodecs");
+        var value = info.audioCodecs;
+        info.audioCodecs = null;
+        assert_equals(info.audioCodecs, value, "The SystemAVCodecs.audioCodecs");
+      });
+      t.done();
+    }, function (error) {
+      t.step(function () {
+        assert_unreached(error.message);
+      });
+      t.done();
+    }
+  );
+});
+</script>

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemAVCodecs_videoCodecs_attribute.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemAVCodecs_videoCodecs_attribute.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>DeviceCapabilities Test: SystemAVCodecs_videoCodecs_attribute</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="http://www.w3.org/2012/sysapps/device-capabilities/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+var t = async_test("Check if the readonly attribute SystemAVCodecs.videoCodecs exists and typeof object", {timeout: 2000});
+
+t.step(function () {
+  assert_true(!!system, "The Navigator support system");
+
+  system.getAVCodecs().then(
+    function (info) {
+      t.step(function () {
+        assert_true("videoCodecs" in info, "The SystemAVCodecs.videoCodecs exists");
+        assert_equals(typeof info.videoCodecs, "object", "The type of SystemAVCodecs.videoCodecs");
+        var value = info.videoCodecs;
+        info.videoCodecs = null;
+        assert_equals(info.videoCodecs, value, "The SystemAVCodecs.videoCodecs");
+      });
+      t.done();
+    }, function (error) {
+      t.step(function () {
+        assert_unreached(error.message);
+      });
+      t.done();
+    }
+  );
+});
+</script>

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemCPU_archName_attribute.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemCPU_archName_attribute.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>DeviceCapabilities Test: SystemCPU_archName_attribute</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="http://www.w3.org/2012/sysapps/device-capabilities/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+var t = async_test("Check if the readonly attribute SystemCPU.archName exists and typeof string", {timeout: 2000});
+
+t.step(function () {
+  assert_true(!!system, "The Navigator support system");
+
+  system.getCPUInfo().then(
+    function (info) {
+      t.step(function () {
+        assert_true("archName" in info, "The SystemCPU.archName exists");
+        assert_equals(typeof info.archName, "string", "The type of SystemCPU.archName");
+        var value = info.archName;
+        info.archName = value + "archName";
+        assert_equals(info.archName, value, "The SystemCPU.archName");
+      });
+      t.done();
+    }, function (error) {
+      t.step(function () {
+        assert_unreached(error.message);
+      });
+      t.done();
+    }
+  );
+});
+</script>

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemCPU_load_attribute.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemCPU_load_attribute.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>DeviceCapabilities Test: SystemCPU_load_attribute</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="http://www.w3.org/2012/sysapps/device-capabilities/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+var t = async_test("Check if the readonly attribute SystemCPU.load exists and typeof number", {timeout: 2000});
+
+t.step(function () {
+  assert_true(!!system, "The Navigator support system");
+
+  system.getCPUInfo().then(
+    function (info) {
+      t.step(function () {
+        assert_true("load" in info, "The SystemCPU.load exists");
+        assert_equals(typeof info.load, "number", "The type of SystemCPU.load");
+        var value = info.load;
+        info.load = value + 1;
+        assert_equals(info.load, value, "The SystemCPU.load");
+      });
+      t.done();
+    }, function (error) {
+      t.step(function () {
+        assert_unreached(error.message);
+      });
+      t.done();
+    }
+  );
+});
+</script>

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemCPU_numOfProcessors_attribute.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemCPU_numOfProcessors_attribute.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>DeviceCapabilities Test: SystemCPU_numOfProcessors_attribute</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="http://www.w3.org/2012/sysapps/device-capabilities/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+var t = async_test("Check if the readonly attribute SystemCPU.numOfProcessors exists and typeof number", {timeout: 2000});
+
+t.step(function () {
+  assert_true(!!system, "The Navigator support system");
+
+  system.getCPUInfo().then(
+    function (info) {
+      t.step(function () {
+        assert_true("numOfProcessors" in info, "The SystemCPU.numOfProcessors exists");
+        assert_equals(typeof info.numOfProcessors, "number", "The type of SystemCPU.numOfProcessors");
+        var value = info.numOfProcessors;
+        info.numOfProcessors = value + 1;
+        assert_equals(info.numOfProcessors, value, "The SystemCPU.numOfProcessors");
+      });
+      t.done();
+    }, function (error) {
+      t.step(function () {
+        assert_unreached(error.message);
+      });
+      t.done();
+    }
+  );
+});
+</script>

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemDisplayEvent_DisplayUnit_manual.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemDisplayEvent_DisplayUnit_manual.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>DeviceCapabilities Test: SystemDisplayEvent_DisplayUnit_manual</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="http://www.w3.org/2012/sysapps/device-capabilities/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<meta name="flags" content="interact">
+<meta name="assert" content="Check if the readonly attribute SystemDisplayEvent.DisplayUnit exists and typeof object">
+<p>Connect a new display to the system</p>
+<p>Test passes if "PASS" reault appears after you connect a new display to the system</p>
+<div id="log"></div>
+<script>
+var t = async_test("Check if the readonly attribute SystemDisplayEvent.DisplayUnit exists and typeof object", {timeout: 40000});
+
+t.step(function () {
+  assert_true(!!system, "The Navigator support system");
+
+  system.addEventListener("displayconnect", function (e) {
+    t.step(function () {
+      assert_true("DisplayUnit" in e, "The SystemDisplayEvent.DisplayUnit exists");
+      assert_equals(typeof e.DisplayUnit, "object", "The type of SystemDisplayEvent.DisplayUnit");
+      var value = e.DisplayUnit;
+      e.DisplayUnit = null;
+      assert_equals(e.DisplayUnit, value, "The SystemDisplayEvent.DisplayUnit");
+    });
+    t.done();
+  });
+});
+</script>

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemDisplay_displays_attribute.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemDisplay_displays_attribute.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>DeviceCapabilities Test: SystemDisplay_displays_attribute</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="http://www.w3.org/2012/sysapps/device-capabilities/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+var t = async_test("Check if the readonly attribute SystemDisplay.displays exists and typeof object", {timeout: 2000});
+
+t.step(function () {
+  assert_true(!!system, "The Navigator support system");
+
+  system.getDisplayInfo().then(
+    function (info) {
+      t.step(function () {
+        assert_true("displays" in info, "The SystemDisplay.displays exists");
+        assert_equals(typeof info.displays, "object", "The type of SystemDisplay.displays");
+        var value = info.displays;
+        info.displays = null;
+        assert_equals(info.displays, value, "The SystemDisplay.displays");
+      });
+      t.done();
+    }, function (error) {
+      t.step(function () {
+        assert_unreached(error.message);
+      });
+      t.done();
+    }
+  );
+});
+</script>

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemMemory_availCapacity_attribute.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemMemory_availCapacity_attribute.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>DeviceCapabilities Test: SystemMemory_availCapacity_attribute</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="http://www.w3.org/2012/sysapps/device-capabilities/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+var t = async_test("Check if the readonly attribute SystemMemory.availCapacity exists and typeof number", {timeout: 2000});
+
+t.step(function () {
+  assert_true(!!system, "The Navigator support system");
+
+  system.getMemoryInfo().then(
+    function (info) {
+      t.step(function () {
+        assert_true("availCapacity" in info, "The SystemMemory.availCapacity exists");
+        assert_equals(typeof info.availCapacity, "number", "The type of SystemMemory.availCapacity");
+        var value = info.availCapacity;
+        info.availCapacity = value + 1;
+        assert_equals(info.availCapacity, value, "The SystemMemory.availCapacity");
+      });
+      t.done();
+    }, function (error) {
+      t.step(function () {
+        assert_unreached(error.message);
+      });
+      t.done();
+    }
+  );
+});
+</script>

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemMemory_capacity_attribute.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemMemory_capacity_attribute.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>DeviceCapabilities Test: SystemMemory_capacity_attribute</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="http://www.w3.org/2012/sysapps/device-capabilities/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+var t = async_test("Check if the readonly attribute SystemMemory.capacity exists and typeof number", {timeout: 2000});
+
+t.step(function () {
+  assert_true(!!system, "The Navigator support system");
+
+  system.getMemoryInfo().then(
+    function (info) {
+      t.step(function () {
+        assert_true("capacity" in info, "The SystemMemory.capacity exists");
+        assert_equals(typeof info.capacity, "number", "The type of SystemMemory.capacity");
+        var value = info.capacity;
+        info.capacity = value + 1;
+        assert_equals(info.capacity, value, "The SystemMemory.capacity");
+      });
+      t.done();
+    }, function (error) {
+      t.step(function () {
+        assert_unreached(error.message);
+      });
+      t.done();
+    }
+  );
+});
+</script>

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemStorageEvent_StorageUnit_manual.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemStorageEvent_StorageUnit_manual.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>DeviceCapabilities Test: SystemStorageEvent_StorageUnit_manual</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="http://www.w3.org/2012/sysapps/device-capabilities/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<meta name="flags" content="interact">
+<meta name="assert" content="Check if the readonly attribute SystemStorageEvent.StorageUnit exists and typeof object">
+<p>Attach a new storage to the system</p>
+<p>Test passes if "PASS" reault appears after you attach a new storage to the system</p>
+<div id="log"></div>
+<script>
+var t = async_test("Check if the readonly attribute SystemStorageEvent.StorageUnit exists and typeof object", {timeout: 40000});
+
+t.step(function () {
+  assert_true(!!system, "The Navigator support system");
+
+  system.addEventListener("storageattach", function (e) {
+    t.step(function () {
+      assert_true("StorageUnit" in e, "The SystemStorageEvent.StorageUnit exists");
+      assert_equals(typeof e.StorageUnit, "object", "The type of SystemStorageEvent.StorageUnit");
+      var value = e.StorageUnit;
+      e.StorageUnit = null;
+      assert_equals(e.StorageUnit, value, "The SystemStorageEvent.StorageUnit");
+    });
+    t.done();
+  });
+});
+</script>

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemStorage_storages_attribute.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemStorage_storages_attribute.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>DeviceCapabilities Test: SystemStorage_storages_attribute</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="http://www.w3.org/2012/sysapps/device-capabilities/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+var t = async_test("Check if the readonly attribute SystemStorage.storages exists and typeof object", {timeout: 2000});
+
+t.step(function () {
+  assert_true(!!system, "The Navigator support system");
+
+  system.getStorageInfo().then(
+    function (info) {
+      t.step(function () {
+        assert_true("storages" in info, "The SystemStorage.storages exists");
+        assert_equals(typeof info.storages, "object", "The type of SystemStorage.storages");
+        var value = info.storages;
+        info.storages = null;
+        assert_equals(info.storages, value, "The SystemStorage.storages");
+      });
+      t.done();
+    }, function (error) {
+      t.step(function () {
+        assert_unreached(error.message);
+      });
+      t.done();
+    }
+  );
+});
+</script>

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/VideoCodec_encode_attribute.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/VideoCodec_encode_attribute.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>DeviceCapabilities Test: VideoCodec_encode_attribute</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="http://www.w3.org/2012/sysapps/device-capabilities/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+var t = async_test("Check if the readonly attribute VideoCodec.encode exists and typeof boolean", {timeout: 2000});
+
+t.step(function () {
+  assert_true(!!system, "The Navigator support system");
+
+  system.getAVCodecs().then(
+    function (info) {
+      t.step(function () {
+        var video = info.videoCodecs[0];
+        assert_true("encode" in video, "The VideoCodec.encode exists");
+        assert_equals(typeof video.encode, "boolean", "The type of VideoCodec.encode");
+        var flag = video.encode;
+        video.encode = !flag;
+        assert_equals(video.encode, flag, "The VideoCodec.encode");
+      });
+      t.done();
+    }, function (error) {
+      t.step(function () {
+        assert_unreached(error.message);
+      });
+      t.done();
+    }
+  );
+});
+</script>

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/VideoCodec_format_attribute.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/VideoCodec_format_attribute.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>DeviceCapabilities Test: VideoCodec_format_attribute</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="http://www.w3.org/2012/sysapps/device-capabilities/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+var t = async_test("Check if the readonly attribute VideoCodec.format exists and typeof string", {timeout: 2000});
+
+t.step(function () {
+  assert_true(!!system, "The Navigator support system");
+
+  system.getAVCodecs().then(
+    function (info) {
+      t.step(function () {
+        var video = info.videoCodecs[0];
+        assert_true("format" in video, "The VideoCodec.format exists");
+        assert_equals(typeof video.format, "string", "The type of VideoCodec.format");
+        var value = video.format;
+        video.format = value + "test";
+        assert_equals(video.format, value, "The VideoCodec.format");
+      });
+      t.done();
+    }, function (error) {
+      t.step(function () {
+        assert_unreached(error.message);
+      });
+      t.done();
+    }
+  );
+});
+</script>

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/VideoCodec_hwAccel_attribute.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/VideoCodec_hwAccel_attribute.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>DeviceCapabilities Test: VideoCodec_hwAccel_attribute</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="http://www.w3.org/2012/sysapps/device-capabilities/">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+var t = async_test("Check if the readonly attribute VideoCodec.hwAccel exists and typeof boolean", {timeout: 2000});
+
+t.step(function () {
+  assert_true(!!system, "The Navigator support system");
+
+  system.getAVCodecs().then(
+    function (info) {
+      t.step(function () {
+        var video = info.videoCodecs[0];
+        assert_true("hwAccel" in video, "The VideoCodec.hwAccel exists");
+        assert_equals(typeof video.hwAccel, "boolean", "The type of VideoCodec.hwAccel");
+        var flag = video.hwAccel;
+        video.hwAccel = !flag;
+        assert_equals(video.hwAccel, flag, "The VideoCodec.hwAccel");
+      });
+      t.done();
+    }, function (error) {
+      t.step(function () {
+        assert_unreached(error.message);
+      });
+      t.done();
+    }
+  );
+});
+</script>

--- a/webapi/webapi-devicecapabilities-sysapps-tests/tests.full.xml
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/tests.full.xml
@@ -653,6 +653,378 @@
           </spec>
         </specs>
       </testcase>
+      <testcase purpose="Check if the readonly attribute Navigator.system exists and typeof object" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" priority="P1" id="Navigator_system_attribute">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/Navigator_system_attribute.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="system" interface="Navigator" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the DeviceCapabilities.getCPUInfo exists and typeof function" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" priority="P1" id="DeviceCapabilities_getCPUInfo_method">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DeviceCapabilities_methods.html?total_num=5&amp;locator_key=id&amp;value=1</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="getCPUInfo" interface="DeviceCapabilities" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the DeviceCapabilities.getMemoryInfo exists and typeof function" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" priority="P1" id="DeviceCapabilities_getMemoryInfo_method">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DeviceCapabilities_methods.html?total_num=5&amp;locator_key=id&amp;value=2</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="getMemoryInfo" interface="DeviceCapabilities" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the DeviceCapabilities.getStorageInfo exists and typeof function" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" priority="P1" id="DeviceCapabilities_getStorageInfo_method">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DeviceCapabilities_methods.html?total_num=5&amp;locator_key=id&amp;value=3</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="getStorageInfo" interface="DeviceCapabilities" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the DeviceCapabilities.getDisplayInfo exists and typeof function" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" priority="P1" id="DeviceCapabilities_getDisplayInfo_method">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DeviceCapabilities_methods.html?total_num=5&amp;locator_key=id&amp;value=4</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="getDisplayInfo" interface="DeviceCapabilities" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the DeviceCapabilities.getAVCodecs exists and typeof function" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" priority="P1" id="DeviceCapabilities_getAVCodecs_method">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DeviceCapabilities_methods.html?total_num=5&amp;locator_key=id&amp;value=5</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="getAVCodecs" interface="DeviceCapabilities" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute SystemStorageEvent.StorageUnit exists and typeof object" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="manual" priority="P1" id="SystemStorageEvent_StorageUnit_manual">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemStorageEvent_StorageUnit_manual.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="StorageUnit" interface="SystemStorageEvent" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute SystemDisplayEvent.DisplayUnit exists and typeof object" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="manual" priority="P1" id="SystemDisplayEvent_DisplayUnit_manual">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemDisplayEvent_DisplayUnit_manual.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="DisplayUnit" interface="SystemDisplayEvent" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute SystemCPU.archName exists and typeof string" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" priority="P1" id="SystemCPU_archName_attribute">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemCPU_archName_attribute.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="archName" interface="SystemCPU" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute SystemCPU.load exists and typeof number" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" priority="P1" id="SystemCPU_load_attribute">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemCPU_load_attribute.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="load" interface="SystemCPU" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute SystemCPU.numOfProcessors exists and typeof number" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" priority="P1" id="SystemCPU_numOfProcessors_attribute">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemCPU_numOfProcessors_attribute.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="numOfProcessors" interface="SystemCPU" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute SystemMemory.availCapacity exists and typeof number" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" priority="P1" id="SystemMemory_availCapacity_attribute">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemMemory_availCapacity_attribute.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="availCapacity" interface="SystemMemory" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute SystemMemory.capacity exists and typeof number" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" priority="P1" id="SystemMemory_capacity_attribute">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemMemory_capacity_attribute.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="capacity" interface="SystemMemory" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute SystemStorage.storages exists and typeof object" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" priority="P1" id="SystemStorage_storages_attribute">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemStorage_storages_attribute.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="storages" interface="SystemStorage" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute StorageUnit.capacity exists and typeof number" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" priority="P1" id="StorageUnit_capacity_attribute">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/StorageUnit_capacity_attribute.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="capacity" interface="StorageUnit" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute StorageUnit.id exists and typeof string" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" priority="P1" id="StorageUnit_id_attribute">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/StorageUnit_id_attribute.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="id" interface="StorageUnit" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute StorageUnit.name exists and typeof string" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" priority="P1" id="StorageUnit_name_attribute">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/StorageUnit_name_attribute.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="name" interface="StorageUnit" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute StorageUnit.type exists and typeof string" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" priority="P1" id="StorageUnit_type_attribute">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/StorageUnit_type_attribute.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="type" interface="StorageUnit" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute SystemDisplay.displays exists and typeof object" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" priority="P1" id="SystemDisplay_displays_attribute">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemDisplay_displays_attribute.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="displays" interface="SystemDisplay" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute DisplayUnit.deviceXDPI exists and typeof number" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" priority="P1" id="DisplayUnit_deviceXDPI_attribute">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DisplayUnit_deviceXDPI_attribute.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="deviceXDPI" interface="DisplayUnit" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute DisplayUnit.deviceYDPI exists and typeof number" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" priority="P1" id="DisplayUnit_deviceYDPI_attribute">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DisplayUnit_deviceYDPI_attribute.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="deviceYDPI" interface="DisplayUnit" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute DisplayUnit.external exists and typeof boolean" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" priority="P1" id="DisplayUnit_external_attribute">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DisplayUnit_external_attribute.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="external" interface="DisplayUnit" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute DisplayUnit.id exists and typeof string" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" priority="P1" id="DisplayUnit_id_attribute">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DisplayUnit_id_attribute.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="id" interface="DisplayUnit" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute DisplayUnit.name exists and typeof string" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" priority="P1" id="DisplayUnit_name_attribute">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DisplayUnit_name_attribute.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="name" interface="DisplayUnit" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute DisplayUnit.primary exists and typeof boolean" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" priority="P1" id="DisplayUnit_primary_attribute">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DisplayUnit_primary_attribute.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="primary" interface="DisplayUnit" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute SystemAVCodecs.audioCodecs exists and typeof object" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" priority="P1" id="SystemAVCodecs_audioCodecs_attribute">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemAVCodecs_audioCodecs_attribute.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="audioCodecs" interface="SystemAVCodecs" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute SystemAVCodecs.videoCodecs exists and typeof object" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" priority="P1" id="SystemAVCodecs_videoCodecs_attribute">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemAVCodecs_videoCodecs_attribute.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="videoCodecs" interface="SystemAVCodecs" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute AudioCodec.format exists and typeof string" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" priority="P1" id="AudioCodec_format_attribute">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/AudioCodec_format_attribute.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="format" interface="AudioCodec" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute VideoCodec.encode exists and typeof boolean" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" priority="P1" id="VideoCodec_encode_attribute">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/VideoCodec_encode_attribute.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="encode" interface="VideoCodec" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute VideoCodec.format exists and typeof string" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" priority="P1" id="VideoCodec_format_attribute">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/VideoCodec_format_attribute.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="format" interface="VideoCodec" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute VideoCodec.hwAccel exists and typeof boolean" type="compliance" status="approved" component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" priority="P1" id="VideoCodec_hwAccel_attribute">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/VideoCodec_hwAccel_attribute.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="hwAccel" interface="VideoCodec" specification="Device Capabilities" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/2012/sysapps/device-capabilities/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
     </set>
   </suite>
 </test_definition>

--- a/webapi/webapi-devicecapabilities-sysapps-tests/tests.xml
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/tests.xml
@@ -275,6 +275,161 @@
           <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/VideoCodec_encode.html</test_script_entry>
         </description>
       </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" id="Navigator_system_attribute" purpose="Check if the readonly attribute Navigator.system exists and typeof object">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/Navigator_system_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" id="DeviceCapabilities_getCPUInfo_method" purpose="Check if the DeviceCapabilities.getCPUInfo exists and typeof function">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DeviceCapabilities_methods.html?total_num=5&amp;locator_key=id&amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" id="DeviceCapabilities_getMemoryInfo_method" purpose="Check if the DeviceCapabilities.getMemoryInfo exists and typeof function">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DeviceCapabilities_methods.html?total_num=5&amp;locator_key=id&amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" id="DeviceCapabilities_getStorageInfo_method" purpose="Check if the DeviceCapabilities.getStorageInfo exists and typeof function">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DeviceCapabilities_methods.html?total_num=5&amp;locator_key=id&amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" id="DeviceCapabilities_getDisplayInfo_method" purpose="Check if the DeviceCapabilities.getDisplayInfo exists and typeof function">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DeviceCapabilities_methods.html?total_num=5&amp;locator_key=id&amp;value=4</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" id="DeviceCapabilities_getAVCodecs_method" purpose="Check if the DeviceCapabilities.getAVCodecs exists and typeof function">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DeviceCapabilities_methods.html?total_num=5&amp;locator_key=id&amp;value=5</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="manual" id="SystemStorageEvent_StorageUnit_manual" purpose="Check if the readonly attribute SystemStorageEvent.StorageUnit exists and typeof object">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemStorageEvent_StorageUnit_manual.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="manual" id="SystemDisplayEvent_DisplayUnit_manual" purpose="Check if the readonly attribute SystemDisplayEvent.DisplayUnit exists and typeof object">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemDisplayEvent_DisplayUnit_manual.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" id="SystemCPU_archName_attribute" purpose="Check if the readonly attribute SystemCPU.archName exists and typeof string">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemCPU_archName_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" id="SystemCPU_load_attribute" purpose="Check if the readonly attribute SystemCPU.load exists and typeof number">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemCPU_load_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" id="SystemCPU_numOfProcessors_attribute" purpose="Check if the readonly attribute SystemCPU.numOfProcessors exists and typeof number">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemCPU_numOfProcessors_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" id="SystemMemory_availCapacity_attribute" purpose="Check if the readonly attribute SystemMemory.availCapacity exists and typeof number">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemMemory_availCapacity_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" id="SystemMemory_capacity_attribute" purpose="Check if the readonly attribute SystemMemory.capacity exists and typeof number">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemMemory_capacity_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" id="SystemStorage_storages_attribute" purpose="Check if the readonly attribute SystemStorage.storages exists and typeof object">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemStorage_storages_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" id="StorageUnit_capacity_attribute" purpose="Check if the readonly attribute StorageUnit.capacity exists and typeof number">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/StorageUnit_capacity_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" id="StorageUnit_id_attribute" purpose="Check if the readonly attribute StorageUnit.id exists and typeof string">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/StorageUnit_id_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" id="StorageUnit_name_attribute" purpose="Check if the readonly attribute StorageUnit.name exists and typeof string">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/StorageUnit_name_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" id="StorageUnit_type_attribute" purpose="Check if the readonly attribute StorageUnit.type exists and typeof string">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/StorageUnit_type_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" id="SystemDisplay_displays_attribute" purpose="Check if the readonly attribute SystemDisplay.displays exists and typeof object">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemDisplay_displays_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" id="DisplayUnit_deviceXDPI_attribute" purpose="Check if the readonly attribute DisplayUnit.deviceXDPI exists and typeof number">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DisplayUnit_deviceXDPI_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" id="DisplayUnit_deviceYDPI_attribute" purpose="Check if the readonly attribute DisplayUnit.deviceYDPI exists and typeof number">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DisplayUnit_deviceYDPI_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" id="DisplayUnit_external_attribute" purpose="Check if the readonly attribute DisplayUnit.external exists and typeof boolean">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DisplayUnit_external_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" id="DisplayUnit_id_attribute" purpose="Check if the readonly attribute DisplayUnit.id exists and typeof string">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DisplayUnit_id_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" id="DisplayUnit_name_attribute" purpose="Check if the readonly attribute DisplayUnit.name exists and typeof string">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DisplayUnit_name_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" id="DisplayUnit_primary_attribute" purpose="Check if the readonly attribute DisplayUnit.primary exists and typeof boolean">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/DisplayUnit_primary_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" id="SystemAVCodecs_audioCodecs_attribute" purpose="Check if the readonly attribute SystemAVCodecs.audioCodecs exists and typeof object">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemAVCodecs_audioCodecs_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" id="SystemAVCodecs_videoCodecs_attribute" purpose="Check if the readonly attribute SystemAVCodecs.videoCodecs exists and typeof object">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemAVCodecs_videoCodecs_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" id="AudioCodec_format_attribute" purpose="Check if the readonly attribute AudioCodec.format exists and typeof string">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/AudioCodec_format_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" id="VideoCodec_encode_attribute" purpose="Check if the readonly attribute VideoCodec.encode exists and typeof boolean">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/VideoCodec_encode_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" id="VideoCodec_format_attribute" purpose="Check if the readonly attribute VideoCodec.format exists and typeof string">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/VideoCodec_format_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Device Capabilities" execution_type="auto" id="VideoCodec_hwAccel_attribute" purpose="Check if the readonly attribute VideoCodec.hwAccel exists and typeof boolean">
+        <description>
+          <test_script_entry>/opt/webapi-devicecapabilities-sysapps-tests/devicecapabilities/VideoCodec_hwAccel_attribute.html</test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>


### PR DESCRIPTION
```
Impacted Suites: webapi-devicecapabilities-sysapps-tests
Impacted TCs num: New 31, Update 0, Delete 0
Unit test Platform: Tizen
Tizen test result summary: Pass 5, Fail 24, Blocked 2

Comments:
1. 24 TCs failed due to the reason that attributes are not readonly
2. 2 TCs can not be executed in ivi platform.
```
