### PR TITLE
[webapi] Add basic RawSockets TCs instead of IDL for existent checkpoint

### DIFF
--- a/webapi/webapi-rawsockets-sysapps-tests/rawsockets/RawSockets_interface_basic.html
+++ b/webapi/webapi-rawsockets-sysapps-tests/rawsockets/RawSockets_interface_basic.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Shentu.Jiazhen <jiazhenx.shentu@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<title>Raw Socket Test: RawSockets interface basic</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="http://www.w3.org/2012/sysapps/raw-sockets/#interface-UDPSocket">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+
+test(function() {
+  assert_true(!!namespace, "namespace exist");
+  assert_true("UDPSocket" in namespace, "UDPSocket attribute exist");
+}, "Check if UDPSocket exists");
+
+test(function() {
+  assert_true(!!namespace, "namespace exist");
+  assert_true("TCPSocket" in namespace, "TCPSocket attribute exist in window");
+}, "Check if TCPSocket exists");
+
+test(function() {
+  assert_true(!!namespace, "namespace exist");
+  assert_true("TCPServerSocket" in namespace, "TCPServerSocket attribute exist in window");
+}, "Check if TCPServerSocket exists");
+
+</script>

--- a/webapi/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_interface_basic.html
+++ b/webapi/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_interface_basic.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Shentu.Jiazhen <jiazhenx.shentu@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<title>Raw Socket Test: TCPServerSocket interface basic</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="http://www.w3.org/2012/sysapps/raw-sockets/#interface-TCPServerSocket">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+
+var tcpserversocket = new namespace.TCPServerSocket(socketOptions);
+
+[
+  ["DOMString", "localAddress", "readonly"],
+  ["unsigned short", "localPort", "readonly"],
+  ["enum", "readyState", "readonly"],
+  ["event", "onconnect", ""],
+  ["event", "onerror", ""],
+  ["function", "close", ""],
+  ["function", "suspend", ""],
+  ["function", "resume", ""]
+].forEach(function(attr) {
+  var type = attr[0];
+  var name = attr[1];
+  var read = attr[2];
+
+  test(function() {
+    assert_true(name in tcpserversocket, name + " attribute in TCPServerSocket element");
+    switch(type) {
+      case "DOMString":
+        assert_equals(typeof tcpserversocket[name], "string", name + " attribute of type");
+        break;
+
+      case "function":
+        assert_equals(typeof tcpserversocket[name], "function", name + " attribute of type");
+        break;
+
+      case "enum":
+        assert_equals(typeof tcpserversocket[name], "number", name + " attribute of type");
+        break;
+
+      case "unsigned short":
+        assert_equals(typeof tcpserversocket[name], "number", name + " attribute of type");
+        var value = tcpserversocket[name];
+        assert_true(0 <= value && value <= 65535, "unsigned short " + value + " not in range [0, 65535]");
+        break;
+
+      default:
+        break;
+    }
+
+    switch(read) {
+      case "readonly":
+        assert_readonly(tcpserversocket, name, name + " attribute");
+        break;
+
+      default:
+        break;
+    }
+  }, "Check if " + read + " TCPServerSocket." + name + " exists and type of " + type);
+});
+
+</script>

