### PR TITLE
[webapi] Add tests for netinfo from delta

### DIFF
--- a/webapi/tct-netinfo-w3c-tests/netinfo/Connection_bandwidth_zero.html
+++ b/webapi/tct-netinfo-w3c-tests/netinfo/Connection_bandwidth_zero.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Liu.Xin <xinx.liu@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<title>NetworkInfo Test: Connection_bandwidth_zero</title>
+<link rel="author" title="Intel" href="http://www.intel.com"/>
+<link rel="help" href="http://www.w3.org/TR/2012/WD-netinfo-api-20121129/#widl-Connection-bandwidth"/>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<p>
+  Pre-condition: Make sure the network connection is unavailable.<br/>
+</p>
+<div id="log"></div>
+<script>
+  test(function() {
+    var connection = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+    assert_true(!!connection, "NetworkInformation.connection attribute exists");
+    assert_equals(connection.bandwidth, 0, "the value of Connection.bandwidth attribute");
+  }, "Test checks that the value of Connection.bandwidth attribute is 0 when the user is currently offline");
+</script>
+

--- a/webapi/tct-netinfo-w3c-tests/netinfo/Connection_metered_false.html
+++ b/webapi/tct-netinfo-w3c-tests/netinfo/Connection_metered_false.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Liu.Xin <xinx.liu@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<title>NetworkInfo Test: Connection_metered_false</title>
+<link rel="author" title="Intel" href="http://www.intel.com"/>
+<link rel="help" href="http://www.w3.org/TR/2012/WD-netinfo-api-20121129/#widl-Connection-metered"/>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<p>
+  Pre-condition: Make sure the network connection is unavailable.<br/>
+</p>
+<div id="log"></div>
+<script>
+  test(function() {
+    var connection = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+    assert_true(!!connection, "NetworkInformation.connection attribute exists");
+    assert_equals(connection.metered, false, "The value of Connection.metered");
+  }, "Test checks that the value of Connection.metered is false when the user is offline");
+</script>
+

--- a/webapi/tct-netinfo-w3c-tests/netinfo/NetworkInformation_example1_write_bandwidth.html
+++ b/webapi/tct-netinfo-w3c-tests/netinfo/NetworkInformation_example1_write_bandwidth.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Liu.Xin <xinx.liu@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<title>NetworkInfo Test: NetworkInformation_example1_write_bandwidth</title>
+<link rel="author" title="Intel" href="http://www.intel.com"/>
+<link rel="help" href="http://www.w3.org/TR/2012/WD-netinfo-api-20121129/#widl-NetworkInformation-connection"/>
+<meta name="flags" content=""/>
+<meta name="assert" content="Test checks that trivial example writes the connection bandwidth to the page and shows it again each time it is changing"/>
+<p>
+  This test case passes if the yellow area shows the current connection bandwidth.<br/>
+  <pre>
+    Note:
+      0 if the user is currently offline;
+      Infinity if the bandwidth is unknown;
+      an estimation of the current bandwidth in MB/s if the user is currently online.
+  </pre>
+</p>
+<div id="result" style="background-color: yellow"></div>
+<script>
+  var connection = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+
+  if (!!connection) {
+    connection.addEventListener('change', show, false);
+    show();
+  } else {
+    document.getElementById('result').innerHTML = "NetworkInformation.connection attribute does not exist.";
+  }
+
+  function show() {
+    document.getElementById('result').innerHTML = "The current bandwidth is " + connection.bandwidth + " MB/s.";
+  }
+</script>
+

--- a/webapi/tct-netinfo-w3c-tests/tests.full.xml
+++ b/webapi/tct-netinfo-w3c-tests/tests.full.xml
@@ -123,6 +123,44 @@
           </spec>
         </specs>
       </testcase>
+      <testcase purpose="Test checks that trivial example writes the connection bandwidth to the page and shows it again each time it is changing" type="compliance" status="approved" component="WebAPI/Device/The Network Information API" execution_type="manual" priority="P3" id="NetworkInformation_example1_write_bandwidth">
+        <description>
+          <test_script_entry>/opt/tct-netinfo-w3c-tests/netinfo/NetworkInformation_example1_write_bandwidth.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion usage="true" interface="Connection" specification="The Network Information API" section="Device" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-netinfo-api-20121129/#widl-NetworkInformation-connection</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Test checks that the value of Connection.bandwidth attribute is 0 when the user is currently offline" type="compliance" status="approved" component="WebAPI/Device/The Network Information API" execution_type="auto" priority="P2" id="Connection_bandwidth_zero">
+        <description>
+          <pre_condition>Make sure the network connection is unavailable</pre_condition>
+          <test_script_entry>/opt/tct-netinfo-w3c-tests/netinfo/Connection_bandwidth_zero.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="bandwidth" interface="Connection" specification="The Network Information API" section="Device" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-netinfo-api-20121129/#widl-Connection-bandwidth</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Test checks that the value of Connection.metered is false when the user is offline" type="compliance" status="approved" component="WebAPI/Device/The Network Information API" execution_type="auto" priority="P2" id="Connection_metered_false">
+        <description>
+          <pre_condition>Make sure the network connection is unavailable</pre_condition>
+          <test_script_entry>/opt/tct-netinfo-w3c-tests/netinfo/Connection_metered_false.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="metered" interface="Connection" specification="The Network Information API" section="Device" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-netinfo-api-20121129/#widl-Connection-metered</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
     </set>
   </suite>
 </test_definition>

