### PR TITLE
[misc-sanity] Fix XWALK-1311 by removing DnD from Android tests

### DIFF
--- a/misc/webapi-sanityapp-w3c-tests/tests.android.xml
+++ b/misc/webapi-sanityapp-w3c-tests/tests.android.xml
@@ -283,18 +283,6 @@
           <test_script_entry test_script_expected_result="0"/>
         </description>
       </testcase>
-      <testcase component="sanity" execution_type="manual" id="DragandDrop" purpose="Drag and Drop Test">
-        <description>
-          <pre_condition/>
-          <steps>
-            <step order="1">
-              <step_desc>0</step_desc>
-              <expected>0</expected>
-            </step>
-          </steps>
-          <test_script_entry test_script_expected_result="0"/>
-        </description>
-      </testcase>
       <testcase component="sanity" execution_type="manual" id="PageVisibility" purpose="Page Visibility Test">
         <description>
           <pre_condition/>

--- a/misc/webapi-sanityapp-w3c-tests/tests.full.xml
+++ b/misc/webapi-sanityapp-w3c-tests/tests.full.xml
@@ -323,7 +323,7 @@
           <test_script_entry test_script_expected_result="0"/>
         </description>
       </testcase>
-      <testcase purpose="Drag and Drop Test" type="functional_positive" status="approved" component="sanity" execution_type="manual" platform="all" priority="P0" id="DragandDrop">
+      <testcase purpose="Drag and Drop Test" type="functional_positive" status="approved" component="sanity" execution_type="manual" platform="tizen" priority="P0" id="DragandDrop">
         <description>
           <pre_condition/>
           <post_condition/>


### PR DESCRIPTION
Removed Drag and Drop from Android tests because the feature is not ready based on the comment in <a href="https://crosswalk-project.org/jira/browse/XWALK-1311">XWALK-1311</a>
