### PR TITLE
[wrt] Add 4 TCs for wrt-packertool-android-tests

### DIFF
--- a/wrt/wrt-packertool-android-tests/packertool/Crosswalk_Packer_Tool_PythonVersion_2.0.1.html
+++ b/wrt/wrt-packertool-android-tests/packertool/Crosswalk_Packer_Tool_PythonVersion_2.0.1.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+    Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Packer_Tool_PythonVersion_2.0.1</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>Package an web app with command: python make_apk.py --name=Test --package=test.xwalk.org --app-url=http://www.baidu.com --app-versionCodeBase=1 --app-version=1.0.0 --arch=x86</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>Installation Package generated failed</li>      
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-packertool-android-tests/packertool/Crosswalk_Packer_Tool_PythonVersion_2.7.6.html
+++ b/wrt/wrt-packertool-android-tests/packertool/Crosswalk_Packer_Tool_PythonVersion_2.7.6.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+    Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Packer_Tool_PythonVersion_2.7.6</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>Package an web app with command: python make_apk.py --name=Test --package=test.xwalk.org --app-url=http://www.baidu.com --app-versionCodeBase=1 --app-version=1.0.0 --arch=x86</li>
+      <li>Install the application with command like: adb install Test.apk</li>
+      <li>Launch the application</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>Installation Package generated successfully</li>
+      <li>Web Application could be installed successfully</li>
+      <li>Web Application could be launched successfully</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-packertool-android-tests/packertool/Crosswalk_Packer_Tool_PythonVersion_3.0.html
+++ b/wrt/wrt-packertool-android-tests/packertool/Crosswalk_Packer_Tool_PythonVersion_3.0.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+    Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Packer_Tool_PythonVersion_3.0</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>Package an web app with command: python make_apk.py --name=Test --package=test.xwalk.org --app-url=http://www.baidu.com --app-versionCodeBase=1 --app-version=1.0.0 --arch=x86</li>
+      <li>Install the application with command like: adb install Test.apk</li>
+      <li>Launch the application</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>Installation Package generated successfully</li>
+      <li>Web Application could be installed successfully</li>
+      <li>Web Application could be launched successfully</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-packertool-android-tests/packertool/Crosswalk_Packer_Tool_PythonVersion_3.4.html
+++ b/wrt/wrt-packertool-android-tests/packertool/Crosswalk_Packer_Tool_PythonVersion_3.4.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+    Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_Packer_Tool_PythonVersion_3.4</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>Package an web app with command: python make_apk.py --name=Test --package=test.xwalk.org --app-url=http://www.baidu.com --app-versionCodeBase=1 --app-version=1.0.0 --arch=x86</li>
+      <li>Install the application with command like: adb install Test.apk</li>
+      <li>Launch the application</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>Installation Package generated successfully</li>
+      <li>Web Application could be installed successfully</li>
+      <li>Web Application could be launched successfully</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-packertool-android-tests/tests.full.xml
+++ b/wrt/wrt-packertool-android-tests/tests.full.xml
@@ -2290,6 +2290,41 @@
           <test_script_entry>/opt/wrt-packertool-android-tests/packertool/Crosswalk_Packer_Tool_Keep_Screen_On_Manifest.html</test_script_entry>
         </description>
       </testcase>
