### PR TITLE
[webapi] Remove spec.json not for release

### DIFF
--- a/webapi/tct-capability-tests/capability/spec.json
+++ b/webapi/tct-capability-tests/capability/spec.json
@@ -1,7 +1,0 @@
-{
- "capability": {
-  "spec_url": "https://developer.tizen.org/help/topic/org.tizen.web.device.apireference/tizen/systeminfo.html",
-  "spec_desc": "Tizen Device API",
-  "spec_category": "tizen"
- }
-}

--- a/webapi/tct-security-tcs-tests/security/spec.json
+++ b/webapi/tct-security-tcs-tests/security/spec.json
@@ -1,7 +1,0 @@
-{
- "security": {
-  "spec_url": "http://source.tizen.org/compliance/compliance-specification",
-  "spec_desc": "Tizen Compliance Specification Security Section M",
-  "spec_category": "tcs"
- }
-}


### PR DESCRIPTION
tct-capability-tests, tct-security-tcs-tests are not in webtestingservice release.
