### PR TITLE
[misc] Fix APK packaging issue of package names

### DIFF
--- a/misc/wrt-stablonglast2D-android-tests/inst.sh
+++ b/misc/wrt-stablonglast2D-android-tests/inst.sh
@@ -25,12 +25,12 @@ function unzippkg()
     echo "Package unzip successfully and push to /opt/usr/media/"
     chmod 777 /opt/usr/media/opt/$NAME/$folderName/*.sh
     echo "Install webapp ..."
-    adb install -r /opt/usr/media/opt/$NAME/$folderName/dynamic2D*.apk
+    adb install -r /opt/usr/media/opt/$NAME/$folderName/dynamicdd*.apk
 }
 
 function cleansource()
 {
-    adb uninstall org.xwalk.dynamic2D
+    adb uninstall org.xwalk.dynamicdd
     [ -d /opt/usr/media/opt/$NAME ] && rm -rf /opt/usr/media/opt/$NAME
     [ -e /opt/usr/media/$NAME.zip ] && rm -rf /opt/usr/media/$NAME.zip
     echo "Clean folder successfully..."

--- a/misc/wrt-stablonglast2D-android-tests/pack.sh
+++ b/misc/wrt-stablonglast2D-android-tests/pack.sh
@@ -82,7 +82,7 @@ do
     if [ -d $BUILD_DEST/opt/$name/$folderName/$buildfolder ];then
         if [ $buildfolder == "dynamic" ];then
             cd $xpkpacktooldir
-            python make_apk.py --package=org.xwalk.$buildfolder"2D" --name=$buildfolder"2D" --app-root=$BUILD_DEST/opt/$name/$folderName/$buildfolder --app-local-path=index.html --mode=$mode --arch=$arch
+            python make_apk.py --package=org.xwalk.$buildfolder"dd" --name=$buildfolder"dd" --app-root=$BUILD_DEST/opt/$name/$folderName/$buildfolder --app-local-path=index.html --mode=$mode --arch=$arch
             if [ $? -ne 0 ];then
                 echo "Create $name.apk fail.... >>>>>>>>>>>>>>>>>>>>>>>>>"
                 #clean_workspace
@@ -91,7 +91,7 @@ do
             #clean middle files
             rm *.pyc
             rm *.stam*
-            rm -rf dynamic2D
+            rm -rf dynamicdd
             rm -rf $BUILD_DEST/opt/$name/$folderName/$buildfolder
             sleep 2
         fi

--- a/misc/wrt-stablonglast2D-android-tests/stablonglast2D/RunGame2DGraphicsLongTimeTest.sh
+++ b/misc/wrt-stablonglast2D-android-tests/stablonglast2D/RunGame2DGraphicsLongTimeTest.sh
@@ -29,12 +29,12 @@
 
 local_path=$(cd "$(dirname $0)";pwd)
 #monitor sys
-WEBAPP_PACKAGE="org.xwalk.dynamic2D"
+WEBAPP_PACKAGE="org.xwalk.dynamicdd"
 SLEEP=86400
 $local_path/sysmon.sh `(basename $0)` $SLEEP $WEBAPP_PACKAGE &
 
 #launch app
-adb shell am start -a android.intent.action.View -n $WEBAPP_PACKAGE/.dynamic2DActivity &
+adb shell am start -a android.intent.action.View -n $WEBAPP_PACKAGE/.dynamicddActivity &
 
 KILLSLEEP=$[ $SLEEP * 3 / 10 ]
 sleep $(($SLEEP + $KILLSLEEP ))

--- a/misc/wrt-stablonglast3D-android-tests/inst.sh
+++ b/misc/wrt-stablonglast3D-android-tests/inst.sh
@@ -25,12 +25,12 @@ function unzippkg()
     echo "Package unzip successfully and push to /opt/usr/media/"
     chmod 777 /opt/usr/media/opt/$NAME/$folderName/*.sh
     echo "Install webapp ..."
-    adb install -r /opt/usr/media/opt/$NAME/$folderName/dynamic3D*.apk
+    adb install -r /opt/usr/media/opt/$NAME/$folderName/dynamicddd*.apk
 }
 
 function cleansource()
 {
-    adb uninstall org.xwalk.dynamic3D
+    adb uninstall org.xwalk.dynamicddd
     [ -d /opt/usr/media/opt/$NAME ] && rm -rf /opt/usr/media/opt/$NAME
     [ -e /opt/usr/media/$NAME.zip ] && rm -rf /opt/usr/media/$NAME.zip
     echo "Clean folder successfully..."

--- a/misc/wrt-stablonglast3D-android-tests/pack.sh
+++ b/misc/wrt-stablonglast3D-android-tests/pack.sh
@@ -81,7 +81,7 @@ for buildfolder in `ls`
 do
     if [ -d $BUILD_DEST/opt/$name/$folderName/$buildfolder ];then
         cd $xpkpacktooldir
-        python make_apk.py --package=org.xwalk.dynamic3D --name=dynamic3D --app-url=http://rscohn2.herokuapp.com/sbp/ --mode=$mode --arch=$arch
+        python make_apk.py --package=org.xwalk.dynamicddd --name=dynamicddd --app-url=http://rscohn2.herokuapp.com/sbp/ --mode=$mode --arch=$arch
         if [ $? -ne 0 ];then
             echo "Create $name.apk fail.... >>>>>>>>>>>>>>>>>>>>>>>>>"
             #clean_workspace
@@ -90,7 +90,7 @@ do
         #clean middle files
         rm *.pyc
         rm *.stam*
-        rm -rf dynamic3D
+        rm -rf dynamicddd
         rm -rf $BUILD_DEST/opt/$name/$folderName/$buildfolder
         sleep 2
     fi

--- a/misc/wrt-stablonglast3D-android-tests/stablonglast3D/RunGame3DGraphicsLongTimeTest.sh
+++ b/misc/wrt-stablonglast3D-android-tests/stablonglast3D/RunGame3DGraphicsLongTimeTest.sh
@@ -29,12 +29,12 @@
 
 local_path=$(cd "$(dirname $0)";pwd)
 #monitor sys
-WEBAPP_PACKAGE="org.xwalk.dynamic3D"
+WEBAPP_PACKAGE="org.xwalk.dynamicddd"
 SLEEP=86400
 $local_path/sysmon.sh `(basename $0)` $SLEEP $WEBAPP_PACKAGE &
 
 #launch app
-adb shell am start -a android.intent.action.View -n $WEBAPP_PACKAGE/.dynamic3DActivity &
+adb shell am start -a android.intent.action.View -n $WEBAPP_PACKAGE/.dynamicdddActivity &
 
 KILLSLEEP=$[ $SLEEP * 3 / 10 ]
 sleep $(($SLEEP + $KILLSLEEP ))


### PR DESCRIPTION
Signed-off-by: Hao yunfeix yunfeix.hao@intel.com
New crosswalk package tool 7.35._._ doesn't support numbers and upper letters.
Change 2D => dd, 3D=>ddd
