### PR TITLE
[webapi][XWALK-1735] Refine and automate a test for W3C Notification

### DIFF
--- a/webapi/tct-notification-w3c-tests/notification/onshow_using.html
+++ b/webapi/tct-notification-w3c-tests/notification/onshow_using.html
@@ -33,10 +33,9 @@ Authors:
 <html>
   <head>
     <title>Notification Test: onshow_using</title>
-    <link rel="author" title="Intel" href="http://www.intel.com/" />
-    <link rel="help" href="http://www.w3.org/TR/2012/WD-notifications-20120614/#api" />
-    <meta name="flags" content="interact" />
-    <meta name="assert" content="Check if the attribute altKey exists" />
+    <link rel="author" title="Intel" href="http://www.intel.com/"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/WD-notifications-20120614/#api"/>
+    <meta name="flags" content=""/>
     <script src="support/notifications.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
@@ -44,18 +43,21 @@ Authors:
   <body >
     <div id="log"></div>
     <script>
-        t = async_test(document.title, { timeout: 3000 });
+      t = async_test(document.title, { timeout: 3000 });
+      t.step(function () {
         getnotification();
         notification.show();
-        notification.onshow = function(){
-            t.done();
-        }
-        setTimeout(function(){
-            t.step(function() {
-                assert_true(false, "onshow event should be fired");
-            });
-            t.done();
-        }, 3000)
+      });
+
+      notification.onshow = function() {
+        t.done();
+      }
+      setTimeout(function() {
+        t.step(function() {
+          assert_unreached("timeout should not be fired");
+        });
+        t.done();
+      }, 1000)
     </script>
   </body>
 </html>

--- a/webapi/tct-notification-w3c-tests/tests.full.xml
+++ b/webapi/tct-notification-w3c-tests/tests.full.xml
@@ -195,9 +195,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if the notification.onshow event can work" type="compliance" status="approved" component="WebAPI/UI/Web Notifications (Partial)" execution_type="manual" priority="P2" id="onshow_using">
+      <testcase purpose="Check if the notification.onshow event can work" type="compliance" status="approved" component="WebAPI/UI/Web Notifications (Partial)" execution_type="auto" priority="P2" id="onshow_using">
         <description>
-          <test_script_entry>/opt/tct-notification-w3c-tests/notification/onshow_using-manual.html</test_script_entry>
+          <test_script_entry>/opt/tct-notification-w3c-tests/notification/onshow_using.html</test_script_entry>
         </description>
         <specs>
           <spec>

--- a/webapi/tct-notification-w3c-tests/tests.xml
+++ b/webapi/tct-notification-w3c-tests/tests.xml
@@ -83,9 +83,9 @@
           <test_script_entry>/opt/tct-notification-w3c-tests/notification/notification_tag-manual.html</test_script_entry>
         </description>
         </testcase>
-      <testcase component="WebAPI/UI/Web Notifications (Partial)" execution_type="manual" id="onshow_using" purpose="Check if the notification.onshow event can work">
+      <testcase component="WebAPI/UI/Web Notifications (Partial)" execution_type="auto" id="onshow_using" purpose="Check if the notification.onshow event can work">
         <description>
-          <test_script_entry>/opt/tct-notification-w3c-tests/notification/onshow_using-manual.html</test_script_entry>
+          <test_script_entry>/opt/tct-notification-w3c-tests/notification/onshow_using.html</test_script_entry>
         </description>
         </testcase>
     </set>


### PR DESCRIPTION
- Tizen IVI doesn't support W3C Notification
- It supports Tizen Notification?

Impacted tests (approved): new 0, update 1, delete 0
Unit test Platform: Tizen IVI
Unit test result summary: pass 0, fail 1, block 0
