### PR TITLE
[webapi][XWALK-1745] Refine tests for IVI Speech API

### DIFF
--- a/webapi/webapi-speechapi-ivi-tests/speechapi/Speech_setCBListener_exist.html
+++ b/webapi/webapi-speechapi-ivi-tests/speechapi/Speech_setCBListener_exist.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2014 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Hao, Yunfei <yunfeix.hao@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<title>Speech API: Speech_setCBListener_exist</title>
+<link rel='author' title='Intel' href='http://www.intel.com'>
+<script src="../resources/unitcommon.js"></script>
+<div id="log"></div>
+<script>
+
+  test(function() {
+    // Check if the tizen.speech exists
+    assert_own_property(tizen, "speech", "Tizen should implement speech");
+    // Check if tizen.speech has the setCBListener method
+    assert_true("setCBListener" in tizen.speech, "Speech has setCBListener method");
+    check_method_exists(tizen.speech, "setCBListener");
+  }, "Speech_setCBListener_exist");
+
+</script>

--- a/webapi/webapi-speechapi-ivi-tests/speechapi/Speech_vocalizeString_setCBListener-manual.html
+++ b/webapi/webapi-speechapi-ivi-tests/speechapi/Speech_vocalizeString_setCBListener-manual.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2014 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Hao, Yunfei <yunfeix.hao@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<title>Speech API: vocalizeString and setCBListener</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<meta name="assert" content="Test checks that if vocalizeString and setCBListener work well.">
+<script>
+
+function toggleSTT() {
+  var btn = document.getElementById('btn_stt');
+
+  if (btn.value == 'Record Voice') {
+    btn.value = 'Stop Recording';
+    tizen.speech.setCBListener(function(cmds) {
+      var output = document.getElementById('log');
+
+      var log = 'Found Commands: <br>';
+      for (var i = 0; i < cmds.length; i++) {
+        log += '    ' + cmds[i] + '<br>';
+      }
+      output.innerHTML += log;
+    });
+  } else {
+    tizen.speech.setCBListener(null);
+    btn.value = 'Record Voice';
+  }
+}
+  
+function handleTextToSpeech() {
+  var currentText = document.getElementById("inputText").value;
+  tizen.speech.vocalizeString(currentText);
+}
+
+</script>
+<body>
+  <p>TTS Test: Type in some word in the textbox,then press button "Speak Out".</p>
+  <p>Test Passes if you can hear the word typed in speak out from headset.</p>
+  <p>STT Test: Press "Record Voice", speak to mic some word then click "Stop Recording".</p>
+  <p>Test Passes if "Found Commands: xxx" displayed on the screen.</p>
+
+  <div name="input">
+    <div id="instructionLabel">Type in some text to listen:</div>
+    <input type="text" id="inputText"><br>
+    <input id='btn_say' type='button' onClick='handleTextToSpeech()' value='Speak Out'/>
+  </div>
+  
+  <div id="output">
+    <input id='btn_stt' type='button' onClick='toggleSTT()' value='Record Voice'/>
+    <div id='log'></div>
+  </div>
+</body>

--- a/webapi/webapi-speechapi-ivi-tests/tests.full.xml
+++ b/webapi/webapi-speechapi-ivi-tests/tests.full.xml
@@ -3,71 +3,63 @@
 <test_definition>
   <suite launcher="xwalk" name="webapi-speechapi-ivi-tests" category="WebAPI/IVI">
     <set name="speechapi">
-      <testcase component="WebAPI/IVI/Speech" execution_type="auto" priority="P2" id="SpeechRecognition_constructor_TIVI-950" purpose="Check if constructor of SpeechRecognition work well.">
+      <testcase component="WebAPI/IVI/Speech" execution_type="auto" priority="P2" id="SpeechRecognition_constructor_TIVI-950" purpose="Check if constructor of SpeechRecognition work well." status="designed">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-speechapi-ivi-tests/speechapi/SpeechRecognition_constructor.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/IVI/Speech" execution_type="manual" priority="P1" id="SpeechAPI_MediaPlayer_test_TIVI-950" purpose="Check if web app MediaPlayerbasic supported basic voice commands by SpeechAPI.">
+      <testcase component="WebAPI/IVI/Speech" execution_type="manual" priority="P1" id="Speech_vocalizeString_setCBListener-manual" purpose="Check if tizen Speech API work well." status="approved">
         <description>
-          <pre_condition>1. Make sure there are musics in /opt/usr/media/ with the mp4 type.</pre_condition>
           <steps>
             <step order="1">
-              <step_desc>Plug in a USB microphone (could be a webcam with one built in).</step_desc>
-              <expected>The microphone pluged in.</expected>
+              <step_desc>Plug in a headset.</step_desc>
+              <expected>The headset pluged in.</expected>
             </step>
             <step order="2">
