### PR TITLE
[webapi] Add 73 exist TCs for webrtc

### DIFF
--- a/webapi/webapi-webrtc-w3c-tests/tests.full.xml
+++ b/webapi/webapi-webrtc-w3c-tests/tests.full.xml
@@ -16,6 +16,884 @@
         </specs>
       </testcase>
     </set>
+    <set name="webRTC_basic">
+      <testcase purpose="Check if readonly RTCPeerConnection.localDescription exists and type of object" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_localDescription_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="localDescription" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly RTCPeerConnection.remoteDescription exists and type of object" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_remoteDescription_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="remoteDescription" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly RTCPeerConnection.signalingState exists and type of string" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_signalingState_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="signalingState" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly RTCPeerConnection.iceGatheringState exists and type of string" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_iceGatheringState_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="iceGatheringState" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly RTCPeerConnection.iceConnectionState exists and type of string" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_iceConnectionState_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="iceConnectionState" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCPeerConnection.onnegotiationneeded exists" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_onnegotiationneeded_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="onnegotiationneeded" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCPeerConnection.onicecandidate exists" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_onicecandidate_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="onicecandidate" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCPeerConnection.onsignalingstatechange exists" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_onsignalingstatechange_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="onsignalingstatechange" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCPeerConnection.onaddstream exists" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_onaddstream_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="onaddstream" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCPeerConnection.onremovestream exists" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_onremovestream_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="onremovestream" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCPeerConnection.oniceconnectionstatechange exists" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_oniceconnectionstatechange_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="oniceconnectionstatechange" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCPeerConnection.ondatachannel exists" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_ondatachannel_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="ondatachannel" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCPeerConnection.createOffer exists and type of function" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_createOffer_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="createOffer" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCPeerConnection.createAnswer exists and type of function" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_createAnswer_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="createAnswer" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCPeerConnection.setLocalDescription exists and type of function" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_setLocalDescription_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="setLocalDescription" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCPeerConnection.setRemoteDescription exists and type of function" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_setRemoteDescription_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=16</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="setRemoteDescription" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCPeerConnection.updateIce exists and type of function" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_updateIce_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="updateIce" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCPeerConnection.addIceCandidate exists and type of function" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_addIceCandidate_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=18</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="addIceCandidate" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCPeerConnection.getConfiguration exists and type of function" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_getConfiguration_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=19</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="getConfiguration" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCPeerConnection.getLocalStreams exists and type of function" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_getLocalStreams_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=20</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="getLocalStreams" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCPeerConnection.getRemoteStreams exists and type of function" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_getRemoteStreams_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=21</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="getRemoteStreams" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCPeerConnection.getStreamById exists and type of function" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_getStreamById_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=22</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="getStreamById" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCPeerConnection.addStream exists and type of function" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_addStream_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=23</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="addStream" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCPeerConnection.removeStream exists and type of function" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_removeStream_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=24</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="removeStream" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCPeerConnection.close exists and type of function" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_close_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=25</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="close" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCPeerConnection.createDataChannel exists and type of function" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_createDataChannel_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=26</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="createDataChannel" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCPeerConnection.getStats exists and type of function" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_getStats_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=27</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="getStats" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute peerIdentity of RTCPeerConnection exists and type of RTCIdentityAssertion" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_peerIdentity_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=28</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="peerIdentity" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCPeerConnection.onidentityresult exists" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_onidentityresult_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=29</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="onidentityresult" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCPeerConnection.onpeeridentity exists" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_onpeeridentity_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=30</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="onpeeridentity" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCPeerConnection.onidpassertionerror exists" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_onidpassertionerror_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=31</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="onidpassertionerror" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCPeerConnection.onidpvalidationerror exists" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_onidpvalidationerror_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=32</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="onidpvalidationerror" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCPeerConnection.setIdentityProvider exists and type of function" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_setIdentityProvider_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=33</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="setIdentityProvider" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCPeerConnection.getIdentityAssertion exists and type of function" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_getIdentityAssertion_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=34</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="getIdentityAssertion" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute sdpLineNumber of RTCSdpError exists and type of number" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCSdpError_sdpLineNumber_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCSdpError_sdpLineNumber_basic.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="sdpLineNumber" interface="RTCSdpError" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcsdperror</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCSessionDescription.type exists and type of string" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCSessionDescription_type_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCSessionDescription_basic.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="type" interface="RTCSessionDescription" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcsessiondescription-class</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCSessionDescription.sdp exists and type of string" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCSessionDescription_sdp_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCSessionDescription_basic.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="sdp" interface="RTCSessionDescription" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcsessiondescription-class</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCIceCandidate.candidate exists and type of string" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCIceCandidate_candidate_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCIceCandidate_basic.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="candidate" interface="RTCIceCandidate" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcicecandidate-type</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCIceCandidate.sdpMid exists and type of string" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCIceCandidate_sdpMid_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCIceCandidate_basic.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="sdpMid" interface="RTCIceCandidate" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcicecandidate-type</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCIceCandidate.sdpMLineIndex exists and type of number" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCIceCandidate_sdpMLineIndex_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCIceCandidate_basic.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="sdpMLineIndex" interface="RTCIceCandidate" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcicecandidate-type</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute candidate of RTCPeerConnectionIceEvent exists and type of string" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnectionIceEvent_candidate_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnectionIceEvent_candidate_basic.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="candidate" interface="RTCPeerConnectionIceEvent" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnectioniceevent</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly RTCDataChannel.label exists and type of string" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCDataChannel_label_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="label" interface="RTCDataChannel" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly RTCDataChannel.ordered exists and type of boolean" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCDataChannel_ordered_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="ordered" interface="RTCDataChannel" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly RTCDataChannel.maxRetransmitTime exists and type of number" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCDataChannel_maxRetransmitTime_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="maxRetransmitTime" interface="RTCDataChannel" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly RTCDataChannel.maxRetransmits exists and type of number" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCDataChannel_maxRetransmits_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="maxRetransmits" interface="RTCDataChannel" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly RTCDataChannel.protocol exists and type of string" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCDataChannel_protocol_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="protocol" interface="RTCDataChannel" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly RTCDataChannel.negotiated exists and type of boolean" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCDataChannel_negotiated_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="negotiated" interface="RTCDataChannel" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly RTCDataChannel.id exists and type of number" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCDataChannel_id_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="id" interface="RTCDataChannel" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly RTCDataChannel.readyState exists and type of string" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCDataChannel_readyState_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="readyState" interface="RTCDataChannel" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly RTCDataChannel.bufferedAmount exists and type of number" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCDataChannel_bufferedAmount_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="bufferedAmount" interface="RTCDataChannel" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCDataChannel.binaryType exists and type of string" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCDataChannel_binaryType_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="binaryType" interface="RTCDataChannel" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCDataChannel.onopen exists" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCDataChannel_onopen_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="onopen" interface="RTCDataChannel" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCDataChannel.onerror exists" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCDataChannel_onerror_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="onerror" interface="RTCDataChannel" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCDataChannel.onclose exists" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCDataChannel_onclose_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="onclose" interface="RTCDataChannel" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCDataChannel.onmessage exists" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCDataChannel_onmessage_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="onmessage" interface="RTCDataChannel" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCDataChannel.close exists and type of function" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCDataChannel_close_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="close" interface="RTCDataChannel" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCDataChannel.send exists and type of function" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCDataChannel_send_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=16</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="send" interface="RTCDataChannel" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute channel of RTCDataChannelEvent exists and type of RTCDataChannel" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCDataChannelEvent_channel_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannelEvent_channel_basic.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="channel" interface="RTCDataChannelEvent" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannelevent</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCPeerConnection.createDTMFSender exists and type of function" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCPeerConnection_createDTMFSender_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_createDTMFSender_basic.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="createDTMFSender" interface="RTCPeerConnection" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface-extensions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly RTCDTMFSender.canInsertDTMF exists and type of boolean" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCDTMFSender_canInsertDTMF_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDTMFSender_basic.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="canInsertDTMF" interface="RTCDTMFSender" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdtmfsender</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly RTCDTMFSender.track exists and type of mediaStreamTrack" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCDTMFSender_track_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDTMFSender_basic.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="track" interface="RTCDTMFSender" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdtmfsender</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly RTCDTMFSender.toneBuffer exists and type of string" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCDTMFSender_toneBuffer_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDTMFSender_basic.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="toneBuffer" interface="RTCDTMFSender" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdtmfsender</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly RTCDTMFSender.duration exists and type of number" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCDTMFSender_duration_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDTMFSender_basic.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="duration" interface="RTCDTMFSender" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdtmfsender</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly RTCDTMFSender.interToneGap exists and type of number" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCDTMFSender_interToneGap_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDTMFSender_basic.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="interToneGap" interface="RTCDTMFSender" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdtmfsender</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCDTMFSender.ontonechange exists" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCDTMFSender_ontonechange_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDTMFSender_basic.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="ontonechange" interface="RTCDTMFSender" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdtmfsender</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCDTMFSender.insertDTMF exists and type of function" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCDTMFSender_insertDTMF_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDTMFSender_basic.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="insertDTMF" interface="RTCDTMFSender" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdtmfsender</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute tone of RTCDTMFToneChangeEvent exists and type of string" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCDTMFToneChangeEvent_tone_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDTMFToneChangeEvent_tone_basic.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="tone" interface="RTCDTMFToneChangeEvent" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdtmftonechangeevent</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCStatsReport.RTCStats exists and type of function" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCStatsReport_RTCStats_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCStatsReport_RTCStats_basic.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="RTCStats" interface="RTCStatsReport" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcstatsreport-object</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the attribute assertion of RTCIdentityEvent exists and type of string" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCIdentityEvent_assertion_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCIdentityEvent_assertion_basic.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="assertion" interface="RTCIdentityEvent" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcidentityevent-type</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCIdentityErrorEvent.idp exists and type of string" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCIdentityErrorEvent_idp_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCIdentityErrorEvent_basic.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="idp" interface="RTCIdentityErrorEvent" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcidentityerrorevent-type</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCIdentityErrorEvent.protocol exists and type of string" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCIdentityErrorEvent_protocol_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCIdentityErrorEvent_basic.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="protocol" interface="RTCIdentityErrorEvent" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcidentityerrorevent-type</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if RTCIdentityErrorEvent.loginUrl exists and type of string" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCIdentityErrorEvent_loginUrl_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCIdentityErrorEvent_basic.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="loginUrl" interface="RTCIdentityErrorEvent" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcidentityerrorevent-type</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute stream of MediaStreamEvent exists and type of MediaStream" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="MediaStreamEvent_stream_basic">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/MediaStreamEvent_stream_basic.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="stream" interface="MediaStreamEvent" specification="WebRTC" section="Networking" category="W3C API Specifications"/>
+            <spec_url>http://dev.w3.org/2011/webrtc/editor/webrtc.html#mediastreamevent</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+    </set>
     <set name="WebRTC">
       <testcase purpose="Check if the setting of RTCDataChannel.binaryType is normally" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P0" id="RTCDataChannel_binaryType_init_value">
         <description>

