### PR TITLE
[webapi][XWALK-990]Change 16 TCs stauts to approved

### DIFF
--- a/webapi/tct-application-tizen-tests/tests.full.xml
+++ b/webapi/tct-application-tizen-tests/tests.full.xml
@@ -1233,7 +1233,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check using kill method (with non-optional arguments) in ApplicationManager interface" type="compliance" onload_delay="30" status="designed" component="TizenAPI/Application/Application" execution_type="auto" priority="P1" id="ApplicationManager_kill">
+      <testcase purpose="Check using kill method (with non-optional arguments) in ApplicationManager interface" type="compliance" onload_delay="30" status="approved" component="TizenAPI/Application/Application" execution_type="auto" priority="P1" id="ApplicationManager_kill">
         <description>
           <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_kill.html</test_script_entry>
         </description>
@@ -1245,7 +1245,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check optional argument 'onError' (kill) type conversion" type="compliance" onload_delay="30" status="designed" component="TizenAPI/Application/Application" execution_type="auto" priority="P2" id="ApplicationManager_kill_errorCallback_TypeMismatch">
+      <testcase purpose="Check optional argument 'onError' (kill) type conversion" type="compliance" onload_delay="30" status="approved" component="TizenAPI/Application/Application" execution_type="auto" priority="P2" id="ApplicationManager_kill_errorCallback_TypeMismatch">
         <description>
           <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_kill_errorCallback_TypeMismatch.html</test_script_entry>
         </description>
@@ -1257,7 +1257,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if an exception was thrown when a fake callback (onError) was passed into kill method" type="compliance" onload_delay="30" status="designed" component="TizenAPI/Application/Application" execution_type="auto" priority="P2" id="ApplicationManager_kill_errorCallback_invalid_cb">
+      <testcase purpose="Check if an exception was thrown when a fake callback (onError) was passed into kill method" type="compliance" onload_delay="30" status="approved" component="TizenAPI/Application/Application" execution_type="auto" priority="P2" id="ApplicationManager_kill_errorCallback_invalid_cb">
         <description>
           <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_kill_errorCallback_invalid_cb.html</test_script_entry>
         </description>
@@ -1269,7 +1269,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if method kill exist" type="compliance" status="designed" component="TizenAPI/Application/Application" execution_type="auto" priority="P1" id="ApplicationManager_kill_exist">
+      <testcase purpose="Check if method kill exist" type="compliance" status="approved" component="TizenAPI/Application/Application" execution_type="auto" priority="P1" id="ApplicationManager_kill_exist">
         <description>
           <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_kill_exist.html</test_script_entry>
         </description>
@@ -1281,7 +1281,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check optional argument 'onSuccess' (kill) type conversion" type="compliance" onload_delay="30" status="designed" component="TizenAPI/Application/Application" execution_type="auto" priority="P2" id="ApplicationManager_kill_successCallback_TypeMismatch">
+      <testcase purpose="Check optional argument 'onSuccess' (kill) type conversion" type="compliance" onload_delay="30" status="approved" component="TizenAPI/Application/Application" execution_type="auto" priority="P2" id="ApplicationManager_kill_successCallback_TypeMismatch">
         <description>
           <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_kill_successCallback_TypeMismatch.html</test_script_entry>
         </description>
@@ -1293,7 +1293,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if an exception was thrown when a fake callback (onSuccess) was passed into kill method" type="compliance" onload_delay="30" status="designed" component="TizenAPI/Application/Application" execution_type="auto" priority="P2" id="ApplicationManager_kill_successCallback_invalid_cb">
+      <testcase purpose="Check if an exception was thrown when a fake callback (onSuccess) was passed into kill method" type="compliance" onload_delay="30" status="approved" component="TizenAPI/Application/Application" execution_type="auto" priority="P2" id="ApplicationManager_kill_successCallback_invalid_cb">
         <description>
           <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_kill_successCallback_invalid_cb.html</test_script_entry>
         </description>
@@ -1305,7 +1305,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check using kill method (with optional argument errorCallback) in ApplicationManager interface" type="compliance" onload_delay="30" status="designed" component="TizenAPI/Application/Application" execution_type="auto" priority="P1" id="ApplicationManager_kill_with_errorCallback">
+      <testcase purpose="Check using kill method (with optional argument errorCallback) in ApplicationManager interface" type="compliance" onload_delay="30" status="approved" component="TizenAPI/Application/Application" execution_type="auto" priority="P1" id="ApplicationManager_kill_with_errorCallback">
         <description>
           <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_kill_with_errorCallback.html</test_script_entry>
         </description>
