### PR TITLE
[misc-sanity] Fix the issue of SessionHistory

### DIFF
--- a/misc/webapi-sanityapp-w3c-tests/tests/SessionHistory/index.html
+++ b/misc/webapi-sanityapp-w3c-tests/tests/SessionHistory/index.html
@@ -60,19 +60,25 @@ Authors:
             </div>
           </div>
         </li>
+        <li>
+        <pre>Test Purpose:
+Verifies go back or forward the
+specified number of steps in the joint
+session history.
+
+Test Step:
+The page will add 11 session history
+state from 0 - 10, tap "back" or
+"forward" button will back or forward
+current history state.
+
+Expected Result:
+Test passes if go back or forward page
+will change window.history.state well.</pre>
+        </li>
       </ul>
     </div>
     <div data-role="footer" data-position="fixed">
-    </div>
-    <div data-role="popup" id="popup_info">
-      <font class="fontSize">
-        <p>Test Purpose: </p>
-        <p>Verifies go back or forward the specified number of steps in the joint session history.</p>
-        <p>Test Step: </p>
-        <p>The page will add 11 session history state from 0 - 10, tap "back" or "forward" button will back or forward current history state.
-        <p>Expected Result: </p>
-        <p>Test passes if go back or forward page will change window.history.state well.</p>
-      </font>
     </div>
   </body>
 </html>


### PR DESCRIPTION
The "Info" button on footer bar will popup a dialog to show the tips. But this dialog will change the sessionhistory default. So I remove this dialog, and add the tips to the page directly.
