### PR TITLE
[webapi] Remove the multiple URLs in spec.json for runtime

### DIFF
--- a/webapi/webapi-runtime-xwalk-tests/runtime/spec.json
+++ b/webapi/webapi-runtime-xwalk-tests/runtime/spec.json
@@ -1,6 +1,6 @@
 {
  "runtime": {
-  "spec_url": "https://crosswalk-project.org/jira/browse/XWALK-516,XWALK-596,XWALK-597",
+  "spec_url": "https://crosswalk-project.org/jira/browse/XWALK-597",
   "spec_desc": "Runtime",
   "spec_category": "xwalk"
  }


### PR DESCRIPTION
I have link XWALK-516, XWALK-596 to XWALK-597 in JIRA.
Base on https://github.com/crosswalk-project/crosswalk-test-suite/issues/166