@@ -1317,7 +1317,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check using kill method (with optional argument successCallback) in ApplicationManager interface" type="compliance" onload_delay="30" status="designed" component="TizenAPI/Application/Application" execution_type="auto" priority="P1" id="ApplicationManager_kill_with_successCallback">
+      <testcase purpose="Check using kill method (with optional argument successCallback) in ApplicationManager interface" type="compliance" onload_delay="30" status="approved" component="TizenAPI/Application/Application" execution_type="auto" priority="P1" id="ApplicationManager_kill_with_successCallback">
         <description>
           <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_kill_with_successCallback.html</test_script_entry>
         </description>
@@ -1329,7 +1329,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check using launch method (with non-optional arguments) in ApplicationManager interface" type="compliance" onload_delay="30" status="designed" component="TizenAPI/Application/Application" execution_type="auto" priority="P1" id="ApplicationManager_launch">
+      <testcase purpose="Check using launch method (with non-optional arguments) in ApplicationManager interface" type="compliance" onload_delay="30" status="approved" component="TizenAPI/Application/Application" execution_type="auto" priority="P1" id="ApplicationManager_launch">
         <description>
           <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_launch.html</test_script_entry>
         </description>
@@ -1557,7 +1557,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check optional argument 'onError' (launch) type conversion" type="compliance" onload_delay="30" status="designed" component="TizenAPI/Application/Application" execution_type="auto" priority="P2" id="ApplicationManager_launch_errorCallback_TypeMismatch">
+      <testcase purpose="Check optional argument 'onError' (launch) type conversion" type="compliance" onload_delay="30" status="approved" component="TizenAPI/Application/Application" execution_type="auto" priority="P2" id="ApplicationManager_launch_errorCallback_TypeMismatch">
         <description>
           <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_launch_errorCallback_TypeMismatch.html</test_script_entry>
         </description>
@@ -1569,7 +1569,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if an exception was thrown when a fake callback (on error) was passed" type="compliance" onload_delay="30" status="designed" component="TizenAPI/Application/Application" execution_type="auto" priority="P2" id="ApplicationManager_launch_errorCallback_invalid_cb">
+      <testcase purpose="Check if an exception was thrown when a fake callback (on error) was passed" type="compliance" onload_delay="30" status="approved" component="TizenAPI/Application/Application" execution_type="auto" priority="P2" id="ApplicationManager_launch_errorCallback_invalid_cb">
         <description>
           <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_launch_errorCallback_invalid_cb.html</test_script_entry>
         </description>
@@ -1581,7 +1581,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if method launch exist" type="compliance" status="designed" component="TizenAPI/Application/Application" execution_type="auto" priority="P1" id="ApplicationManager_launch_exist">
+      <testcase purpose="Check if method launch exist" type="compliance" status="approved" component="TizenAPI/Application/Application" execution_type="auto" priority="P1" id="ApplicationManager_launch_exist">
         <description>
           <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_launch_exist.html</test_script_entry>
         </description>
@@ -1593,7 +1593,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check optional argument 'onSuccess' (launch) type conversion" type="compliance" onload_delay="30" status="designed" component="TizenAPI/Application/Application" execution_type="auto" priority="P2" id="ApplicationManager_launch_successCallback_TypeMismatch">
+      <testcase purpose="Check optional argument 'onSuccess' (launch) type conversion" type="compliance" onload_delay="30" status="approved" component="TizenAPI/Application/Application" execution_type="auto" priority="P2" id="ApplicationManager_launch_successCallback_TypeMismatch">
         <description>
           <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_launch_successCallback_TypeMismatch.html</test_script_entry>
         </description>
@@ -1605,7 +1605,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if an exception was thrown when a fake callback (on success) was passed" type="compliance" onload_delay="30" status="designed" component="TizenAPI/Application/Application" execution_type="auto" priority="P2" id="ApplicationManager_launch_successCallback_invalid_cb">
+      <testcase purpose="Check if an exception was thrown when a fake callback (on success) was passed" type="compliance" onload_delay="30" status="approved" component="TizenAPI/Application/Application" execution_type="auto" priority="P2" id="ApplicationManager_launch_successCallback_invalid_cb">
         <description>
           <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_launch_successCallback_invalid_cb.html</test_script_entry>
         </description>
@@ -1617,7 +1617,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check using launch method (with optional argument errorCallback) in ApplicationManager interface" type="compliance" onload_delay="30" status="designed" component="TizenAPI/Application/Application" execution_type="auto" priority="P1" id="ApplicationManager_launch_with_errorCallback">
+      <testcase purpose="Check using launch method (with optional argument errorCallback) in ApplicationManager interface" type="compliance" onload_delay="30" status="approved" component="TizenAPI/Application/Application" execution_type="auto" priority="P1" id="ApplicationManager_launch_with_errorCallback">
         <description>
           <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_launch_with_errorCallback.html</test_script_entry>
         </description>
