### PR TITLE
[webapi][XWALK-1871] Replace picture URL in presentation

### DIFF
--- a/webapi/webapi-presentation-xwalk-tests/presentation/presentation_secondary_page_image/index.html
+++ b/webapi/webapi-presentation-xwalk-tests/presentation/presentation_secondary_page_image/index.html
@@ -49,7 +49,7 @@ Authors:
       var presentationWindow = null;
       function onsuccess(w) {
         presentationWindow = w;
-        w.postMessage("http://test.csswg.org/source/approved/support/cat.png", "*");
+        w.postMessage("http://test.csswg.org/source/support/cat.png", "*");
       }
 
       function onerror(error) {


### PR DESCRIPTION
-Old pictrue URL now is invalid, so replace it.

Impacted TCs num(approved): New 0, Update 1, Delete 0
Unit test Platform: Android
Android test result summary: Pass 1, Fail 0, Blocked 0