+      <testcase purpose="Validate if the Packaging Tool only support Python 2.7+" type="Functional" status="approved" component="Crosswalk Packer Tool" execution_type="manual" priority="P2" id="Crosswalk_Packer_Tool_PythonVersion_2.0.1">
+        <description>
+          <pre_condition>
+            Make sure the version of Python is Python 2.0.1.
+          </pre_condition>
+          <test_script_entry>/opt/wrt-packertool-android-tests/packertool/Crosswalk_Packer_Tool_PythonVersion_2.0.1.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate if the Packaging Tool support Python 2.7.6" type="Functional" status="approved" component="Crosswalk Packer Tool" execution_type="manual" priority="P2" id="Crosswalk_Packer_Tool_PythonVersion_2.7.6">
+        <description>
+          <pre_condition>
+            1.Make sure the version of Python is Python 2.7.6
+            2.Make sure Crosswalk is installed.
+          </pre_condition>
+          <test_script_entry>/opt/wrt-packertool-android-tests/packertool/Crosswalk_Packer_Tool_PythonVersion_2.7.6.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate if the Packaging Tool support Python 3.0" type="Functional" status="approved" component="Crosswalk Packer Tool" execution_type="manual" priority="P2" id="Crosswalk_Packer_Tool_PythonVersion_3.0">
+        <description>
+          <pre_condition>
+            1.Make sure the version of Python is Python 3.0
+            2.Make sure Crosswalk is installed.
+          </pre_condition>
+          <test_script_entry>/opt/wrt-packertool-android-tests/packertool/Crosswalk_Packer_Tool_PythonVersion_3.0.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Validate if the Packaging Tool support Python 3.4" type="Functional" status="approved" component="Crosswalk Packer Tool" execution_type="manual" priority="P2" id="Crosswalk_Packer_Tool_PythonVersion_3.4">
+        <description>
+          <pre_condition>
+            1.Make sure the version of Python is Python 3.4
+            2.Make sure Crosswalk is installed.
+          </pre_condition>
+          <test_script_entry>/opt/wrt-packertool-android-tests/packertool/Crosswalk_Packer_Tool_PythonVersion_3.4.html</test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>

--- a/wrt/wrt-packertool-android-tests/tests.xml
+++ b/wrt/wrt-packertool-android-tests/tests.xml
@@ -2280,6 +2280,41 @@
           <test_script_entry>/opt/wrt-packertool-android-tests/packertool/Crosswalk_Packer_Tool_Keep_Screen_On_Manifest.html</test_script_entry>
         </description>
       </testcase>
+      <testcase component="Crosswalk Packer Tool" execution_type="manual" id="Crosswalk_Packer_Tool_PythonVersion_2.0.1" purpose="Validate if the Packaging Tool only support Python 2.7+">
+        <description>
+          <pre_condition>
+            Make sure the version of Python is Python 2.0.1.
+          </pre_condition>
+          <test_script_entry>/opt/wrt-packertool-android-tests/packertool/Crosswalk_Packer_Tool_PythonVersion_2.0.1.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Packer Tool" execution_type="manual" id="Crosswalk_Packer_Tool_PythonVersion_2.7.6" purpose="Validate if the Packaging Tool support Python 2.7.6">
+        <description>
+          <pre_condition>
+            1.Make sure the version of Python is Python 2.7.6
+            2.Make sure Crosswalk is installed.
+          </pre_condition>
+          <test_script_entry>/opt/wrt-packertool-android-tests/packertool/Crosswalk_Packer_Tool_PythonVersion_2.7.6.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Packer Tool" execution_type="manual" id="Crosswalk_Packer_Tool_PythonVersion_3.0" purpose="Validate if the Packaging Tool support Python 3.0">
+        <description>
+          <pre_condition>
+            1.Make sure the version of Python is Python 3.0
+            2.Make sure Crosswalk is installed.
+          </pre_condition>
+          <test_script_entry>/opt/wrt-packertool-android-tests/packertool/Crosswalk_Packer_Tool_PythonVersion_3.0.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Packer Tool" execution_type="manual" id="Crosswalk_Packer_Tool_PythonVersion_3.4" purpose="Validate if the Packaging Tool support Python 3.4">
+        <description>
+          <pre_condition>
+            1.Make sure the version of Python is Python 3.4
+            2.Make sure Crosswalk is installed.
+          </pre_condition>
+          <test_script_entry>/opt/wrt-packertool-android-tests/packertool/Crosswalk_Packer_Tool_PythonVersion_3.4.html</test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>


### PR DESCRIPTION
Impacted TCs num(approved): New 4 Update 0 Delete 0
Unit test Platform: Android
Unit test result summary: Pass 3, Fail 1, Block 0
Fail TCs:Crosswalk_Packer_Tool_3.0_PythonVersion
Fail reason: bug[XWALK-1721]