@@ -1629,7 +1629,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check using launch method (with optional argument successCallback) in ApplicationManager interface" type="compliance" onload_delay="30" status="designed" component="TizenAPI/Application/Application" execution_type="auto" priority="P1" id="ApplicationManager_launch_with_successCallback">
+      <testcase purpose="Check using launch method (with optional argument successCallback) in ApplicationManager interface" type="compliance" onload_delay="30" status="approved" component="TizenAPI/Application/Application" execution_type="auto" priority="P1" id="ApplicationManager_launch_with_successCallback">
         <description>
           <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_launch_with_successCallback.html</test_script_entry>
         </description>
@@ -1749,7 +1749,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check using exit method (with non-optional arguments) in Application interface" type="compliance" onload_delay="30" status="approved" component="TizenAPI/Application/Application" execution_type="auto" priority="P1" id="Application_exit">
+      <testcase purpose="Check using exit method (with non-optional arguments) in Application interface" type="compliance" onload_delay="30" status="designed" component="TizenAPI/Application/Application" execution_type="auto" priority="P1" id="Application_exit">
         <description>
           <test_script_entry>/opt/tct-application-tizen-tests/application/Application_exit.html</test_script_entry>
         </description>
@@ -1821,7 +1821,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check using hide method (with non-optional arguments) in Application interface" type="compliance" onload_delay="30" status="approved" component="TizenAPI/Application/Application" execution_type="auto" priority="P1" id="Application_hide">
+      <testcase purpose="Check using hide method (with non-optional arguments) in Application interface" type="compliance" onload_delay="30" status="designed" component="TizenAPI/Application/Application" execution_type="auto" priority="P1" id="Application_hide">
         <description>
           <test_script_entry>/opt/tct-application-tizen-tests/application/Application_hide.html</test_script_entry>
         </description>
@@ -1845,7 +1845,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check using hide method (with extra arguments) in Application interface" type="compliance" onload_delay="30" status="approved" component="TizenAPI/Application/Application" execution_type="auto" priority="P1" id="Application_hide_extra_argument">
+      <testcase purpose="Check using hide method (with extra arguments) in Application interface" type="compliance" onload_delay="30" status="designed" component="TizenAPI/Application/Application" execution_type="auto" priority="P1" id="Application_hide_extra_argument">
         <description>
           <test_script_entry>/opt/tct-application-tizen-tests/application/Application_hide_extra_argument.html</test_script_entry>
         </description>

--- a/webapi/tct-application-tizen-tests/tests.xml
+++ b/webapi/tct-application-tizen-tests/tests.xml
@@ -330,6 +330,86 @@
           <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_in_tizen.html</test_script_entry>
         </description>
       </testcase>
