### PR TITLE
[webapi] Fix typo of 2 tests for Geolocation

### DIFF
--- a/webapi/tct-geoallow-w3c-tests/geoallow/Geolocation_getCurrentPosition_successCallback_maximumAge_700000_timeout_zero.html
+++ b/webapi/tct-geoallow-w3c-tests/geoallow/Geolocation_getCurrentPosition_successCallback_maximumAge_700000_timeout_zero.html
@@ -60,7 +60,6 @@ Authors:
           assert_true(error.code == error.TIMEOUT, "The timeout occurred");
         });
         t.done();
-        }
       }
     </script>
   </body>

--- a/webapi/tct-geoallow-w3c-tests/geoallow/Geolocation_getCurrentPosition_successCallback_with_errorCallback_null.html
+++ b/webapi/tct-geoallow-w3c-tests/geoallow/Geolocation_getCurrentPosition_successCallback_with_errorCallback_null.html
@@ -40,13 +40,16 @@ Authors:
   </head>
   <body>
     <div id="log"></div>
-    <script">
+    <script>
       var t = async_test(document.title);
       setup({timeout: 20000});
 
       try {
         navigator.geolocation.getCurrentPosition(successCallback, null);
-      } catch (e) {
+      } catch (err) {
+        t.step(function () {
+          assert_unreached("Error message: {" + err.message + " }");
+        });
         t.done();
       }
       function successCallback (position) {


### PR DESCRIPTION
Impacted Suites: tct-geoallow-w3c-tests
Impacted TCs num: New 0, Update 2, Delete 0
Unit test platform: Tizen(IVI), 
Tizen test result summary: Pass 2, Fail 0, Blocked 0
