### PR TITLE
[webapi][XWALK-1909] Fix the wrong path of case entry when running webapi/background

### DIFF
--- a/webapi/tct-backgrounds-css3-tests/tests.xml
+++ b/webapi/tct-backgrounds-css3-tests/tests.xml
@@ -2680,7 +2680,7 @@
         </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Backgrounds and Borders Module Level 3 (Partial)" execution_type="manual" id="background-012" purpose="Check if background with (image attachment) display correctly in visual">
         <description>
-          <test_script_entry>/opt/tct-backgrounds-css3-tests/backgrounds/csswg/background-012.htm</test_script_entry>
+          <test_script_entry>/opt/tct-backgrounds-css3-tests/backgrounds/csswg/background-012-manual.htm</test_script_entry>
         </description>
         </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Backgrounds and Borders Module Level 3 (Partial)" execution_type="manual" id="background-013" purpose="Check if background with (image position) display correctly in visual">
@@ -2725,7 +2725,7 @@
         </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Backgrounds and Borders Module Level 3 (Partial)" execution_type="manual" id="background-021" purpose="Check if background with (attachment position) display correctly in visual">
         <description>
-          <test_script_entry>/opt/tct-backgrounds-css3-tests/backgrounds/csswg/background-021-manual.htm</test_script_entry>
+          <test_script_entry>/opt/tct-backgrounds-css3-tests/backgrounds/csswg/background-021.htm</test_script_entry>
         </description>
         </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Backgrounds and Borders Module Level 3 (Partial)" execution_type="manual" id="background-022" purpose="Check if background with (position color) display correctly in visual">


### PR DESCRIPTION
Impacted tests(approved): New 0, Update 2, Delete 0
Unit test platform: [Android]
Unit test result summary: Pass 2, Fail 0, Block 0