+      <testcase component="TizenAPI/Application/Application" execution_type="auto" id="ApplicationManager_kill" onload_delay="30" purpose="Check using kill method (with non-optional arguments) in ApplicationManager interface">
+        <description>
+          <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_kill.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="TizenAPI/Application/Application" execution_type="auto" id="ApplicationManager_kill_errorCallback_TypeMismatch" onload_delay="30" purpose="Check optional argument 'onError' (kill) type conversion">
+        <description>
+          <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_kill_errorCallback_TypeMismatch.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="TizenAPI/Application/Application" execution_type="auto" id="ApplicationManager_kill_errorCallback_invalid_cb" onload_delay="30" purpose="Check if an exception was thrown when a fake callback (onError) was passed into kill method">
+        <description>
+          <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_kill_errorCallback_invalid_cb.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="TizenAPI/Application/Application" execution_type="auto" id="ApplicationManager_kill_exist" purpose="Check if method kill exist">
+        <description>
+          <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_kill_exist.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="TizenAPI/Application/Application" execution_type="auto" id="ApplicationManager_kill_successCallback_TypeMismatch" onload_delay="30" purpose="Check optional argument 'onSuccess' (kill) type conversion">
+        <description>
+          <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_kill_successCallback_TypeMismatch.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="TizenAPI/Application/Application" execution_type="auto" id="ApplicationManager_kill_successCallback_invalid_cb" onload_delay="30" purpose="Check if an exception was thrown when a fake callback (onSuccess) was passed into kill method">
+        <description>
+          <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_kill_successCallback_invalid_cb.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="TizenAPI/Application/Application" execution_type="auto" id="ApplicationManager_kill_with_errorCallback" onload_delay="30" purpose="Check using kill method (with optional argument errorCallback) in ApplicationManager interface">
+        <description>
+          <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_kill_with_errorCallback.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="TizenAPI/Application/Application" execution_type="auto" id="ApplicationManager_kill_with_successCallback" onload_delay="30" purpose="Check using kill method (with optional argument successCallback) in ApplicationManager interface">
+        <description>
+          <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_kill_with_successCallback.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="TizenAPI/Application/Application" execution_type="auto" id="ApplicationManager_launch" onload_delay="30" purpose="Check using launch method (with non-optional arguments) in ApplicationManager interface">
+        <description>
+          <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_launch.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="TizenAPI/Application/Application" execution_type="auto" id="ApplicationManager_launch_errorCallback_TypeMismatch" onload_delay="30" purpose="Check optional argument 'onError' (launch) type conversion">
+        <description>
+          <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_launch_errorCallback_TypeMismatch.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="TizenAPI/Application/Application" execution_type="auto" id="ApplicationManager_launch_errorCallback_invalid_cb" onload_delay="30" purpose="Check if an exception was thrown when a fake callback (on error) was passed">
+        <description>
+          <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_launch_errorCallback_invalid_cb.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="TizenAPI/Application/Application" execution_type="auto" id="ApplicationManager_launch_exist" purpose="Check if method launch exist">
+        <description>
+          <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_launch_exist.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="TizenAPI/Application/Application" execution_type="auto" id="ApplicationManager_launch_successCallback_TypeMismatch" onload_delay="30" purpose="Check optional argument 'onSuccess' (launch) type conversion">
+        <description>
+          <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_launch_successCallback_TypeMismatch.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="TizenAPI/Application/Application" execution_type="auto" id="ApplicationManager_launch_successCallback_invalid_cb" onload_delay="30" purpose="Check if an exception was thrown when a fake callback (on success) was passed">
+        <description>
+          <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_launch_successCallback_invalid_cb.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="TizenAPI/Application/Application" execution_type="auto" id="ApplicationManager_launch_with_errorCallback" onload_delay="30" purpose="Check using launch method (with optional argument errorCallback) in ApplicationManager interface">
+        <description>
+          <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_launch_with_errorCallback.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="TizenAPI/Application/Application" execution_type="auto" id="ApplicationManager_launch_with_successCallback" onload_delay="30" purpose="Check using launch method (with optional argument successCallback) in ApplicationManager interface">
+        <description>
+          <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_launch_with_successCallback.html</test_script_entry>
+        </description>
+      </testcase>
       <testcase component="TizenAPI/Application/Application" execution_type="auto" id="ApplicationManager_notexist" purpose="Check if ApplicationManager notexist">
         <description>
           <test_script_entry>/opt/tct-application-tizen-tests/application/ApplicationManager_notexist.html</test_script_entry>
@@ -345,11 +425,6 @@
           <test_script_entry>/opt/tct-application-tizen-tests/application/Application_appInfo_attribute.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="TizenAPI/Application/Application" execution_type="auto" id="Application_exit" onload_delay="30" purpose="Check using exit method (with non-optional arguments) in Application interface">
-        <description>
-          <test_script_entry>/opt/tct-application-tizen-tests/application/Application_exit.html</test_script_entry>
-        </description>
-      </testcase>
       <testcase component="TizenAPI/Application/Application" execution_type="auto" id="Application_exit_exist" purpose="Check if method Application.exit exist">
         <description>
           <test_script_entry>/opt/tct-application-tizen-tests/application/Application_exit_exist.html</test_script_entry>
@@ -360,19 +435,9 @@
           <test_script_entry>/opt/tct-application-tizen-tests/application/Application_extend.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="TizenAPI/Application/Application" execution_type="auto" id="Application_hide" onload_delay="30" purpose="Check using hide method (with non-optional arguments) in Application interface">
-        <description>
-          <test_script_entry>/opt/tct-application-tizen-tests/application/Application_hide.html</test_script_entry>
-        </description>
-      </testcase>
       <testcase component="TizenAPI/Application/Application" execution_type="auto" id="Application_hide_exist" purpose="Check if method Application.hide exist">
         <description>
           <test_script_entry>/opt/tct-application-tizen-tests/application/Application_hide_exist.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="TizenAPI/Application/Application" execution_type="auto" id="Application_hide_extra_argument" onload_delay="30" purpose="Check using hide method (with extra arguments) in Application interface">
-        <description>
-          <test_script_entry>/opt/tct-application-tizen-tests/application/Application_hide_extra_argument.html</test_script_entry>
         </description>
       </testcase>
       <testcase component="TizenAPI/Application/Application" execution_type="auto" id="Application_notexist" purpose="Check if Application notexist">


### PR DESCRIPTION
- Fail Reason: The app id is wrong, error callback is invoked.

Impacted TCs num(approved): New 16, Update 0, Delete 0
Unit test Platform: [Tizen-IVI]
Test result summary: Pass 2, Fail 14, Blocked 0
