### PR TITLE
[misc] add sample app for gamepad

### DIFF
--- a/misc/webapi-usecase-w3c-tests/inst.sh.apk
+++ b/misc/webapi-usecase-w3c-tests/inst.sh.apk
@@ -7,7 +7,7 @@ USAGE="Usage: ./inst.sh [-i] [-u]
 [-i] option was set as default."
 
 #TODO:update PACKAGENAME for each suite,pay attention to use '_'
-PACKAGENAME=webapi_sanityapp_w3c_tests
+PACKAGENAME=webapi_usecase_w3c_tests
 SUITENAME=`echo $PACKAGENAME |sed 's/_/-/g'`
 RESOURCE_DIR=/opt/usr/media
 

--- a/misc/webapi-usecase-w3c-tests/tests.full.xml
+++ b/misc/webapi-usecase-w3c-tests/tests.full.xml
@@ -295,6 +295,20 @@
           <test_script_entry test_script_expected_result="0"/>
         </description>
       </testcase>
+      <testcase purpose="GamePad Test" type="functional_positive" status="designed" component="sanity" execution_type="manual" platform="android" priority="P0" id="GamePad">
+        <capability name="accelerometer"/>
+        <description>
+          <pre_condition/>
+          <post_condition/>
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0"/>
+        </description>
+      </testcase>
     </set>
     <set name="Gesture">
       <testcase purpose="Touch Test" type="functional_positive" status="approved" component="sanity" execution_type="manual" platform="all" priority="P0" id="Touch">

--- a/misc/webapi-usecase-w3c-tests/tests/GamePad/css/style.css
+++ b/misc/webapi-usecase-w3c-tests/tests/GamePad/css/style.css
@@ -1,0 +1,223 @@
+/*
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Jianfeng <jianfengx.xu@intel.com>
+
+*/
+
+
+.button {
+  position: absolute;
+  height: 3%;
+  border-radius: 10px;
+  border: 2px solid black;
+  background-color: white;
+  background-repeat: no-repeat;
+  text-align:center;
+}
+
+.used {
+  border: 2px solid green;
+}
+
+.pressed {
+  background-color: blue;
+}
+
+.axes {
+  position: absolute;
+  width:20%;
+  display: none;
+}
+
+#d {
+  position: absolute;
+  left: 0px;
+  top: 10%;
+  width: 100%;
+  height:100%;
+}
+
+#GamePad {
+  position: absolute;
+  left: 0px;
+  top: 12%;
+  width: 100%;
+  height:100%;
+  display: none;
+}
+
+#Axes {
+  position: absolute;
+  left: 5%;
+  top: 52%;
+  width: 100%;
+  height:50%;
+  display: none;
+}
+
+#button0 {
+  left: 75%;
+  top: 25%;
+  width: 10%;
+}
+
+#button1 {
+  left: 85%;
+  top: 20%;
+  width: 10%;
+}
+
+#button2 {
+  left: 65%;
+  top: 20%;
+  width: 10%;
+}
+
+#button3{
+  left: 75%;
+  top: 15%;
+  width: 10%;
+}
+
+#button4{
+  left: 10%;
+  top: 8%;
+  width: 20%;
+}
+
+#button5{
+  left: 70%;
+  top: 8%;
+  width: 20%;
+}
+
+#button6{
+  left: 10%;
+  top: 1%;
+  width: 20%;
+}
+
+#button7{
+  left: 70%;
+  top: 1%;
+  width: 20%;
+}
+
+#button8{
+  left: 40%;
+  top: 10%;
+  width: 7%;
+}
+
+#button9{
+  left: 50%;
+  top: 10%;
+  width: 7%;
+}
+
+#button10{
+  left: 10%;
+  top: 32%;
+  width: 20%;
+}
+
+#button11{
+  left: 70%;
+  top: 32%;
+  width: 20%;
+}
+
+#button12{
+  left: 15%;
+  top: 15%;
+  width: 10%;
+}
+
+#button13{
+  left: 15%;
+  top: 25%;
+  width: 10%;
+}
+
+#button14{
+  left: 5%;
+  top: 20%;
+  width: 10%;
+}
+
+#button15{
+  left: 25%;
+  top: 20%;
+  width: 10%;
+}
+
+#button16{
+  left: 41%;
+  top: 20%;
+  width: 15%;
+}
+
+#axes0{
+  left: 0%;
+  top: 0%;
+}
+
+#axes1{
+  left: 21%;
+  top: 0%;
+}
+
+#axes2{
+  left: 0%;
+  top: 7%;
+}
+
+#axes3{
+  left: 21%;
+  top: 7%;
+}
+
+#axes4{
+  left: 0%;
+  top: 14%;
+}
+
+#axes5{
+  left: 21%;
+  top: 14%;
+}
+
+#axes6{
+  left: 0%;
+  top: 21%;
+}
+
+#axes7{
+  left: 21%;
+  top: 21%;
+}