--- a/webapi/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html
+++ b/webapi/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Shentu.Jiazhen <jiazhenx.shentu@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<title>Raw Socket Test: TCPSocket interface basic</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="http://www.w3.org/2012/sysapps/raw-sockets/#interface-tcpsocket">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+
+var tcpsocket = new namespace.TCPSocket(remoteAddress, remotePort);
+
+[
+  ["DOMString", "remoteAddress", "readonly"],
+  ["DOMString", "remotePort", "readonly"],
+  ["DOMString", "localAddress", "readonly"],
+  ["unsigned short", "localPort", "readonly"],
+  ["unsigned long", "bufferedAmount", "readonly"],
+  ["enum", "readyState", "readonly"],
+  ["event", "ondrain", ""],
+  ["event", "onopen", ""],
+  ["event", "onclose", ""],
+  ["event", "onhalfclose", ""],
+  ["event", "onerror", ""],
+  ["event", "onmessage", ""],
+  ["function", "close", ""],
+  ["function", "halfClose", ""],
+  ["function", "suspend", ""],
+  ["function", "resume", ""],
+  ["function", "send", ""]
+].forEach(function(attr) {
+  var type = attr[0];
+  var name = attr[1];
+  var read = attr[2];
+
+  test(function() {
+    assert_true(name in tcpsocket, name + " attribute in TCPSocket element");
+    switch(type) {
+      case "DOMString":
+        assert_equals(typeof tcpsocket[name], "string", name + " attribute of type");
+        break;
+
+      case "function":
+        assert_equals(typeof tcpsocket[name], "function", name + " attribute of type");
+        break;
+
+      case "enum":
+        assert_equals(typeof tcpsocket[name], "number", name + " attribute of type");
+        break;
+
+      case "unsigned short":
+        assert_equals(typeof tcpsocket[name], "number", name + " attribute of type");
+        var value = tcpsocket[name];
+        assert_true(0 <= value && value <= 65535, "unsigned short " + value + " not in range [0, 65535]");
+        break;
+
+      case "unsigned long":
+        assert_equals(typeof tcpsocket[name], "number", name + " attribute of type");
+        var value = tcpsocket[name];
+        assert_true(0 <= value && value <= 4294967295, "unsigned long " + value + " not in range [0, 4294967295]");
+        break;
+
+      default:
+        break;
+    }
+
+    switch(read) {
+      case "readonly":
+        assert_readonly(tcpsocket, name, name + " attribute");
+        break;
+
+      default:
+        break;
+    }
+  }, "Check if " + read + " TCPSocket." + name + " exists and type of " + type);
+});
+
+</script>

--- a/webapi/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html
+++ b/webapi/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Shentu.Jiazhen <jiazhenx.shentu@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<title>Raw Socket Test: UDPSocket interface basic</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="http://www.w3.org/2012/sysapps/raw-sockets/#interface-UDPSocket">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+
+var udpsocket = new namespace.UDPSocket();
+
+[
+  ["DOMString", "localAddress", "readonly"],
+  ["unsigned short", "localPort", "readonly"],
+  ["DOMString", "remoteAddress", "readonly"],
+  ["unsigned short", "remotePort", "readonly"],
+  ["boolean", "addressReuse", "readonly"],
+  ["boolean", "loopback", "readonly"],
+  ["unsigned long", "bufferedAmount", "readonly"],
+  ["enum", "readyState", "readonly"],
+  ["event", "ondrain", ""],
+  ["event", "onerror", ""],
+  ["event", "onmessage", ""],
+  ["function", "close", ""],
+  ["function", "suspend", ""],
+  ["function", "resume", ""],
+  ["function", "joinMulticastGroup", ""],
+  ["function", "leaveMulticastGroup", ""],
+  ["function", "send", ""],
+].forEach(function(attr) {
+  var type = attr[0];
+  var name = attr[1];
+  var read = attr[2];
+
+  test(function() {
+    assert_true(name in udpsocket, name + " attribute in UDPSocket element");
+    switch(type) {
+      case "DOMString":
+        assert_equals(typeof udpsocket[name], "string", name + " attribute of type");
+        break;
+
+      case "function":
+        assert_equals(typeof udpsocket[name], "function", name + " attribute of type");
+        break;
+
+      case "enum":
+        assert_equals(typeof udpsocket[name], "number", name + " attribute of type");
+        break;
+
+      case "unsigned short":
+        assert_equals(typeof udpsocket[name], "number", name + " attribute of type");
+        var value = udpsocket[name];
+        assert_true(0 <= value && value <= 65535, "unsigned short " + value + " not in range [0, 65535]");
+        break;
+
+      case "unsigned long":
+        assert_equals(typeof tcpsocket[name], "number", name + " attribute of type");
+        var value = tcpsocket[name];
+        assert_true(0 <= value && value <= 4294967295, "unsigned long " + value + " not in range [0, 4294967295]");
+        break;
+
+      default:
+        break;
+    }
+
+    switch(read) {
+      case "readonly":
+        assert_readonly(udpsocket, name, name + " attribute");
+        break;
+
+      default:
+        break;
+    }
+  }, "Check if " + read + " UDPSocket." + name + " exists and type of " + type);
+});
+
+</script>

