### PR TITLE
[webapi] Fix XWALK-1447 to define a variable

### DIFF
--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_datachannel_event.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_datachannel_event.html
@@ -49,6 +49,7 @@ Authors:
       var pc1_offer;
       var pc2_answer;
       var pc1 = new RTCPeerConnection(null, null);
+      var pc2;
 
       function requestSucceeded1 (offer) {
         pc1_offer = offer;
@@ -63,8 +64,8 @@ Authors:
       }
 
       function requestSucceeded2 () {
-        var pc2 = new RTCPeerConnection(null, null);
-        pc2.ondatachannel = t.step(function (event) {
+        pc2 = new RTCPeerConnection(null, null);
+        pc2.ondatachannel = t.step_func(function (event) {
           t.done();
         });
         pc2.setRemoteDescription(pc1_offer, requestSucceeded3, requestFailed3);
@@ -115,10 +116,8 @@ Authors:
         t.done();
       }
 
-      t.step(function () {
-        pc1.createDataChannel("This is pc1");
-        pc1.createOffer(requestSucceeded1, requestFailed1);
-      });
+      pc1.createDataChannel("This is pc1");
+      pc1.createOffer(requestSucceeded1, requestFailed1);
 
     </script>
   </body>


### PR DESCRIPTION
Impacted test suite: webapi-webrtc-w3c-tests
Impacted TCs num: New 0, Update 1, Delete 0
Unit test platform: IVI
IVI test result summary: Fail

Fail Reason:
Fix XWALK-1447 bug to define a variable, but this case is still failed due to the ondatachannel event cannot be fired.
