### PR TITLE
[misc-sanity] Fix XWALK-1310 by changing notification cancel to close method

### DIFF
--- a/misc/webapi-sanityapp-w3c-tests/tests/Notifications/js/main.js
+++ b/misc/webapi-sanityapp-w3c-tests/tests/Notifications/js/main.js
@@ -42,5 +42,5 @@ function showNotification() {
 }
 
 function closeNotification() {
-  notification.cancel();
+  notification.close();
 }


### PR DESCRIPTION
Unit test platform: Android 
Android test result: Fail

Fail reason: Android platform may be not support notification.close method.