--- a/webapi/webapi-rawsockets-sysapps-tests/tests.full.xml
+++ b/webapi/webapi-rawsockets-sysapps-tests/tests.full.xml
@@ -3,9 +3,549 @@
 <test_definition>
   <suite name="webapi-rawsockets-sysapps-tests" launcher="xwalk" category="W3C/HTML5 APIs">
     <set name="idlharness">
-      <testcase purpose="This test validates the WebIDL included in the Raw Sockets specification" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="RawSockets_idlhaness_test">
+      <testcase purpose="This test validates the WebIDL included in the Raw Sockets specification" type="compliance" status="designed" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="RawSockets_idlhaness_test">
         <description>
           <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/RawSockets_idlharness.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This test validates the UDPSocket exists" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="RawSockets_interface_basic_UDPSocket">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/RawSockets_interface_basic.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This test validates the TCPSocket exists" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="RawSockets_interface_basic_TCPSocket">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/RawSockets_interface_basic.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This test validates the TCPServerSocket exists" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="RawSockets_interface_basic_TCPServerSocket">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/RawSockets_interface_basic.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly TCPServerSocket.localAddress exists and type of DOMString" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPServerSocket_localAddress_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_interface_basic.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly TCPServerSocket.localPort exists and type of unsigned short" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPServerSocket_localPort_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_interface_basic.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly TCPServerSocket.readyState exists and type of enum" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPServerSocket_readyState_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_interface_basic.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if TCPServerSocket.onconnect exists and type of event" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPServerSocket_onconnect_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_interface_basic.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if TCPServerSocket.onerror exists and type of event" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPServerSocket_onerror_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_interface_basic.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if TCPServerSocket.close exists and type of function" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPServerSocket_close_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_interface_basic.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if TCPServerSocket.suspend exists and type of function" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPServerSocket_suspend_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_interface_basic.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if TCPServerSocket.resume exists and type of function" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPServerSocket_resume_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_interface_basic.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly TCPSocket.remoteAddress exists and type of DOMString" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPSocket_remoteAddress_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly TCPSocket.remotePort exists and type of DOMString" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPSocket_remotePort_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly TCPSocket.localAddress exists and type of DOMString" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPSocket_localAddress_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly TCPSocket.localPort exists and type of unsigned short" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPSocket_localPort_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly TCPSocket.bufferedAmount exists and type of unsigned long" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPSocket_bufferedAmount_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly TCPSocket.readyState exists and type of enum" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPSocket_readyState_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if TCPSocket.ondrain exists and type of event" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPSocket_ondrain_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if TCPSocket.onopen exists and type of event" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPSocket_onopen_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if TCPSocket.onclose exists and type of event" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPSocket_onclose_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if TCPSocket.onhalfclose exists and type of event" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPSocket_onhalfclose_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if TCPSocket.onerror exists and type of event" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPSocket_onerror_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if TCPSocket.onmessage exists and type of event" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPSocket_onmessage_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if TCPSocket.close exists and type of function" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPSocket_close_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if TCPSocket.halfClose exists and type of function" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPSocket_halfClose_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if TCPSocket.suspend exists and type of function" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPSocket_suspend_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if TCPSocket.resume exists and type of function" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPSocket_resume_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=16</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if TCPSocket.send exists and type of function" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPSocket_send_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly UDPSocket.localAddress exists and type of DOMString" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="UDPSocket_send_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=1&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly UDPSocket.localPort exists and type of unsigned short" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="UDPSocket_localPort_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly UDPSocket.remoteAddress exists and type of DOMString" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="UDPSocket_remoteAddress_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly UDPSocket.remotePort exists and type of unsigned short" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="UDPSocket_remotePort_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly UDPSocket.addressReuse exists and type of boolean" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="UDPSocket_addressReuse_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=5&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly UDPSocket.loopback exists and type of boolean" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="UDPSocket_loopback_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly UDPSocket.bufferedAmount exists and type of unsigned long" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="UDPSocket_bufferedAmount_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly UDPSocket.readyState exists and type of enum" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="UDPSocket_readyState_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if UDPSocket.ondrain exists and type of event" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="UDPSocket_ondrain_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=9&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if UDPSocket.onerror exists and type of event" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="UDPSocket_onerror_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if UDPSocket.onmessage exists and type of event" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="UDPSocket_onmessage_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if UDPSocket.close exists and type of function" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="UDPSocket_close_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if UDPSocket.suspend exists and type of function" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="UDPSocket_suspend_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if UDPSocket.resume exists and type of function" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="UDPSocket_resume_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if UDPSocket.joinMulticastGroup exists and type of function" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="UDPSocket_joinMulticastGroup_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if UDPSocket.leaveMulticastGroup exists and type of function" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="UDPSocket_leaveMulticastGroup_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="TBD" element_name="TBD" interface="TBD" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/raw-sockets/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if UDPSocket.send exists and type of function" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="UDPSocket_send_basic">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
         </description>
         <specs>
           <spec>

