### PR TITLE
[webapi][XWALK-1940]Fix bug by removing show method for notification

### DIFF
--- a/webapi/tct-notification-w3c-tests/notification/notification_body-manual.html
+++ b/webapi/tct-notification-w3c-tests/notification/notification_body-manual.html
@@ -44,7 +44,6 @@ Authors:
     <p>Test passes if the notification body content is "Room 101".</p>
     <script>
         getnotification();
-        notification.show();
     </script>
   </body>
 </html>

--- a/webapi/tct-notification-w3c-tests/notification/notification_tag-manual.html
+++ b/webapi/tct-notification-w3c-tests/notification/notification_tag-manual.html
@@ -50,7 +50,6 @@ Authors:
                        {
                            tag: 'message1'
                        });
-        notification.show();
         var notification2 = typeof Notification != "undefined" ?
                        new Notification("New Email Received",
                        {
@@ -60,7 +59,6 @@ Authors:
                        {
                            tag: 'message1'
                        });
-        notification2.show();
     </script>
   </body>
 </html>

--- a/webapi/tct-notification-w3c-tests/notification/onshow_using.html
+++ b/webapi/tct-notification-w3c-tests/notification/onshow_using.html
@@ -46,7 +46,6 @@ Authors:
       t = async_test(document.title, { timeout: 3000 });
       t.step(function () {
         getnotification();
-        notification.show();
       });
 
       notification.onshow = function() {


### PR DESCRIPTION
- notification spec show() method have been removed.

Impacted TCs num(approved): New 0, Update 2, Delete 0
Unit test Platform: Tizen IVI
Andriod test result summary: Pass 2, Fail 0, Blocked 0
