### PR TITLE
[misc-sanity] Remove Hash item from AppURI

### DIFF
--- a/misc/webapi-usecase-w3c-tests/tests/AppURI/index.html
+++ b/misc/webapi-usecase-w3c-tests/tests/AppURI/index.html
@@ -55,10 +55,6 @@ Authors:
         <li>
           <label id="protocol"></label>
         </li>
-        <li data-role="list-divider">Hash</li>
-        <li>
-          <label id="hash"></label>
-        </li>
         <li data-role="list-divider">Origin</li>
         <li>
           <label id="origin"></label>
@@ -76,7 +72,7 @@ Authors:
         <p>Test Purpose: </p>
         <p>Verifies the app uri has the right format.</p>
         <p>Expected Result: </p>
-        <p>Test passes if the structure of AppURI is correct. Protocol, Hash, Origin and Pathname is the correct part of uri.</p>
+        <p>Test passes if the structure of AppURI is correct. Protocol, Origin and Pathname is the correct part of uri.</p>
       </font>
     </div>
   </body>

--- a/misc/webapi-usecase-w3c-tests/tests/AppURI/js/main.js
+++ b/misc/webapi-usecase-w3c-tests/tests/AppURI/js/main.js
@@ -32,7 +32,6 @@ $(document).ready(function () {
     var location = window.location;
     $("#uri").text(location);
     $("#protocol").text(location.protocol);
-    $("#hash").text(location.hash);
     $("#origin").text(location.origin);
     $("#pathname").text(location.pathname);
 });


### PR DESCRIPTION
The URI of AppURI test page in sanity app don't have Hash value, so we remove this item otherwise this item will be none always.