-              <step_desc>Call "pactl list sour ces | grep Name: | grep usb" with app user.</step_desc>
-              <expected>Get the microphone's information output on terminal</expected>
-            </step>
-            <step order="3">
-              <step_desc>Take that output and use it for the "MIKE" line in /etc/sysconfig/speech-recognition.</step_desc>
-              <expected>Modified successfully.</expected>
-            </step>
-            <step order="4">
-              <step_desc>Also add it to the "sphinx.pulsesrc" line of /etc/speech-recognition/speech-recognition.conf.</step_desc>
-              <expected>Modified successfully.</expected>
-            </step>
-            <step order="5">
-              <step_desc>Call "systemctl --user start speech-recognition", this gets the speech recognition daemon running.</step_desc>
+              <step_desc>Enable audio by cmd: "pacmd set-sink-mute 0 false".</step_desc>
               <expected>Success.</expected>
             </step>
+            <step order="3">
+              <step_desc>Type in some text in the textbox to listen, for example "OK".</step_desc>
+              <expected>Success.</expected>
+            </step>
+            <step order="4">
+              <step_desc>Press button "Speak Out".</step_desc>
+              <expected>Hear the word typed in speak out from headset.</expected>
+            </step>
+            <step order="5">
+              <step_desc>Plug in a mic(could be a headset with one built in) .</step_desc>
+              <expected>Pluged in success.</expected>
+            </step>
             <step order="6">
-              <step_desc>Launch MediaPlayer with the command: wrt-launcher -s t8j6HTRpuz.MediaPlayer</step_desc>
-              <expected>The web app MediaPlayer launched.</expected>
+              <step_desc>Press button "Record Voice".</step_desc>
+              <expected>Button turned to "Stop Recording".</expected>
             </step>
             <step order="7">
-              <step_desc>Click the "music" picture.</step_desc>
-              <expected>Music list displayed on the screen.</expected>
+              <step_desc>Speak some words to the mic, for example "OK".</step_desc>
+              <expected>Success.</expected>
             </step>
             <step order="8">
-              <step_desc>Say "play" to the microphone.</step_desc>
-              <expected>Music start to play.</expected>
-            </step>
-            <step order="9">
-              <step_desc>Say "next" to the microphone.</step_desc>
-              <expected>Play the next music.</expected>
-            </step>
-            <step order="10">
-              <step_desc>Say "previous" to the microphone.</step_desc>
-              <expected>Play the previous music.</expected>
-            </step>
-            <step order="11">
-              <step_desc>Say "stop" to the microphone.</step_desc>
-              <expected>Stop to play music.</expected>
+              <step_desc>Press button "Stop Recording".</step_desc>
+              <expected>"Found Commands: OK" displayed on the screen.</expected>
             </step>
           </steps>
-          <test_script_entry test_script_expected_result="0"/>
+          <test_script_entry test_script_expected_result="0">/opt/webapi-speechapi-ivi-tests/speechapi/Speech_vocalizeString_setCBListener-manual.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/IVI/Speech" execution_type="auto" priority="P1" id="Speech_exist" purpose="Check if tizen implemented speech API.">
+      <testcase component="WebAPI/IVI/Speech" execution_type="auto" priority="P1" id="Speech_exist" purpose="Check if tizen implemented speech API." status="approved">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-speechapi-ivi-tests/speechapi/Speech_exist.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/IVI/Speech" execution_type="auto" priority="P1" id="Speech_vocalizeString_exist" purpose="Check if tizen.speech has vocalizeString method.">
+      <testcase component="WebAPI/IVI/Speech" execution_type="auto" priority="P1" id="Speech_vocalizeString_exist" purpose="Check if tizen.speech has vocalizeString method." status="approved">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-speechapi-ivi-tests/speechapi/Speech_vocalizeString_exist.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/IVI/Speech" execution_type="auto" priority="P1" id="Speech_setCBListener_exist" purpose="Check if tizen.speech has setCBListener method." status="approved" >
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/webapi-speechapi-ivi-tests/speechapi/Speech_setCBListener_exist.html</test_script_entry>
         </description>
       </testcase>
     </set>

--- a/webapi/webapi-speechapi-ivi-tests/tests.xml
+++ b/webapi/webapi-speechapi-ivi-tests/tests.xml
@@ -1,63 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="./testcase.xsl" ?>
+<?xml-stylesheet type="text/xsl" href="./testcase.xsl"?>
 <test_definition>
-  <suite launcher="xwalk" name="webapi-speechapi-ivi-tests" category="WebAPI/IVI">
+  <suite category="WebAPI/IVI" launcher="xwalk" name="webapi-speechapi-ivi-tests">
     <set name="speechapi">
-      <testcase component="WebAPI/IVI/Speech" execution_type="auto" id="SpeechRecognition_constructor_TIVI-950" purpose="Check if constructor of SpeechRecognition work well.">
+      <testcase component="WebAPI/IVI/Speech" execution_type="manual" id="Speech_vocalizeString_setCBListener-manual" purpose="Check if tizen Speech API work well.">
         <description>
