### PR TITLE
[webapi] Fix security issue form zap scan

### DIFF
--- a/webapi/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/COPYING
+++ b/webapi/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/COPYING
@@ -1,7 +1,8 @@
 This test suite comes from
 https://github.com/w3c/web-platform-tests(commit 96c61ac7c21f7f37526d1c03c4c6087734524130)
-without any modification except necessary adjustment on reference path
-to test harness.
+with some modification:
+1. the necessary adjustment on reference path to test harness.
+2. turn off AUTOCOMPLETE attribute in form input element containing password by using autocomplete="off".
 
 These tests are copyright by W3C and/or the author listed in the test
 file. The tests are dual-licensed under the W3C Test Suite License:

--- a/webapi/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-content.html
+++ b/webapi/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-content.html
@@ -63,7 +63,7 @@
 
 		<form id="attr-value-form1">
 			<input id="attr-value-input1" type="text">
-			<input id="attr-value-input2" type="password">
+			<input id="attr-value-input2" type="password" autocomplete="off"> <!-- set autocomplete to "off" only for web security -->
 			<input id="attr-value-input3" type="hidden">
 			<input id="attr-value-input4" type="radio">
 			<input id="attr-value-input5" type="checkbox">
@@ -243,7 +243,7 @@
 
 	<div id="pseudo-ui">
 		<input id="pseudo-ui-input1" type="text">
-		<input id="pseudo-ui-input2" type="password">
+		<input id="pseudo-ui-input2" type="password" autocomplete="off"> <!-- set autocomplete to "off" only for web security -->
 		<input id="pseudo-ui-input3" type="radio">
 		<input id="pseudo-ui-input4" type="radio" checked="checked">
 		<input id="pseudo-ui-input5" type="checkbox">
@@ -255,7 +255,7 @@
 		<button id="pseudo-ui-button1">Enabled</button>
 
 		<input id="pseudo-ui-input10" disabled="disabled" type="text">
-		<input id="pseudo-ui-input11" disabled="disabled" type="password">
+		<input id="pseudo-ui-input11" disabled="disabled" type="password" autocomplete="off"> <!-- set autocomplete to "off" only for web security -->
 		<input id="pseudo-ui-input12" disabled="disabled" type="radio">
 		<input id="pseudo-ui-input13" disabled="disabled" type="radio" checked="checked">
 		<input id="pseudo-ui-input14" disabled="disabled" type="checkbox">

--- a/webapi/tct-selectorslevel2-w3c-tests/selectorslevel2/w3c/submissions/Opera/level2-content.html
+++ b/webapi/tct-selectorslevel2-w3c-tests/selectorslevel2/w3c/submissions/Opera/level2-content.html
@@ -63,7 +63,7 @@
 
 		<form id="attr-value-form1">
 			<input id="attr-value-input1" type="text">
-			<input id="attr-value-input2" type="password">
+			<input id="attr-value-input2" type="password" autocomplete="off"> <!-- set autocomplete to "off" only for web security -->
 			<input id="attr-value-input3" type="hidden">
 			<input id="attr-value-input4" type="radio">
 			<input id="attr-value-input5" type="checkbox">
@@ -243,7 +243,7 @@
 
 	<div id="pseudo-ui">
 		<input id="pseudo-ui-input1" type="text">
-		<input id="pseudo-ui-input2" type="password">
+		<input id="pseudo-ui-input2" type="password" autocomplete="off"> <!-- set autocomplete to "off" only for web security -->
 		<input id="pseudo-ui-input3" type="radio">
 		<input id="pseudo-ui-input4" type="radio" checked="checked">
 		<input id="pseudo-ui-input5" type="checkbox">
@@ -255,7 +255,7 @@
 		<button id="pseudo-ui-button1">Enabled</button>
 
 		<input id="pseudo-ui-input10" disabled="disabled" type="text">
-		<input id="pseudo-ui-input11" disabled="disabled" type="password">
+		<input id="pseudo-ui-input11" disabled="disabled" type="password" autocomplete="off"> <!-- set autocomplete to "off" only for web security -->
 		<input id="pseudo-ui-input12" disabled="disabled" type="radio">
 		<input id="pseudo-ui-input13" disabled="disabled" type="radio" checked="checked">
 		<input id="pseudo-ui-input14" disabled="disabled" type="checkbox">

--- a/webapi/tct-websocket-w3c-tests/websocket-py/w3c/cookies/support/set-cookie.py
+++ b/webapi/tct-websocket-w3c-tests/websocket-py/w3c/cookies/support/set-cookie.py
@@ -1,5 +1,5 @@
 import urllib
 
 def main(request, response):
-    response.headers.set('Set-Cookie', urllib.unquote(request.url_parts.query))
+    response.headers.set('Set-Cookie', urllib.unquote(request.url_parts.query) + ";httponly")
     return [("Content-Type", "text/plain")], ""


### PR DESCRIPTION
- Set "HttpOnly" to all cookies
- Turn off AUTOCOMPLETE attribute in form input element
  containing password by using autocomplete="off"