--- a/misc/webapi-usecase-w3c-tests/tests/GamePad/index.html
+++ b/misc/webapi-usecase-w3c-tests/tests/GamePad/index.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Jianfeng <jianfengx.xu@intel.com>
+
+-->
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, width=device-width">
+    <link rel="stylesheet" type="text/css" href="../../css/jquery.mobile.css" />
+    <link rel="stylesheet" type="text/css" href="../../css/main.css" />
+    <link rel="stylesheet" type="text/css" href="css/style.css" />
+    <script src="../../js/thirdparty/jquery.js"></script>
+    <script src="../../js/thirdparty/jquery.mobile.js"></script>
+    <script src="../../js/tests.js"></script>
+    <script src="js/gamepadtest.js"></script>
+  </head>
+  <body>
+    <div data-role="header">
+      <h1 id="main_page_title"></h1>
+    </div>
+    <div data-role="content">
+      <div id= "d">
+      <div id="GamePad">
+           <div class="button" id = "button0">0</div>
+           <div class="button" id = "button1">1</div>
+           <div class="button" id = "button2">2</div>
+           <div class="button" id = "button3">3</div>
+           <div class="button" id = "button4">4</div>
+           <div class="button" id = "button5">5</div>
+           <div class="button" id = "button6">6</div>
+           <div class="button" id = "button7">7</div>
+           <div class="button" id = "button8">8</div>
+           <div class="button" id = "button9">9</div>
+           <div class="button" id = "button10">10</div>
+           <div class="button" id = "button11">11</div>
+           <div class="button" id = "button12">12</div>
+           <div class="button" id = "button13">13</div>
+           <div class="button" id = "button14">14</div>
+           <div class="button" id = "button15">15</div>
+           <div class="button" id = "button16">16</div>
+      </div>
+      <div id="Axes">
+           <progress class="axes" id = "axes0">0</progress>
+           <progress class="axes" id = "axes1">1</progress>
+           <progress class="axes" id = "axes2">2</progress>
+           <progress class="axes" id = "axes3">3</progress>
+           <progress class="axes" id = "axes4">4</progress>
+           <progress class="axes" id = "axes5">5</progress>
+           <progress class="axes" id = "axes6">6</progress>
+           <progress class="axes" id = "axes7">7</progress>
+      </div>
+       <div id="start">Connect and press a button on your gamepad to start</div>
+      <div>
+    </div>
+    <div data-role="footer" data-position="fixed">
+    </div>
+    <div data-role="popup" id="popup_info">
+      <font class="fontSize">
+        <p>Test Purpose: </p>
+        <p>Verifies the GamePad API can receive the signal from GamePad.</p>
+        <p>Test Step: </p>
+          <ol>
+            <li>Connect gamepad to device.</li>
+            <li>Operate different buttons on the gamepad.</li>
+          </ol>
+        <p>Expected Result: </p>
+        <p>Test passes if the different signal can be captured and show on the page.</p>
+      </font>
+    </div>
+  </body>
+</html>

--- a/misc/webapi-usecase-w3c-tests/tests/GamePad/js/gamepadtest.js
+++ b/misc/webapi-usecase-w3c-tests/tests/GamePad/js/gamepadtest.js
@@ -1,0 +1,99 @@
+/*
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Jianfeng <jianfengx.xu@intel.com>
+
+*/
+
+var GAMEPAD = null;
+var rAF = window.requestAnimationFrame;
+
+function gamepadconnect(e) {
+ GAMEPAD = e.gamepad;
+  adddevice(e.gamepad);
+}
+function adddevice(gamepad) {
+  var gameTxt =  "gamepad: " + gamepad.id;
+  document.getElementById("Axes").style.display =  "block";
+  document.getElementById("GamePad").style.display =  "block";
+  document.getElementById("start").innerHTML = gameTxt;
+  for (var i = 0; i < gamepad.buttons.length; i++) {
+    document.getElementById("button" + i).className = "button used";
+  }
+  for (var i = 0; i < gamepad.axes.length; i++) {
+    var e = document.getElementById("axes" + i);
+    e.style.display = "block";
+    e.setAttribute("max", "2");
+    e.setAttribute("value", "1");
+  }
+  refreshStatus();
+}
+
+function disconnecthandler(e) {
+  removegamepad(e.gamepad);
+}
+
+function removegamepad(gamepad) {
+  var d = document.getElementById("controller" + gamepad.index);
+  for (var i = 0; i <= 16 ; i++)
+  {
+     document.getElementById("button" + i).className = "button";
+     if (i < 8)
+     {
+        document.getElementById("axes" + i).style.display = "none";
+     }
+  }
+  document.getElementById("GamePad").style.display =  "none";
+  document.getElementById("Axes").style.display =  "none";
+  document.getElementById("start").innerHTML = "Connect and press a button on your gamepad to start";
+}
+
+function refreshStatus() {
+  for (var i = 0; i < GAMEPAD.buttons.length; i++) {
+    var b = document.getElementById("button" + i);
+    var val = GAMEPAD.buttons[i];
+    var pressed = val == 1.0;
+    if (typeof(val) == "object") {
+      pressed = val.pressed;
+      val = val.value;
+    }
+    if (pressed) {
+      b.className = "button pressed used";
+    } else {
+      b.className = "button used";
+    }
+  }
+  for (var i = 0; i < GAMEPAD.axes.length; i++) {
+    var a = document.getElementById("axes" + i);
+    a.innerHTML = i + ": " + GAMEPAD.axes[i].toFixed(4);
+    a.setAttribute("value", GAMEPAD.axes[i] + 1);
+  }
+  rAF(refreshStatus);
+}
+
+window.addEventListener("gamepadconnected", gamepadconnect);
+window.addEventListener("gamepaddisconnected", disconnecthandler);


### PR DESCRIPTION
Impacted Suites: webapi-sanityapp-w3c-tests
Impacted TCs num: New 1, Update 0, Delete 0
Unit test Platform: Android
Android test result summary: Pass 0, Fail 1, Blocked 0

Comments:
1. The sample app  base on Firefox browser.
2. The spec is not supported in android.

Singed-off-by: Xu, JianfengX jianfengx.xu@intel.com 