-          <test_script_entry test_script_expected_result="0">/opt/webapi-speechapi-ivi-tests/speechapi/SpeechRecognition_constructor.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="WebAPI/IVI/Speech" execution_type="manual" id="SpeechAPI_MediaPlayer_test_TIVI-950" purpose="Check if web app MediaPlayerbasic supported basic voice commands by SpeechAPI.">
-        <description>
-          <pre_condition>1. Make sure there are musics in /opt/usr/media/ with the mp4 type.</pre_condition>
           <steps>
             <step order="1">
-              <step_desc>Plug in a USB microphone (could be a webcam with one built in).</step_desc>
-              <expected>The microphone pluged in.</expected>
+              <step_desc>Plug in a headset.</step_desc>
+              <expected>The headset pluged in.</expected>
             </step>
             <step order="2">
-              <step_desc>Call "pactl list sour ces | grep Name: | grep usb" with app user.</step_desc>
-              <expected>Get the microphone's information output on terminal</expected>
-            </step>
-            <step order="3">
-              <step_desc>Take that output and use it for the "MIKE" line in /etc/sysconfig/speech-recognition.</step_desc>
-              <expected>Modified successfully.</expected>
-            </step>
-            <step order="4">
-              <step_desc>Also add it to the "sphinx.pulsesrc" line of /etc/speech-recognition/speech-recognition.conf.</step_desc>
-              <expected>Modified successfully.</expected>
-            </step>
-            <step order="5">
-              <step_desc>Call "systemctl --user start speech-recognition", this gets the speech recognition daemon running.</step_desc>
+              <step_desc>Enable audio by cmd: "pacmd set-sink-mute 0 false".</step_desc>
               <expected>Success.</expected>
             </step>
+            <step order="3">
+              <step_desc>Type in some text in the textbox to listen, for example "OK".</step_desc>
+              <expected>Success.</expected>
+            </step>
+            <step order="4">
+              <step_desc>Press button "Speak Out".</step_desc>
+              <expected>Hear the word typed in speak out from headset.</expected>
+            </step>
+            <step order="5">
+              <step_desc>Plug in a mic(could be a headset with one built in) .</step_desc>
+              <expected>Pluged in success.</expected>
+            </step>
             <step order="6">
-              <step_desc>Launch MediaPlayer with the command: wrt-launcher -s t8j6HTRpuz.MediaPlayer</step_desc>
-              <expected>The web app MediaPlayer launched.</expected>
+              <step_desc>Press button "Record Voice".</step_desc>
+              <expected>Button turned to "Stop Recording".</expected>
             </step>
             <step order="7">
-              <step_desc>Click the "music" picture.</step_desc>
-              <expected>Music list displayed on the screen.</expected>
+              <step_desc>Speak some words to the mic, for example "OK".</step_desc>
+              <expected>Success.</expected>
             </step>
             <step order="8">
-              <step_desc>Say "play" to the microphone.</step_desc>
-              <expected>Music start to play.</expected>
-            </step>
-            <step order="9">
-              <step_desc>Say "next" to the microphone.</step_desc>
-              <expected>Play the next music.</expected>
-            </step>
-            <step order="10">
-              <step_desc>Say "previous" to the microphone.</step_desc>
-              <expected>Play the previous music.</expected>
-            </step>
-            <step order="11">
-              <step_desc>Say "stop" to the microphone.</step_desc>
-              <expected>Stop to play music.</expected>
+              <step_desc>Press button "Stop Recording".</step_desc>
+              <expected>"Found Commands: OK" displayed on the screen.</expected>
             </step>
           </steps>
-          <test_script_entry test_script_expected_result="0"/>
+          <test_script_entry test_script_expected_result="0">/opt/webapi-speechapi-ivi-tests/speechapi/Speech_vocalizeString_setCBListener-manual.html</test_script_entry>
         </description>
       </testcase>
       <testcase component="WebAPI/IVI/Speech" execution_type="auto" id="Speech_exist" purpose="Check if tizen implemented speech API.">
@@ -68,6 +50,11 @@
       <testcase component="WebAPI/IVI/Speech" execution_type="auto" id="Speech_vocalizeString_exist" purpose="Check if tizen.speech has vocalizeString method.">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/webapi-speechapi-ivi-tests/speechapi/Speech_vocalizeString_exist.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/IVI/Speech" execution_type="auto" id="Speech_setCBListener_exist" purpose="Check if tizen.speech has setCBListener method.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/webapi-speechapi-ivi-tests/speechapi/Speech_setCBListener_exist.html</test_script_entry>
         </description>
       </testcase>
     </set>


### PR DESCRIPTION
- Add a test Speech_setCBListener_exist.
- Create a usage test file Speech_vocalizeString_setCBListener-manual.html by using API directly rather than "MediaPlayer" widget which was removed from ELF image.
- Move back a test file SpeechRecognition_constructor.html to "designed" because this API is not supported yet.

Impacted tests (arrpoved): new 4, update 0, delete 1
Unit test Platform: Tizen IVI
Unit test result summary: pass 3, fail 1, blocked 0