--- a/webapi/webapi-rawsockets-sysapps-tests/tests.xml
+++ b/webapi/webapi-rawsockets-sysapps-tests/tests.xml
@@ -3,9 +3,229 @@
 <test_definition>
   <suite category="W3C/HTML5 APIs" launcher="xwalk" name="webapi-rawsockets-sysapps-tests">
     <set name="idlharness">
-      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="RawSockets_idlhaness_test" purpose="This test validates the WebIDL included in the Raw Sockets specification">
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="RawSockets_interface_basic_UDPSocket" purpose="This test validates the UDPSocket exists">
         <description>
-          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/RawSockets_idlharness.html</test_script_entry>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/RawSockets_interface_basic.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="RawSockets_interface_basic_TCPSocket" purpose="This test validates the TCPSocket exists">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/RawSockets_interface_basic.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="RawSockets_interface_basic_TCPServerSocket" purpose="This test validates the TCPServerSocket exists">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/RawSockets_interface_basic.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPServerSocket_localAddress_basic" purpose="Check if readonly TCPServerSocket.localAddress exists and type of DOMString">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_interface_basic.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPServerSocket_localPort_basic" purpose="Check if readonly TCPServerSocket.localPort exists and type of unsigned short">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_interface_basic.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPServerSocket_readyState_basic" purpose="Check if readonly TCPServerSocket.readyState exists and type of enum">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_interface_basic.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPServerSocket_onconnect_basic" purpose="Check if TCPServerSocket.onconnect exists and type of event">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_interface_basic.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPServerSocket_onerror_basic" purpose="Check if TCPServerSocket.onerror exists and type of event">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_interface_basic.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPServerSocket_close_basic" purpose="Check if TCPServerSocket.close exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_interface_basic.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPServerSocket_suspend_basic" purpose="Check if TCPServerSocket.suspend exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_interface_basic.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPServerSocket_resume_basic" purpose="Check if TCPServerSocket.resume exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_interface_basic.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPSocket_remoteAddress_basic" purpose="Check if readonly TCPSocket.remoteAddress exists and type of DOMString">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPSocket_remotePort_basic" purpose="Check if readonly TCPSocket.remotePort exists and type of DOMString">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPSocket_localAddress_basic" purpose="Check if readonly TCPSocket.localAddress exists and type of DOMString">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPSocket_localPort_basic" purpose="Check if readonly TCPSocket.localPort exists and type of unsigned short">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPSocket_bufferedAmount_basic" purpose="Check if readonly TCPSocket.bufferedAmount exists and type of unsigned long">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPSocket_readyState_basic" purpose="Check if readonly TCPSocket.readyState exists and type of enum">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPSocket_ondrain_basic" purpose="Check if TCPSocket.ondrain exists and type of event">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPSocket_onopen_basic" purpose="Check if TCPSocket.onopen exists and type of event">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPSocket_onclose_basic" purpose="Check if TCPSocket.onclose exists and type of event">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPSocket_onhalfclose_basic" purpose="Check if TCPSocket.onhalfclose exists and type of event">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPSocket_onerror_basic" purpose="Check if TCPSocket.onerror exists and type of event">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPSocket_onmessage_basic" purpose="Check if TCPSocket.onmessage exists and type of event">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPSocket_close_basic" purpose="Check if TCPSocket.close exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPSocket_halfClose_basic" purpose="Check if TCPSocket.halfClose exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPSocket_suspend_basic" purpose="Check if TCPSocket.suspend exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPSocket_resume_basic" purpose="Check if TCPSocket.resume exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=16</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPSocket_send_basic" purpose="Check if TCPSocket.send exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="UDPSocket_send_basic" purpose="Check if readonly UDPSocket.localAddress exists and type of DOMString">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=1&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="UDPSocket_localPort_basic" purpose="Check if readonly UDPSocket.localPort exists and type of unsigned short">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="UDPSocket_remoteAddress_basic" purpose="Check if readonly UDPSocket.remoteAddress exists and type of DOMString">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="UDPSocket_remotePort_basic" purpose="Check if readonly UDPSocket.remotePort exists and type of unsigned short">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="UDPSocket_addressReuse_basic" purpose="Check if readonly UDPSocket.addressReuse exists and type of boolean">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=5&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="UDPSocket_loopback_basic" purpose="Check if readonly UDPSocket.loopback exists and type of boolean">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="UDPSocket_bufferedAmount_basic" purpose="Check if readonly UDPSocket.bufferedAmount exists and type of unsigned long">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="UDPSocket_readyState_basic" purpose="Check if readonly UDPSocket.readyState exists and type of enum">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="UDPSocket_ondrain_basic" purpose="Check if UDPSocket.ondrain exists and type of event">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=9&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="UDPSocket_onerror_basic" purpose="Check if UDPSocket.onerror exists and type of event">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="UDPSocket_onmessage_basic" purpose="Check if UDPSocket.onmessage exists and type of event">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=11&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="UDPSocket_close_basic" purpose="Check if UDPSocket.close exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="UDPSocket_suspend_basic" purpose="Check if UDPSocket.suspend exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=13&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="UDPSocket_resume_basic" purpose="Check if UDPSocket.resume exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=14&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="UDPSocket_joinMulticastGroup_basic" purpose="Check if UDPSocket.joinMulticastGroup exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=15&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="UDPSocket_leaveMulticastGroup_basic" purpose="Check if UDPSocket.leaveMulticastGroup exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="UDPSocket_send_basic" purpose="Check if UDPSocket.send exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/UDPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
         </description>
       </testcase>
     </set>


### PR DESCRIPTION
Impacted test suite: webapi-rawsockets-sysapps-tests
Impacted TCs num: New 45, Update 0, Delete 0
Unit test platform: IVI
IVI test result summary: Pass 39, Fail 6, Block 0

Comment:
  The fail cases should be caused by the changement of spec, some attributes have been removed from spec of privious version. Our cases follow the old spec but the implement of interface follow the lastest spec.
