### PR TITLE
[wrt] Update TCs for XWALK-1792

### DIFF
--- a/wrt/wrt-autohost-tizen-tests/autohost/Crosswalk_Tizen_Packaging_Tool_Install_test.sh
+++ b/wrt/wrt-autohost-tizen-tests/autohost/Crosswalk_Tizen_Packaging_Tool_Install_test.sh
@@ -46,7 +46,7 @@ echo "APP=$APP_NAME"
 
 function_creat_xpk $logName
 
-function_install_xwalk $logName
+#function_install_xwalk $logName
 
 #push xpk to device
 sdb shell "[ -e /$APP_NAME.xpk ] && rm -rf $APP_NAME.xpk"

--- a/wrt/wrt-autohost-tizen-tests/tests.full.xml
+++ b/wrt/wrt-autohost-tizen-tests/tests.full.xml
@@ -7,21 +7,21 @@
         <description>
           <pre_condition>
           </pre_condition>
-          <test_script_entry test_script_expected_result="0">app_user@/opt/wrt-autohost-tizen-tests/autohost/Crosswalk_Tizen_Packaging_Tool_Create_test.sh</test_script_entry>
+          <test_script_entry test_script_expected_result="0">/opt/wrt-autohost-tizen-tests/autohost/Crosswalk_Tizen_Packaging_Tool_Create_test.sh</test_script_entry>
         </description>
         </testcase>
       <testcase purpose="Check crosswalk packed app could be installed successfully" type="Functional" status="approved" component="Crosswalk/Runtime/Basicfeature" execution_type="auto" priority="P1" id="Crosswalk_Tizen_Packaging_Tool_Install_test">
         <description>
           <pre_condition>
           </pre_condition>
-          <test_script_entry test_script_expected_result="0">app_user@/opt/wrt-autohost-tizen-tests/autohost/Crosswalk_Tizen_Packaging_Tool_Install_test.sh</test_script_entry>
+          <test_script_entry test_script_expected_result="0">/opt/wrt-autohost-tizen-tests/autohost/Crosswalk_Tizen_Packaging_Tool_Install_test.sh</test_script_entry>
         </description>
         </testcase>
         <testcase purpose="Check crosswalk packed app could be uninstalled successfully" type="Functional" status="approved" component="Crosswalk/Runtime/Basicfeature" execution_type="auto" priority="P1" id="Crosswalk_Tizen_Packaging_Tool_Uninstall_test">
         <description>
           <pre_condition>
           </pre_condition>
-          <test_script_entry test_script_expected_result="0">app_user@/opt/wrt-autohost-tizen-tests/autohost/Crosswalk_Tizen_Packaging_Tool_Uninstall_test.sh</test_script_entry>
+          <test_script_entry test_script_expected_result="0">/opt/wrt-autohost-tizen-tests/autohost/Crosswalk_Tizen_Packaging_Tool_Uninstall_test.sh</test_script_entry>
         </description>
       </testcase>
     </set>

--- a/wrt/wrt-autohost-tizen-tests/tests.xml
+++ b/wrt/wrt-autohost-tizen-tests/tests.xml
@@ -5,17 +5,17 @@
     <set name="tizen">
       <testcase component="Crosswalk/Runtime/Basicfeature" execution_type="auto" id="Crosswalk_Tizen_Packaging_Tool_Create_test" purpose="Check crosswalk packer could be create web app successfully">
         <description>
-          <test_script_entry test_script_expected_result="0">app_user@/opt/wrt-autohost-tizen-tests/autohost/Crosswalk_Tizen_Packaging_Tool_Create_test.sh</test_script_entry>
+          <test_script_entry test_script_expected_result="0">/opt/wrt-autohost-tizen-tests/autohost/Crosswalk_Tizen_Packaging_Tool_Create_test.sh</test_script_entry>
         </description>
       </testcase>
       <testcase component="Crosswalk/Runtime/Basicfeature" execution_type="auto" id="Crosswalk_Tizen_Packaging_Tool_Install_test" purpose="Check crosswalk packed app could be installed successfully">
         <description>
-          <test_script_entry test_script_expected_result="0">app_user@/opt/wrt-autohost-tizen-tests/autohost/Crosswalk_Tizen_Packaging_Tool_Install_test.sh</test_script_entry>
+          <test_script_entry test_script_expected_result="0">/opt/wrt-autohost-tizen-tests/autohost/Crosswalk_Tizen_Packaging_Tool_Install_test.sh</test_script_entry>
         </description>
       </testcase>
       <testcase component="Crosswalk/Runtime/Basicfeature" execution_type="auto" id="Crosswalk_Tizen_Packaging_Tool_Uninstall_test" purpose="Check crosswalk packed app could be uninstalled successfully">
         <description>
-          <test_script_entry test_script_expected_result="0">app_user@/opt/wrt-autohost-tizen-tests/autohost/Crosswalk_Tizen_Packaging_Tool_Uninstall_test.sh</test_script_entry>
+          <test_script_entry test_script_expected_result="0">/opt/wrt-autohost-tizen-tests/autohost/Crosswalk_Tizen_Packaging_Tool_Uninstall_test.sh</test_script_entry>
         </description>
       </testcase>
     </set>


### PR DESCRIPTION
Impacted TC num(approved): New 0, Update 3, Delete 0
Unit test platform:  tizen ivi
Unit test result summary: Pass 1, Fail 2, Block 0
Fail reason: root user is default on ivi group 'root' not allowed, so use "sdb shell xwalkctl --install xxx.xpk" can't install app,