--- a/webapi/webapi-webrtc-w3c-tests/tests.xml
+++ b/webapi/webapi-webrtc-w3c-tests/tests.xml
@@ -9,6 +9,373 @@
         </description>
       </testcase>
     </set>
+    <set name="webRTC_basic">
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_localDescription_basic" purpose="Check if readonly RTCPeerConnection.localDescription exists and type of object">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_remoteDescription_basic" purpose="Check if readonly RTCPeerConnection.remoteDescription exists and type of object">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_signalingState_basic" purpose="Check if readonly RTCPeerConnection.signalingState exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_iceGatheringState_basic" purpose="Check if readonly RTCPeerConnection.iceGatheringState exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_iceConnectionState_basic" purpose="Check if readonly RTCPeerConnection.iceConnectionState exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_onnegotiationneeded_basic" purpose="Check if RTCPeerConnection.onnegotiationneeded exists">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_onicecandidate_basic" purpose="Check if RTCPeerConnection.onicecandidate exists">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_onsignalingstatechange_basic" purpose="Check if RTCPeerConnection.onsignalingstatechange exists">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_onaddstream_basic" purpose="Check if RTCPeerConnection.onaddstream exists">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_onremovestream_basic" purpose="Check if RTCPeerConnection.onremovestream exists">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_oniceconnectionstatechange_basic" purpose="Check if RTCPeerConnection.oniceconnectionstatechange exists">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_ondatachannel_basic" purpose="Check if RTCPeerConnection.ondatachannel exists">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_createOffer_basic" purpose="Check if RTCPeerConnection.createOffer exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_createAnswer_basic" purpose="Check if RTCPeerConnection.createAnswer exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_setLocalDescription_basic" purpose="Check if RTCPeerConnection.setLocalDescription exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_setRemoteDescription_basic" purpose="Check if RTCPeerConnection.setRemoteDescription exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=16</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_updateIce_basic" purpose="Check if RTCPeerConnection.updateIce exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_addIceCandidate_basic" purpose="Check if RTCPeerConnection.addIceCandidate exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=18</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_getConfiguration_basic" purpose="Check if RTCPeerConnection.getConfiguration exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=19</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_getLocalStreams_basic" purpose="Check if RTCPeerConnection.getLocalStreams exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=20</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_getRemoteStreams_basic" purpose="Check if RTCPeerConnection.getRemoteStreams exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=21</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_getStreamById_basic" purpose="Check if RTCPeerConnection.getStreamById exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=22</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_addStream_basic" purpose="Check if RTCPeerConnection.addStream exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=23</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_removeStream_basic" purpose="Check if RTCPeerConnection.removeStream exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=24</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_close_basic" purpose="Check if RTCPeerConnection.close exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=25</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_createDataChannel_basic" purpose="Check if RTCPeerConnection.createDataChannel exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=26</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_getStats_basic" purpose="Check if RTCPeerConnection.getStats exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=27</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_peerIdentity_basic" purpose="Check if the readonly attribute peerIdentity of RTCPeerConnection exists and type of RTCIdentityAssertion">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=28</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_onidentityresult_basic" purpose="Check if RTCPeerConnection.onidentityresult exists">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=29</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_onpeeridentity_basic" purpose="Check if RTCPeerConnection.onpeeridentity exists">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=30</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_onidpassertionerror_basic" purpose="Check if RTCPeerConnection.onidpassertionerror exists">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=31</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_onidpvalidationerror_basic" purpose="Check if RTCPeerConnection.onidpvalidationerror exists">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=32</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_setIdentityProvider_basic" purpose="Check if RTCPeerConnection.setIdentityProvider exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=33</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_getIdentityAssertion_basic" purpose="Check if RTCPeerConnection.getIdentityAssertion exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html?total_num=34&amp;amp;locator_key=id&amp;amp;value=34</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCSdpError_sdpLineNumber_basic" purpose="Check if the readonly attribute sdpLineNumber of RTCSdpError exists and type of number">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCSdpError_sdpLineNumber_basic.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCSessionDescription_type_basic" purpose="Check if RTCSessionDescription.type exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCSessionDescription_basic.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCSessionDescription_sdp_basic" purpose="Check if RTCSessionDescription.sdp exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCSessionDescription_basic.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCIceCandidate_candidate_basic" purpose="Check if RTCIceCandidate.candidate exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCIceCandidate_basic.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCIceCandidate_sdpMid_basic" purpose="Check if RTCIceCandidate.sdpMid exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCIceCandidate_basic.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCIceCandidate_sdpMLineIndex_basic" purpose="Check if RTCIceCandidate.sdpMLineIndex exists and type of number">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCIceCandidate_basic.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnectionIceEvent_candidate_basic" purpose="Check if the readonly attribute candidate of RTCPeerConnectionIceEvent exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnectionIceEvent_candidate_basic.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCDataChannel_label_basic" purpose="Check if readonly RTCDataChannel.label exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCDataChannel_ordered_basic" purpose="Check if readonly RTCDataChannel.ordered exists and type of boolean">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCDataChannel_maxRetransmitTime_basic" purpose="Check if readonly RTCDataChannel.maxRetransmitTime exists and type of number">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCDataChannel_maxRetransmits_basic" purpose="Check if readonly RTCDataChannel.maxRetransmits exists and type of number">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCDataChannel_protocol_basic" purpose="Check if readonly RTCDataChannel.protocol exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCDataChannel_negotiated_basic" purpose="Check if readonly RTCDataChannel.negotiated exists and type of boolean">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCDataChannel_id_basic" purpose="Check if readonly RTCDataChannel.id exists and type of number">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCDataChannel_readyState_basic" purpose="Check if readonly RTCDataChannel.readyState exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCDataChannel_bufferedAmount_basic" purpose="Check if readonly RTCDataChannel.bufferedAmount exists and type of number">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCDataChannel_binaryType_basic" purpose="Check if RTCDataChannel.binaryType exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCDataChannel_onopen_basic" purpose="Check if RTCDataChannel.onopen exists">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCDataChannel_onerror_basic" purpose="Check if RTCDataChannel.onerror exists">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCDataChannel_onclose_basic" purpose="Check if RTCDataChannel.onclose exists">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCDataChannel_onmessage_basic" purpose="Check if RTCDataChannel.onmessage exists">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCDataChannel_close_basic" purpose="Check if RTCDataChannel.close exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCDataChannel_send_basic" purpose="Check if RTCDataChannel.send exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=16</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCDataChannelEvent_channel_basic" purpose="Check if the readonly attribute channel of RTCDataChannelEvent exists and type of RTCDataChannel" onload_delay="20">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDataChannelEvent_channel_basic.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_createDTMFSender_basic" purpose="Check if RTCPeerConnection.createDTMFSender exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_createDTMFSender_basic.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCDTMFSender_canInsertDTMF_basic" purpose="Check if readonly RTCDTMFSender.canInsertDTMF exists and type of boolean">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDTMFSender_basic.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCDTMFSender_track_basic" purpose="Check if readonly RTCDTMFSender.track exists and type of mediaStreamTrack">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDTMFSender_basic.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCDTMFSender_toneBuffer_basic" purpose="Check if readonly RTCDTMFSender.toneBuffer exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDTMFSender_basic.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCDTMFSender_duration_basic" purpose="Check if readonly RTCDTMFSender.duration exists and type of number">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDTMFSender_basic.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCDTMFSender_interToneGap_basic" purpose="Check if readonly RTCDTMFSender.interToneGap exists and type of number">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDTMFSender_basic.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCDTMFSender_ontonechange_basic" purpose="Check if RTCDTMFSender.ontonechange exists">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDTMFSender_basic.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCDTMFSender_insertDTMF_basic" purpose="Check if RTCDTMFSender.insertDTMF exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDTMFSender_basic.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCDTMFToneChangeEvent_tone_basic" purpose="Check if the readonly attribute tone of RTCDTMFToneChangeEvent exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCDTMFToneChangeEvent_tone_basic.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCStatsReport_RTCStats_basic" purpose="Check if RTCStatsReport.RTCStats exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCStatsReport_RTCStats_basic.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCIdentityEvent_assertion_basic" purpose="Check if the attribute assertion of RTCIdentityEvent exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCIdentityEvent_assertion_basic.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCIdentityErrorEvent_idp_basic" purpose="Check if RTCIdentityErrorEvent.idp exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCIdentityErrorEvent_basic.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCIdentityErrorEvent_protocol_basic" purpose="Check if RTCIdentityErrorEvent.protocol exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCIdentityErrorEvent_basic.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCIdentityErrorEvent_loginUrl_basic" purpose="Check if RTCIdentityErrorEvent.loginUrl exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCIdentityErrorEvent_basic.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="MediaStreamEvent_stream_basic" purpose="Check if the readonly attribute stream of MediaStreamEvent exists and type of MediaStream">
+        <description>
+          <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/MediaStreamEvent_stream_basic.html</test_script_entry>
+        </description>
+      </testcase>
+    </set>
     <set name="WebRTC">
       <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCDataChannel_binaryType_init_value" purpose="Check if the setting of RTCDataChannel.binaryType is normally">
         <description>

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/MediaStreamEvent_stream_basic.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/MediaStreamEvent_stream_basic.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Liu,Yun <yunx.liu@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<title>WebRTC Test: MediaStreamEvent - stream basic</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="http://dev.w3.org/2011/webrtc/editor/webrtc.html#mediastreamevent">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+
+var t = async_test("Check if the readonly attribute stream of MediaStreamEvent exists and type of MediaStream", {timeout: 20000});
+
+var configuration = {"iceServers": [{"url": "stun:stun.example.org"}]};
+var pc1 = new webkitRTCPeerConnection(configuration);
+var pc2;
+var pc1_offer;
+var fake_audio;
+
+t.step(function () {
+  navigator.webkitGetUserMedia({audio: true, vedio: true}, gotStream, function () {});
+});
+
+function gotStream(stream) {
+  pc1.addStream(stream);
+  fake_audio = stream;
+  pc1.createOffer(requestSucceeded1, function () {});
+}
+
+function requestSucceeded1 (offer) {
+  pc1_offer = offer;
+  pc1.setLocalDescription(offer, requestSucceeded2, function () {});
+}
+
+
+function requestSucceeded2 () {
+  pc2 = new webkitRTCPeerConnection(null, null);
+  pc2.addStream(fake_audio);
+  pc2.onaddstream = t.step_func(function (evt) {
+    assert_true("stream" in evt, "stream attribute in MediaStreamEvent");
+    assert_equals(Object.prototype.toString.call(evt.stream), "[object MediaStream]", "stream attribute of type");
+    assert_readonly(evt, "stream", "expect attribute stream cannot be changed but");
+    t.done();
+  });
+  pc2.setRemoteDescription(pc1_offer, requestSucceeded3, function () {});
+}
+
+function requestSucceeded3 () {
+  pc2.createAnswer(requestSucceeded4, function () {});
+}
+
+function requestSucceeded4 (answer) {
+  pc2.setLocalDescription(answer, function () {}, function () {});
+}
+
+</script>

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCDTMFSender_basic.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCDTMFSender_basic.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Liu,Yun <yunx.liu@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<title>WebRTC Test: RTCDTMFSender basic</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdtmfsender">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+
+
+var pc;
+var ds;
+
+setup(function () {
+  var configuration = {"iceServers": [{"url": "stun:stun.example.org"}]};
+  pc = new webkitRTCPeerConnection(configuration);
+  navigator.webkitGetUserMedia({audio: true, video: true}, gotStream, function () {});
+}, {explicit_done: true});
+
+
+function gotStream(stream) {
+  pc.addStream(stream);
+  ds = pc.createDTMFSender(stream.getAudioTracks()[0]);
+
+  [
+    ["boolean", "canInsertDTMF", "readonly"],
+    ["mediaStreamTrack", "track", "readonly"],
+    ["string", "toneBuffer", "readonly"],
+    ["number", "duration", "readonly"],
+    ["number", "interToneGap", "readonly"],
+    ["event", "ontonechange", ""],
+    ["function", "insertDTMF", ""]
+  ].forEach(function(attr) {
+    var type = attr[0];
+    var name = attr[1];
+    var read = attr[2];
+
+    test(function () {
+      assert_true(name in ds, name + " attribute in RTCDTMFSender");
+      switch(type) {
+      case "string":
+      case "boolean":
+      case "number":
+        assert_readonly(ds, name, "You cannot change " + name);
+      case "function":
+        assert_equals(typeof ds[name], type, name + " attribute of type");
+        break;
+      case "mediaStreamTrack":
+        assert_equals(Object.prototype.toString.call(ds[name]), "[object MediaStreamTrack]", name + " attribute of type");
+        assert_readonly(ds, name, "expect attribute " + name + " cannot be changed but");
+        break;
+      default:
+        break;
+      }
+    }, "Check if " + read + " RTCDTMFSender." + name + " exists and type of " + type);
+  });
+  done();
+}
+
+</script>
+

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCDTMFToneChangeEvent_tone_basic.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCDTMFToneChangeEvent_tone_basic.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Liu,Yun <yunx.liu@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<title>WebRTC Test: RTCDTMFToneChangeEvent - tone basic</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdtmftonechangeevent">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+
+var t = async_test("Check if the readonly attribute tone of RTCDTMFToneChangeEvent exists and type of string", {timeout: 5000});
+
+var configuration = {"iceServers": [{"url": "stun:stun.example.org"}]};
+var pc = new webkitRTCPeerConnection(configuration);
+
+t.step(function () {
+  navigator.webkitGetUserMedia({audio: true, video: true}, gotStream, error);
+});
+
+function gotStream(stream) {
+  pc.addStream(stream);
+  var dtmfsender = pc.createDTMFSender(stream.getAudioTracks()[0]);
+  dtmfsender.ontonechange = t.step_func(function (event) {
+    assert_true("tone" in event, "tone attribute in RTCDTMFToneChangeEvent");
+    assert_equals(Object.prototype.toString.call(event.tone), "[object String]", "tone attribute of type");
+    assert_readonly(event, "tone", "expect attribute tone cannot be changed but");
+    t.done();
+  });
+  dtmfsender.insertDTMF("1");
+}
+
+function error() {
+  t.step(function () {
+    assert_unreached("Stream generation failed");
+  });
+  t.done();
+}
+
+</script>
+

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCDataChannelEvent_channel_basic.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCDataChannelEvent_channel_basic.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Liu,Yun <yunx.liu@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<title>WebRTC Test: RTCDataChannelEvent - channel basic</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannelevent">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+
+var t = async_test("Check if the readonly attribute channel of RTCDataChannelEvent exists and type of RTCDataChannel");
+setup({timeout: 20000});
+
+var pc1_offer;
+var pc2_answer;
+var pc1 = new webkitRTCPeerConnection(null, null);
+var pc2;
+
+function requestSucceeded1 (offer) {
+  pc1_offer = offer;
+  pc1.setLocalDescription(offer, requestSucceeded2, requestFailed2);
+}
+
+function requestFailed1 () {
+  t.step(function () {
+    assert_unreached("requestFailed1 was called");
+  });
+  t.done();
+}
+
+function requestSucceeded2 () {
+  pc2 = new webkitRTCPeerConnection(null, null);
+  pc2.ondatachannel = t.step_func(function (event) {
+    assert_true("channel" in event, "channel attribute in RTCDataChannelEvent");
+    assert_equals(Object.prototype.toString.call(event.channel), "[object RTCDataChannel]", "channel attribute of type");
+    assert_readonly(event, "channel", "expect attribute channel cannot be changed but");
+    t.done();
+  });
+  pc2.setRemoteDescription(pc1_offer, requestSucceeded3, requestFailed3);
+}
+
+function requestFailed2 () {
+  t.step(function () {
+    assert_unreached("requestFailed2 was called");
+  });
+  t.done();
+}
+
+function requestSucceeded3 () {
+  pc2.createAnswer(requestSucceeded4, requestFailed4);
+}
+
+function requestFailed3 () {
+  t.step(function () {
+    assert_unreached("requestFailed3 was called");
+  });
+  t.done();
+}
+
+function requestSucceeded4 (answer) {
+  pc2_answer = answer;
+  pc2.setLocalDescription(answer, requestSucceeded5, requestFailed5);
+}
+
+function requestFailed4 () {
+  t.step(function () {
+    assert_unreached("requestFailed4 was called");
+  });
+  t.done();
+}
+
+function requestSucceeded5 () {
+  pc1.setRemoteDescription(pc2_answer, function () {}, function () {
+    t.step(function () {
+      assert_unreached("setRemoteDescription request failed");
+    });
+    t.done();
+  });
+}
+function requestFailed5 () {
+  t.step(function () {
+    assert_unreached("requestFailed5 was called");
+  });
+  t.done();
+}
+
+
+pc1.createDataChannel("This is pc1");
+pc1.createOffer(requestSucceeded1, requestFailed1);
+
+
+</script>
+

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Liu,Yun <yunx.liu@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<title>WebRTC Test: RTCDataChannel basic</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcdatachannel">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+
+var pc;
+var channel;
+
+setup(function () {
+  pc = new webkitRTCPeerConnection(null,null);
+  channel = pc.createDataChannel("label");
+});
+
+[
+  ["string", "label", "readonly"],
+  ["boolean", "ordered", "readonly"],
+  ["number", "maxRetransmitTime", "readonly"],
+  ["number", "maxRetransmits", "readonly"],
+  ["string", "protocol", "readonly"],
+  ["boolean", "negotiated", "readonly"],
+  ["number", "id", "readonly"],
+  ["string", "readyState", "readonly"],
+  ["number", "bufferedAmount", "readonly"],
+  ["string", "binaryType", ""],
+  ["event", "onopen", ""],
+  ["event", "onerror", ""],
+  ["event", "onclose", ""],
+  ["event", "onmessage", ""],
+  ["function", "close", ""],
+  ["function", "send", ""]
+].forEach(function(attr) {
+  var type = attr[0];
+  var name = attr[1];
+  var read = attr[2];
+
+  test(function () {
+    assert_true(name in channel, name + " attribute in RTCDataChannel");
+    switch(type) {
+    case "string":
+    case "boolean":
+    case "number":
+      if(read == "readonly") {
+        assert_readonly(channel, name, "expect attribute " + name + " cannot be changed but");
+      }
+    case "function":
+      assert_equals(typeof channel[name], type, name + " attribute of type");      
+      break;
+    default:
+      break;
+    }
+  }, "Check if " + read + " RTCDataChannel." + name + " exists and type of " + type);
+});
+
+</script>

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCIceCandidate_basic.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCIceCandidate_basic.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Liu,Yun <yunx.liu@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<title>WebRTC Test: RTCIceCandidate basic</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcicecandidate-type">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+
+var initializer = {candidate: "foo", sdpMid: "bar", sdpMLineIndex: 6};
+var candidate = new RTCIceCandidate(initializer);
+
+test(function () {
+  assert_true("candidate" in candidate, "candidate attribute in RTCIceCandidate");
+  assert_equals(Object.prototype.toString.call(candidate.candidate), "[object String]", "candidate attribute of type");
+}, "Check if RTCIceCandidate.candidate exists and type of string");
+
+test(function () {
+  assert_true("sdpMid" in candidate, "sdpMid attribute in RTCIceCandidate");
+  assert_equals(Object.prototype.toString.call(candidate.sdpMid), "[object String]", "sdpMid attribute of type");
+}, "Check if RTCIceCandidate.sdpMid exists and type of string");
+
+test(function () {
+  assert_true("sdpMLineIndex" in candidate, "sdpMLineIndex attribute in RTCIceCandidate");
+  assert_equals(Object.prototype.toString.call(candidate.sdpMLineIndex), "[object Number]", "sdpMLineIndex attribute of type");
+}, "Check if RTCIceCandidate.sdpMLineIndex exists and type of number");
+
+</script>
+

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCIdentityErrorEvent_basic.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCIdentityErrorEvent_basic.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Liu,Yun <yunx.liu@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<title>WebRTC Test: RTCIdentityErrorEvent basic</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcidentityerrorevent-type">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+
+setup({timeout: 20000}, {explicit_done: true});
+
+var pc1_offer;
+var pc2_answer;
+var pc1 = new webkitRTCPeerConnection(null, null);
+var pc2;
+
+function requestSucceeded1 (offer) {
+  pc1_offer = offer;
+  pc1.setLocalDescription(offer, requestSucceeded2, function () {});
+}
+
+function requestSucceeded2 () {
+  pc2 = new webkitRTCPeerConnection(null, null);
+  pc2.addEventLister("onidpvalidationerror", function(event) {
+    [
+      ["idp"], ["protocol"], ["loginUrl"],
+    ].forEach(function(attr) {
+      var name = attr[0];
+      test(function() {
+        assert_true(name in event, name + " attribute in RTCIdentityErrorEvent");
+        assert_equals(typeof event[name], "string", name + " attribute of type");
+      }, "Check if RTCIdentityErrorEvent." + name + " exists and type of string"); 
+    });
+    done();
+  }, false);
+  pc2.setRemoteDescription(pc1_offer, requestSucceeded3, function () {});
+}
+
+function requestSucceeded3 () {
+  pc2.close();
+  pc2.createAnswer(requestSucceeded4, function () {});
+}
+
+function requestSucceeded4 (answer) {
+  pc2_answer = answer;
+  pc2.setLocalDescription(answer, requestSucceeded5, function () {});
+}
+
+function requestSucceeded5 () {
+  pc1.setRemoteDescription(pc2_answer, function () {}, function () {});
+}
+
+pc1.createDataChannel("This is pc1");
+pc1.createOffer(requestSucceeded1, function () {});
+
+</script>
+

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCIdentityEvent_assertion_basic.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCIdentityEvent_assertion_basic.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Liu,Yun <yunx.liu@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<title>WebRTC Test: RTCIdentityEvent - assertion basic</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcidentityevent-type">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+
+var t = async_test("Check if the attribute assertion of RTCIdentityEvent exists and type of string");
+setup({timeout: 20000});
+
+var pc1_offer;
+var pc2_answer;
+var pc1 = new webkitRTCPeerConnection(null, null);
+var pc2;
+
+function requestSucceeded1 (offer) {
+  pc1_offer = offer;
+  pc1.setLocalDescription(offer, requestSucceeded2, requestFailed2);
+}
+
+function requestFailed1 () {
+  t.step(function () {
+    assert_unreached("requestFailed1 was called");
+  });
+  t.done();
+}
+
+function requestSucceeded2 () {
+  pc2 = new webkitRTCPeerConnection(null, null);
+  pc2.setRemoteDescription(pc1_offer, requestSucceeded3, requestFailed3);
+}
+
+function requestFailed2 () {
+  t.step(function () {
+    assert_unreached("requestFailed2 was called");
+  });
+  t.done();
+}
+
+function requestSucceeded3 () {
+  pc2.createAnswer(requestSucceeded4, requestFailed4);
+}
+
+function requestFailed3 () {
+  t.step(function () {
+    assert_unreached("requestFailed3 was called");
+  });
+  t.done();
+}
+
+function requestSucceeded4 (answer) {
+  pc2_answer = answer;
+  pc2.setLocalDescription(answer, requestSucceeded5, requestFailed5);
+}
+
+function requestFailed4 () {
+  t.step(function () {
+    assert_unreached("requestFailed4 was called");
+  });
+  t.done();
+}
+
+function requestSucceeded5 () {
+  pc1.setRemoteDescription(pc2_answer, function () {}, function () {
+    t.step(function () {
+      assert_unreached("setRemoteDescription request failed");
+    });
+    t.done();
+  });
+}
+function requestFailed5 () {
+  t.step(function () {
+    assert_unreached("requestFailed5 was called");
+  });
+  t.done();
+}
+
+t.step(function () {
+  pc1.createDataChannel("This is pc1");
+  pc1.onidentityresult = t.step_func(function (event) {
+    assert_true("assertion" in event, "assertion attribute in RTCIdentityEvent");
+    assert_equals(Object.prototype.toString.call(event.assertion), "[object String]", "assertion attribute of type");
+    t.done();
+  });
+  pc1.createOffer(requestSucceeded1, requestFailed1);
+});
+
+</script>
+

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnectionIceEvent_candidate_basic.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnectionIceEvent_candidate_basic.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Liu,Yun <yunx.liu@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<title>WebRTC Test: RTCPeerConnectionIceEvent - candidate basic</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnectioniceevent">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+
+var t = async_test("Check if the readonly attribute candidate of RTCPeerConnectionIceEvent exists and type of string", {timeout: 10000});
+
+var pc = new RTCPeerConnection(null, null);
+var signalingChannel = pc.createDataChannel("label1");
+
+t.step(function () {
+  pc.onicecandidate = t.step_func(function (eve) {
+    assert_true("candidate" in eve, "candidate attribute in RTCPeerConnectionIceEvent");
+    assert_equals(Object.prototype.toString.call(eve.candidate), "[object RTCIceCandidate]", "candidate attribute of type");
+    assert_readonly(eve, "candidate", "expect attribute candidate cannot be changed but");
+    t.done();
+  });
+  pc.createOffer(localDescCreated, logError);
+});
+
+function localDescCreated(desc) {
+  pc.setLocalDescription(desc, function () {
+    signalingChannel.send(JSON.stringify({"sdp": pc.localDescription}));
+  }, logError);
+}
+
+function logError (error) {
+  t.step(function () {
+    assert_unreached("Error message: {" + error.message + "}");
+  });
+  t.done();
+}
+
+</script>

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Liu,Yun <yunx.liu@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<title>WebRTC Test: RTCPeerConnection basic</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+
+var pc;
+
+setup(function () {
+  var configuration = {"iceServers": [{"url": "stun:stun.example.org"}]};
+  pc = new webkitRTCPeerConnection(configuration);
+});
+
+[
+  //attributes of the RTCPeerConnection interface
+  ["object", "localDescription", "readonly"],
+  ["object", "remoteDescription", "readonly"],
+  ["string", "signalingState", "readonly"],
+  ["string", "iceGatheringState", "readonly"],
+  ["string", "iceConnectionState", "readonly"],
+
+  //events of the RTCPeerConnection interface
+  ["event", "onnegotiationneeded", ""],
+  ["event", "onicecandidate", ""],
+  ["event", "onsignalingstatechange", ""],
+  ["event", "onaddstream", ""],
+  ["event", "onremovestream", ""],
+  ["event", "oniceconnectionstatechange", ""],
+  ["event", "ondatachannel", ""],
+
+  //methods of the RTCPeerConnection interface
+  ["function", "createOffer", ""],
+  ["function", "createAnswer", ""],
+  ["function", "setLocalDescription", ""],
+  ["function", "setRemoteDescription", ""],
+  ["function", "updateIce", ""],
+  ["function", "addIceCandidate", ""],
+  ["function", "getConfiguration", ""],
+  ["function", "getLocalStreams", ""],
+  ["function", "getRemoteStreams", ""],
+  ["function", "getStreamById", ""],
+  ["function", "addStream", ""],
+  ["function", "removeStream", ""],
+  ["function", "close", ""],
+  ["function", "createDataChannel", ""],
+  ["function", "getStats", ""],
+
+  //the Identity API extends the RTCPeerConnection interface
+  ["rtcIdentityAssertion", "peerIdentity", "readonly"],
+  ["event", "onidentityresult", ""],
+  ["event", "onpeeridentity", ""],
+  ["event", "onidpassertionerror", ""],
+  ["event", "onidpvalidationerror", ""],
+  ["function", "setIdentityProvider", ""],
+  ["function", "getIdentityAssertion", ""]
+].forEach(function(attr) {
+  var type = attr[0];
+  var name = attr[1];
+  var read = attr[2];
+
+  test(function () {
+    assert_true(name in pc, name + " attribute in RTCPeerConnection");
+    switch(type) {
+    case "string":
+    case "object":
+      if(read == "readonly") {
+        assert_readonly(pc, name, "expect attribute " + name + " cannot be changed but");
+      }
+    case "function":
+      assert_equals(typeof pc[name], type, name + " attribute of type");      
+      break;
+    case "rtcIdentityAssertion":
+      assert_equals(Object.prototype.toString.call(pc[name]), "[object RTCIdentityAssertion]", name + " attribute of type");
+      assert_readonly(pc, name, "expect attribute " + name + " cannot be changed but");
+      break;
+    default:
+      break;
+    }
+  }, "Check if " + read + " RTCPeerConnection." + name + " exists and type of " + type);
+});
+
+</script>
+

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_createDTMFSender_basic.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_createDTMFSender_basic.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Liu,Yun <yunx.liu@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<title>WebRTC Test: RTCPeerConnection - createDTMFSender basic</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcpeerconnection-interface-extensions">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+
+var t = async_test("Check if RTCPeerConnection.createDTMFSender exists and type of function", {timeout: 5000});
+
+var pc;
+var ds;
+
+setup(function () {
+  var configuration = {"iceServers": [{"url": "stun:stun.example.org"}]};
+  pc = new webkitRTCPeerConnection(configuration);
+});
+
+t.step(function () {
+  navigator.webkitGetUserMedia({audio: true, video: true}, gotStream, error);
+});
+
+function gotStream(stream) {
+  pc.addStream(stream);
+  ds = pc.createDTMFSender(stream.getAudioTracks()[0]);
+
+  t.step(function () {
+    assert_true("createDTMFSender" in pc, "createDTMFSender attribute in RTCPeerConnection");
+    assert_equals(typeof pc.createDTMFSender, "function", "createDTMFSender attribute of type");
+  });
+  t.done();
+}
+
+function error() {
+  t.step(function () {
+    assert_unreached("Stream generation failed");
+  });
+  t.done();
+}
+
+</script>
+

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCSdpError_sdpLineNumber_basic.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCSdpError_sdpLineNumber_basic.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Liu,Yun <yunx.liu@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<title>WebRTC Test: RTCSdpError - sdpLineNumber basic</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcsdperror">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+
+var t = async_test("Check if the readonly attribute sdpLineNumber of RTCSdpError exists and type of number");
+
+var pc = new webkitRTCPeerConnection(null, null);
+
+t.step(function () {
+  pc.createOffer(localDescCreated, logError);
+});
+
+function localDescCreated(desc) {
+  pc.close();
+  pc.setLocalDescription(desc, function () {}, logError);
+}
+
+function logError (error) {
+  t.step(function () {
+    assert_true("sdpLineNumber" in error, "sdpLineNumber attribute in RTCSdpError");
+    assert_equals(typeof error.sdpLineNumber, "number", "sdpLineNumber attribute of type");
+    assert_readonly(error, "sdpLineNumber", "expect attribute sdpLineNumber cannot be changed but");
+  });
+  t.done();
+}
+
+</script>
+

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCSessionDescription_basic.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCSessionDescription_basic.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Liu,Yun <yunx.liu@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<title>WebRTC Test: RTCSessionDescription basic</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcsessiondescription-class">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+
+var sd = new RTCSessionDescription({type: "answer", sdp: "remote"});
+
+test(function () {
+  assert_true("type" in sd, "type attribute in RTCSessionDescription");
+  assert_equals(Object.prototype.toString.call(sd.type), "[object String]", "type attribute of type");
+}, "Check if RTCSessionDescription.type exists and type of string");
+
+test(function () {
+  assert_true("sdp" in sd, "sdp attribute in RTCSessionDescription");
+  assert_equals(Object.prototype.toString.call(sd.sdp), "[object String]", "sdp attribute of type");
+}, "Check if RTCSessionDescription.sdp exists and type of string");
+
+</script>
+

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCStatsReport_RTCStats_basic.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCStatsReport_RTCStats_basic.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Liu,Yun <yunx.liu@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<title>WebRTC Test: RTCStatsReport - RTCStats basic</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<link rel="help" href="http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcstatsreport-object">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="./support/support.js"></script>
+<div id="log"></div>
+<script>
+
+var t = async_test("Check if RTCStatsReport.RTCStats exists and type of function", {timeout: 5000});
+
+var configuration = {"iceServers": [{"url": "stun:stun.example.org"}]};
+var pc = new webkitRTCPeerConnection(configuration);
+
+t.step(function () {
+  navigator.webkitGetUserMedia({audio: true, video: true}, gotStream, error);
+});
+
+function gotStream(stream) {
+  var selector = stream.getAudioTracks()[0];
+  pc.getStats(selector, successCallback, failCallback);
+}
+
+function error() {
+  t.step(function () {
+    assert_unreached("Stream generation failed");
+  });
+  t.done();
+}
+
+function successCallback(report) {
+  t.step(function () {
+    assert_true("RTCStats" in report, "RTCStats attribute in RTCStatsReport");
+    assert_equals(typeof report.RTCStats, "function", "RTCStats attribute of type");
+  });
+  t.done();
+}
+
+function failCallback() {
+  t.step(function () {
+    assert_unreached("getStats request failed");
+  });
+  t.done();
+}
+
+</script>
+


### PR DESCRIPTION
Impacted test suite: webapi-webrtc-w3c-tests
Impacted TCs num: New 73, Update 0, Delete 0
Unit test platform: IVI
IVI test result summary: Pass: 57, Fail 8, Block 8

Comment:
The TCs fail due to getConfiguration method is not support and the Identity API extends the RTCPeerConnection interface is not support.
The TCs block due to onidpvalidationerror event and onidentityresult event cannot be fired.