--- a/webapi/tct-netinfo-w3c-tests/tests.xml
+++ b/webapi/tct-netinfo-w3c-tests/tests.xml
@@ -1,58 +1,75 @@
 <?xml version="1.0" encoding="UTF-8"?>
-    <?xml-stylesheet type="text/xsl" href="./testcase.xsl"?>
+<?xml-stylesheet type="text/xsl" href="./testcase.xsl"?>
 <test_definition>
-  <suite launcher="xwalk" name="tct-netinfo-w3c-tests" category="W3C/HTML5 APIs">
+  <suite category="W3C/HTML5 APIs" launcher="xwalk" name="tct-netinfo-w3c-tests">
     <set name="NetworkInfo">
       <testcase component="WebAPI/Device/The Network Information API" execution_type="auto" id="NetworkInformation_connection_exist" purpose="Check if the NetworkInformation.connection attribute exists">
         <description>
           <test_script_entry>/opt/tct-netinfo-w3c-tests/netinfo/NetworkInformation_connection_exist.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/Device/The Network Information API" execution_type="auto" id="NetworkInformation_connection_readonly" purpose="Check if the NetworkInformation.connection attribute is readonly">
         <description>
           <test_script_entry>/opt/tct-netinfo-w3c-tests/netinfo/NetworkInformation_connection_readonly.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/Device/The Network Information API" execution_type="auto" id="NetworkInformation_connection_type" purpose="Check if the type of NetworkInformation.connection is 'object'">
         <description>
           <test_script_entry>/opt/tct-netinfo-w3c-tests/netinfo/NetworkInformation_connection_type.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/Device/The Network Information API" execution_type="auto" id="Connection_bandwidth_exist" purpose="Check if the Connection.bandwidth attribute exists">
         <description>
           <test_script_entry>/opt/tct-netinfo-w3c-tests/netinfo/Connection_attributes.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/Device/The Network Information API" execution_type="auto" id="Connection_bandwidth_type" purpose="Check if the type of Connection.bandwidth is 'number'">
         <description>
           <test_script_entry>/opt/tct-netinfo-w3c-tests/netinfo/Connection_attributes.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/Device/The Network Information API" execution_type="auto" id="Connection_bandwidth_readonly" purpose="Check if the Connection.bandwidth attribute is readonly">
         <description>
           <test_script_entry>/opt/tct-netinfo-w3c-tests/netinfo/Connection_attributes.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/Device/The Network Information API" execution_type="auto" id="Connection_metered_exist" purpose="Check if the Connection.metered attribute exists">
         <description>
           <test_script_entry>/opt/tct-netinfo-w3c-tests/netinfo/Connection_attributes.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/Device/The Network Information API" execution_type="auto" id="Connection_metered_type" purpose="Check if the type of Connection.metered is 'boolean'">
         <description>
           <test_script_entry>/opt/tct-netinfo-w3c-tests/netinfo/Connection_attributes.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/Device/The Network Information API" execution_type="auto" id="Connection_metered_readonly" purpose="Check if the Connection.metered attribute is readonly">
         <description>
           <test_script_entry>/opt/tct-netinfo-w3c-tests/netinfo/Connection_attributes.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/Device/The Network Information API" execution_type="auto" id="Connection_onchange_exist" purpose="Check if the Connection.onchange attribute exists">
         <description>
           <test_script_entry>/opt/tct-netinfo-w3c-tests/netinfo/Connection_attributes.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
+      <testcase component="WebAPI/Device/The Network Information API" execution_type="manual" id="NetworkInformation_example1_write_bandwidth" purpose="Test checks that trivial example writes the connection bandwidth to the page and shows it again each time it is changing">
+        <description>
+          <test_script_entry>/opt/tct-netinfo-w3c-tests/netinfo/NetworkInformation_example1_write_bandwidth.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Device/The Network Information API" execution_type="auto" id="Connection_bandwidth_zero" purpose="Test checks that the value of Connection.bandwidth attribute is 0 when the user is currently offline">
+        <description>
+          <pre_condition>Make sure the network connection is unavailable</pre_condition>
+          <test_script_entry>/opt/tct-netinfo-w3c-tests/netinfo/Connection_bandwidth_zero.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Device/The Network Information API" execution_type="auto" id="Connection_metered_false" purpose="Test checks that the value of Connection.metered is false when the user is offline">
+        <description>
+          <pre_condition>Make sure the network connection is unavailable</pre_condition>
+          <test_script_entry>/opt/tct-netinfo-w3c-tests/netinfo/Connection_metered_false.html</test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>


### PR DESCRIPTION
Impacted Suites: tct-netinfo-w3c-tests
Impacted TCs num: New 3, Update 0, Delete 0
Unit test platform: Tizen(ivi)
Tizen(ivi) test result summary: Pass 0, Fail 3, Blocked 0

Fail reason: the connection interface does not supported on ivi.
