### PR TITLE
[misc-usecase][XWALK-1329] Fix issue for failed to switch to Full Screen mode

### DIFF
--- a/misc/webapi-usecase-w3c-tests/index.html
+++ b/misc/webapi-usecase-w3c-tests/index.html
@@ -69,7 +69,7 @@ Authors:
     </div>
 </div>
 <div data-role="page" id="test_ui">
-    <iframe id="test_frame" width="100%" frameborder="no" border="0" src=""></iframe>
+    <iframe id="test_frame" width="100%" frameborder="no" border="0" src="" allowfullscreen="true"></iframe>
 </div>
 </body>
 </html>


### PR DESCRIPTION
The iframe need to have 'allowfullscreen' attribute, otherwise the iframe can
not enter fullscreen mode

BUG=XWALK-1329
