### PR TITLE
[wrt] Add TCs for wrt-googleplay-android-tests

### DIFF
--- a/wrt/wrt-googleplay-android-tests/googleplay/Crosswalk_Google_Play_Multiple.html
+++ b/wrt/wrt-googleplay-android-tests/googleplay/Crosswalk_Google_Play_Multiple.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+    Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Google_Play_Multiple</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>Package an web app for arm platform with command: python make_apk.py --name=test --package=org.xwalk.test --app-versionCodeBase=1 --app-version=1.0.0 --arch=arm</li>
+      <li>Package an web app for x86 platform with command: python make_apk.py --name=test --package=org.xwalk.test --app-versionCodeBase=2 --app-version=1.0.0 --arch=x86</li>
+      <li>Login the Google Play Developer Console in Browser and click the button "Add new application"</li>
+      <li>Input a Title as application name and click the button "Upload APK"</li>
+      <li>Choose ALPHA TESTING or BETA TESTING, then upload the "x86" arch apk into this application</li>
+      <li>Upload the "arm" arch apk into the same application</li>
+      <li>Add related tester account google groups</li>
+      <li>Publish this application</li>
+      <li>Download the application which we have published and install it</li>
+      <li>Launch the webapp</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>Installation package for arm and x86 generated successfully</li>
+      <li>Dialog "Add new application" popuped</li>
+      <li>Application is created successfully with the name which you input</li>
+      <li>Apk for arm could be uploaded into application successfully</li>
+      <li>Apk for x86 could be uploaded into application successfully</li>
+      <li>Google groups is added successfully</li>
+      <li>The application is published successfully</li>
+      <li>Webapp could be installed successfully</li>
+      <li>Webapp could be launched successfully</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-googleplay-android-tests/tests.full.xml
+++ b/wrt/wrt-googleplay-android-tests/tests.full.xml
@@ -57,6 +57,14 @@
           <test_script_entry>/opt/wrt-googleplay-android-tests/googleplay/Crosswalk_Google_Play_Upgrade.html</test_script_entry>
         </description>
       </testcase>
+      <testcase purpose="Validate Crosswalk webapp for arm,x86 can be uploaded into the same application in Google Play" type="Functional" status="approved" component="Crosswalk Google Play" execution_type="manual" priority="P1" id="Crosswalk_Google_Play_Multiple">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk is installed.
+          </pre_condition>
+          <test_script_entry>/opt/wrt-googleplay-android-tests/googleplay/Crosswalk_Google_Play_Multiple.html</test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>

--- a/wrt/wrt-googleplay-android-tests/tests.xml
+++ b/wrt/wrt-googleplay-android-tests/tests.xml
@@ -57,6 +57,14 @@
           <test_script_entry>/opt/wrt-googleplay-android-tests/googleplay/Crosswalk_Google_Play_Upgrade.html</test_script_entry>
         </description>
       </testcase>
+      <testcase component="Crosswalk Google Play" execution_type="manual" id="Crosswalk_Google_Play_Multiple" purpose="Validate Crosswalk webapp for arm,x86 can be uploaded into the same application in Google Play">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk is installed.
+          </pre_condition>
+          <test_script_entry>/opt/wrt-googleplay-android-tests/googleplay/Crosswalk_Google_Play_Multiple.html</test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>


### PR DESCRIPTION
Impacted TCs num(approved): New 1 Update 0 Delete 0
Unit test Platform: Android
Unit test result summary: Pass 0, Fail 1, Block 0
Fail reason: Crosswalk_Google_Play_Multiple
Can not upload the arm and x86 arch webapp to googleplay into the same application.
