### PR TITLE
[webapi][XWALK-893] Add 6 Tcs and update 24 Tcs for iap

### DIFF
--- a/webapi/webapi-iap-xwalk-tests/iap/IAPProduct.html
+++ b/webapi/webapi-iap-xwalk-tests/iap/IAPProduct.html
@@ -41,7 +41,10 @@ Authors:
 
 setup({explicit_done: true});
 
-navigator.iap.queryProductDetails(["gas"]).then(
+var key = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsEVjLWKJ5B7EKjnH5NVx4eh83xntg1WXFIQhLXgtmiCU0Ro27dN8Q7Q5HIif4ugkFcQWFhlDC/WsliDKtLZQkadmS1sUweOanIo5+ZbNaQ1ITWwtkNdnPb+tRJCjhngft1hFIfLGsKrBMxS8slaWaQ537wgex74Pv5mxuQLhsFyei5GffzDQDz4KN6sQHPqtB+GLDWqKKk2bdAiopQRFRUwYR8edAYcHiMHHZSfidOjaYD1/timhFIUnwFihtvNy4K7OStjoy6kEwCmX9/zXS3SxKkOfk2bNg/Edc8xgym8GkfObUliySSNxS9ukzp1ShDuSjdwfJVt5mvmXk+7jiQIDAQAB';
+iap.init(key);
+
+iap.queryProductDetails(["gas", "yearly", "premium"]).then(
 function(products) {
   [
     //attributes of the IAPProduct interface

--- a/webapi/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html
+++ b/webapi/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html
@@ -41,21 +41,22 @@ Authors:
 
 setup({explicit_done: true});
 
-navigator.iap.purchase("gas").then(
+var key = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsEVjLWKJ5B7EKjnH5NVx4eh83xntg1WXFIQhLXgtmiCU0Ro27dN8Q7Q5HIif4ugkFcQWFhlDC/WsliDKtLZQkadmS1sUweOanIo5+ZbNaQ1ITWwtkNdnPb+tRJCjhngft1hFIfLGsKrBMxS8slaWaQ537wgex74Pv5mxuQLhsFyei5GffzDQDz4KN6sQHPqtB+GLDWqKKk2bdAiopQRFRUwYR8edAYcHiMHHZSfidOjaYD1/timhFIUnwFihtvNy4K7OStjoy6kEwCmX9/zXS3SxKkOfk2bNg/Edc8xgym8GkfObUliySSNxS9ukzp1ShDuSjdwfJVt5mvmXk+7jiQIDAQAB';
+iap.init(key);
+
+iap.buy("gas").then(
 function(transaction) {
   [
     //attributes of the IAPTransactionDetails interface
-    ["string", "id"],
-    ["number", "time"],
-    ["string", "token"]
+    ["orderId"], ["packageName"], ["productId"],
+    ["purchaseTime"], ["purchaseState"], ["token"]
   ].forEach(function(attr) {
-    var type = attr[0];
-    var name = attr[1];
+    var name = attr[0];
 
     test(function () {
       assert_true(name in transaction, name + " attribute in IAPTransactionDetails");
-      assert_equals(typeof transaction[name], type, name + " attribute of type");
-    }, "Check if IAPTransactionDetails." + name + " exists and type of " + type);
+      assert_equals(typeof transaction[name], "string", name + " attribute of type");
+    }, "Check if IAPTransactionDetails." + name + " exists and type of " + string);
 
     test(function () {
       assert_not_equals(transaction[name], null, name + " attribute of IAPTransactionDetails");

--- a/webapi/webapi-iap-xwalk-tests/iap/InAppPurchase.html
+++ b/webapi/webapi-iap-xwalk-tests/iap/InAppPurchase.html
@@ -39,23 +39,26 @@ Authors:
 <div id="log"></div>
 <script>
 
+var key = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsEVjLWKJ5B7EKjnH5NVx4eh83xntg1WXFIQhLXgtmiCU0Ro27dN8Q7Q5HIif4ugkFcQWFhlDC/WsliDKtLZQkadmS1sUweOanIo5+ZbNaQ1ITWwtkNdnPb+tRJCjhngft1hFIfLGsKrBMxS8slaWaQ537wgex74Pv5mxuQLhsFyei5GffzDQDz4KN6sQHPqtB+GLDWqKKk2bdAiopQRFRUwYR8edAYcHiMHHZSfidOjaYD1/timhFIUnwFihtvNy4K7OStjoy6kEwCmX9/zXS3SxKkOfk2bNg/Edc8xgym8GkfObUliySSNxS9ukzp1ShDuSjdwfJVt5mvmXk+7jiQIDAQAB';
+iap.init(key);
+
 [
   //attributes of the InAppPurchase interface
   ["function", "queryProductDetails"],
-  ["function", "purchase"],
+  ["function", "buy"],
   ["function", "restore"]
 ].forEach(function(attr) {
   var type = attr[0];
   var name = attr[1];
 
   test(function () {
-    assert_true(name in Navigator.iap, name + " attribute in InAppPurchase");
-    assert_equals(typeof Navigator.iap[name], type, name + " attribute of type");
+    assert_true(name in iap, name + " attribute in InAppPurchase");
+    assert_equals(typeof iap[name], type, name + " attribute of type");
   }, "Check if InAppPurchase." + name + " exists and type of " + type);
 });
 
 test(function () {
-  navigator.iap.queryProductDetails(["gas"]).then(
+  iap.queryProductDetails(["gas", "yearly", "premium"]).then(
   function(products) {
     assert_not_equals(products, null, "queryProductDetails of InAppPurchase");
   },
@@ -65,7 +68,7 @@ test(function () {
 }, "Check if InAppPurchase.queryProductDetails is valid");
 
 test(function () {
-  navigator.iap.purchase("gas").then(
+  iap.buy("gas").then(
   function(transaction) {
     assert_not_equals(transaction, null, "purchase of InAppPurchase");
   },
@@ -75,7 +78,7 @@ test(function () {
 }, "Check if InAppPurchase.purchase is valid");
 
 test(function () {
-  navigator.iap.restore().then(
+  iap.restore().then(
   function(transactions) {
     assert_not_equals(transactions.length, 0, "restore of InAppPurchase");
   },

--- a/webapi/webapi-iap-xwalk-tests/iap/Navigator_iap.html
+++ b/webapi/webapi-iap-xwalk-tests/iap/Navigator_iap.html
@@ -42,13 +42,11 @@ Authors:
 <script>
 
 test(function () {
-  assert_true(iap in Navigator, "iap attribute in Navigator");
-  assert_equals(typeof Navigator[iap], "InAppPurchase", "iap attribute of type");
-  assert_readonly(Navigator, iap, "expect attribute iap cannot be changed but");
-}, "Check if readonly Navigator.iap exists and type of InAppPurchase");
+  assert_equals(typeof iap, "object", "iap attribute of type");
+}, "Check if readonly Navigator.iap exists and type of object");
 
 test(function () {
-  assert_not_equals(Navigator.iap, null, "iap attribute of PerformanceEntry");
+  assert_not_equals(iap, "undefined", "iap attribute of PerformanceEntry");
 }, "Check if PerformanceEntry.iap is valid");
 
 </script>

--- a/webapi/webapi-iap-xwalk-tests/tests.full.xml
+++ b/webapi/webapi-iap-xwalk-tests/tests.full.xml
@@ -3,7 +3,7 @@
 <test_definition>
   <suite name="webapi-iap-xwalk-tests" launcher="xwalk" category="W3C/HTML5 APIs">
     <set name="iap">
-      <testcase purpose="Check if readonly Navigator.iap exists and type of InAppPurchase" type="compliance" status="designed" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="Navigator_iap">
+      <testcase purpose="Check if readonly Navigator.iap exists and type of object" type="compliance" status="approved" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="Navigator_iap">
         <description>
           <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/Navigator_iap.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
@@ -15,7 +15,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if PerformanceEntry.iap is valid" type="compliance" status="designed" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="Navigator_iap_basic">
+      <testcase purpose="Check if PerformanceEntry.iap is valid" type="compliance" status="approved" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="Navigator_iap_basic">
         <description>
           <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/Navigator_iap.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
@@ -27,7 +27,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if InAppPurchase.queryProductDetails exists and type of function" type="compliance" status="designed" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="InAppPurchase_queryProductDetails">
+      <testcase purpose="Check if InAppPurchase.queryProductDetails exists and type of function" type="compliance" status="approved" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="InAppPurchase_queryProductDetails">
         <description>
           <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/InAppPurchase.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
@@ -39,7 +39,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if InAppPurchase.purchase exists and type of function" type="compliance" status="designed" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="InAppPurchase_purchase">
+      <testcase purpose="Check if InAppPurchase.purchase exists and type of function" type="compliance" status="approved" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="InAppPurchase_purchase">
         <description>
           <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/InAppPurchase.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
@@ -51,7 +51,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if InAppPurchase.restore exists and type of function" type="compliance" status="designed" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="InAppPurchase_restore">
+      <testcase purpose="Check if InAppPurchase.restore exists and type of function" type="compliance" status="approved" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="InAppPurchase_restore">
         <description>
           <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/InAppPurchase.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
         </description>
@@ -63,7 +63,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if InAppPurchase.queryProductDetails is valid" type="compliance" status="designed" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="InAppPurchase_queryProductDetails_basic">
+      <testcase purpose="Check if InAppPurchase.queryProductDetails is valid" type="compliance" status="approved" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="InAppPurchase_queryProductDetails_basic">
         <description>
           <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/InAppPurchase.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
         </description>
@@ -75,7 +75,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if InAppPurchase.purchase is valid" type="compliance" status="designed" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="InAppPurchase_purchase_basic">
+      <testcase purpose="Check if InAppPurchase.purchase is valid" type="compliance" status="approved" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="InAppPurchase_purchase_basic">
         <description>
           <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/InAppPurchase.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
         </description>
@@ -87,7 +87,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if InAppPurchase.restore is valid" type="compliance" status="designed" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="InAppPurchase_restore_basic">
+      <testcase purpose="Check if InAppPurchase.restore is valid" type="compliance" status="approved" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="InAppPurchase_restore_basic">
         <description>
           <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/InAppPurchase.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
         </description>
@@ -99,7 +99,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if IAPProduct.id exists and type of string" type="compliance" status="designed" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPProduct_id">
+      <testcase purpose="Check if IAPProduct.id exists and type of string" type="compliance" status="approved" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPProduct_id">
         <description>
           <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPProduct.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
@@ -111,7 +111,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if IAPProduct.id is valid" type="compliance" status="designed" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPProduct_id_basic">
+      <testcase purpose="Check if IAPProduct.id is valid" type="compliance" status="approved" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPProduct_id_basic">
         <description>
           <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPProduct.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
@@ -123,7 +123,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if IAPProduct.price exists and type of string" type="compliance" status="designed" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPProduct_price">
+      <testcase purpose="Check if IAPProduct.price exists and type of string" type="compliance" status="approved" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPProduct_price">
         <description>
           <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPProduct.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
         </description>
@@ -135,7 +135,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if IAPProduct.price is valid" type="compliance" status="designed" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPProduct_price_basic">
+      <testcase purpose="Check if IAPProduct.price is valid" type="compliance" status="approved" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPProduct_price_basic">
         <description>
           <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPProduct.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
         </description>
@@ -147,7 +147,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if IAPProduct.title exists and type of string" type="compliance" status="designed" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPProduct_title">
+      <testcase purpose="Check if IAPProduct.title exists and type of string" type="compliance" status="approved" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPProduct_title">
         <description>
           <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPProduct.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
         </description>
@@ -159,7 +159,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if IAPProduct.title is valid" type="compliance" status="designed" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPProduct_title_basic">
+      <testcase purpose="Check if IAPProduct.title is valid" type="compliance" status="approved" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPProduct_title_basic">
         <description>
           <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPProduct.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
         </description>
@@ -171,7 +171,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if IAPProduct.type exists and type of string" type="compliance" status="designed" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPProduct_type">
+      <testcase purpose="Check if IAPProduct.type exists and type of string" type="compliance" status="approved" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPProduct_type">
         <description>
           <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPProduct.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
         </description>
@@ -183,7 +183,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if IAPProduct.type is valid" type="compliance" status="designed" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPProduct_type_basic">
+      <testcase purpose="Check if IAPProduct.type is valid" type="compliance" status="approved" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPProduct_type_basic">
         <description>
           <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPProduct.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
         </description>
@@ -195,7 +195,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if IAPProduct.description exists and type of string" type="compliance" status="designed" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPProduct_description">
+      <testcase purpose="Check if IAPProduct.description exists and type of string" type="compliance" status="approved" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPProduct_description">
         <description>
           <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPProduct.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
         </description>
@@ -207,7 +207,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if IAPProduct.description is valid" type="compliance" status="designed" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPProduct_description_basic">
+      <testcase purpose="Check if IAPProduct.description is valid" type="compliance" status="approved" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPProduct_description_basic">
         <description>
           <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPProduct.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
         </description>
@@ -219,57 +219,129 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if IAPTransactionDetails.id exists and type of string" type="compliance" status="designed" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPTransactionDetails_id">
+      <testcase purpose="Check if IAPTransactionDetails.orderId exists and type of string" type="compliance" status="approved" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPTransactionDetails_orderId">
         <description>
-          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="id" interface="IAPTransactionDetails" specification="IAP" section="Networking" category="W3C API Specifications"/>
+            <spec_assertion element_type="property" element_name="orderId" interface="IAPTransactionDetails" specification="IAP" section="Networking" category="W3C API Specifications"/>
             <spec_url>https://crosswalk-project.org/#wiki/A-Possible-Web-IDL-for-IAP</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if IAPTransactionDetails.id is valid" type="compliance" status="designed" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPTransactionDetails_id_basic">
+      <testcase purpose="Check if IAPTransactionDetails.orderId is valid" type="compliance" status="approved" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPTransactionDetails_orderId_basic">
         <description>
-          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="id" interface="IAPTransactionDetails" specification="IAP" section="Networking" category="W3C API Specifications"/>
+            <spec_assertion element_type="property" element_name="orderId" interface="IAPTransactionDetails" specification="IAP" section="Networking" category="W3C API Specifications"/>
             <spec_url>https://crosswalk-project.org/#wiki/A-Possible-Web-IDL-for-IAP</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if IAPTransactionDetails.time exists and type of number" type="compliance" status="designed" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPTransactionDetails_time">
+      <testcase purpose="Check if IAPTransactionDetails.packageName exists and type of number" type="compliance" status="approved" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPTransactionDetails_packageName">
         <description>
-          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="time" interface="IAPTransactionDetails" specification="IAP" section="Networking" category="W3C API Specifications"/>
+            <spec_assertion element_type="property" element_name="packageName" interface="IAPTransactionDetails" specification="IAP" section="Networking" category="W3C API Specifications"/>
             <spec_url>https://crosswalk-project.org/#wiki/A-Possible-Web-IDL-for-IAP</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if IAPTransactionDetails.time is valid" type="compliance" status="designed" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPTransactionDetails_time_basic">
+      <testcase purpose="Check if IAPTransactionDetails.packageName is valid" type="compliance" status="approved" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPTransactionDetails_packageName_basic">
         <description>
-          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="time" interface="IAPTransactionDetails" specification="IAP" section="Networking" category="W3C API Specifications"/>
+            <spec_assertion element_type="property" element_name="packageName" interface="IAPTransactionDetails" specification="IAP" section="Networking" category="W3C API Specifications"/>
             <spec_url>https://crosswalk-project.org/#wiki/A-Possible-Web-IDL-for-IAP</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if IAPTransactionDetails.token exists and type of string" type="compliance" status="designed" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPTransactionDetails_token">
+      <testcase purpose="Check if IAPTransactionDetails.productId exists and type of string" type="compliance" status="approved" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPTransactionDetails_productId">
         <description>
-          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="productId" interface="IAPTransactionDetails" specification="IAP" section="Networking" category="W3C API Specifications"/>
+            <spec_url>https://crosswalk-project.org/#wiki/A-Possible-Web-IDL-for-IAP</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if IAPTransactionDetails.productId is valid" type="compliance" status="approved" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPTransactionDetails_productId_basic">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="productId" interface="IAPTransactionDetails" specification="IAP" section="Networking" category="W3C API Specifications"/>
+            <spec_url>https://crosswalk-project.org/#wiki/A-Possible-Web-IDL-for-IAP</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if IAPTransactionDetails.purchaseTime exists and type of string" type="compliance" status="approved" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPTransactionDetails_purchaseTime">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="purchaseTime" interface="IAPTransactionDetails" specification="IAP" section="Networking" category="W3C API Specifications"/>
+            <spec_url>https://crosswalk-project.org/#wiki/A-Possible-Web-IDL-for-IAP</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if IAPTransactionDetails.purchaseTime is valid" type="compliance" status="approved" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPTransactionDetails_purchaseTime_basic">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="purchaseTime" interface="IAPTransactionDetails" specification="IAP" section="Networking" category="W3C API Specifications"/>
+            <spec_url>https://crosswalk-project.org/#wiki/A-Possible-Web-IDL-for-IAP</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if IAPTransactionDetails.purchaseState exists and type of string" type="compliance" status="approved" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPTransactionDetails_purchaseState">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="purchaseState" interface="IAPTransactionDetails" specification="IAP" section="Networking" category="W3C API Specifications"/>
+            <spec_url>https://crosswalk-project.org/#wiki/A-Possible-Web-IDL-for-IAP</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if IAPTransactionDetails.purchaseState is valid" type="compliance" status="approved" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPTransactionDetails_purchaseState_basic">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="purchaseState" interface="IAPTransactionDetails" specification="IAP" section="Networking" category="W3C API Specifications"/>
+            <spec_url>https://crosswalk-project.org/#wiki/A-Possible-Web-IDL-for-IAP</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if IAPTransactionDetails.token exists and type of string" type="compliance" status="approved" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPTransactionDetails_token">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -279,9 +351,9 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if IAPTransactionDetails.token is valid" type="compliance" status="designed" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPTransactionDetails_token_basic">
+      <testcase purpose="Check if IAPTransactionDetails.token is valid" type="compliance" status="approved" component="WebAPI/Networking/IAP" execution_type="auto" priority="P1" id="IAPTransactionDetails_token_basic">
         <description>
-          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
         </description>
         <specs>
           <spec>

--- a/webapi/webapi-iap-xwalk-tests/tests.xml
+++ b/webapi/webapi-iap-xwalk-tests/tests.xml
@@ -3,6 +3,156 @@
 <test_definition>
   <suite category="W3C/HTML5 APIs" launcher="xwalk" name="webapi-iap-xwalk-tests">
     <set name="iap">
-      </set>
+      <testcase component="WebAPI/Networking/IAP" execution_type="auto" id="Navigator_iap" purpose="Check if readonly Navigator.iap exists and type of object">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/Navigator_iap.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/IAP" execution_type="auto" id="Navigator_iap_basic" purpose="Check if PerformanceEntry.iap is valid">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/Navigator_iap.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/IAP" execution_type="auto" id="InAppPurchase_queryProductDetails" purpose="Check if InAppPurchase.queryProductDetails exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/InAppPurchase.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/IAP" execution_type="auto" id="InAppPurchase_purchase" purpose="Check if InAppPurchase.purchase exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/InAppPurchase.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/IAP" execution_type="auto" id="InAppPurchase_restore" purpose="Check if InAppPurchase.restore exists and type of function">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/InAppPurchase.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/IAP" execution_type="auto" id="InAppPurchase_queryProductDetails_basic" purpose="Check if InAppPurchase.queryProductDetails is valid">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/InAppPurchase.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/IAP" execution_type="auto" id="InAppPurchase_purchase_basic" purpose="Check if InAppPurchase.purchase is valid">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/InAppPurchase.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/IAP" execution_type="auto" id="InAppPurchase_restore_basic" purpose="Check if InAppPurchase.restore is valid">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/InAppPurchase.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/IAP" execution_type="auto" id="IAPProduct_id" purpose="Check if IAPProduct.id exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPProduct.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/IAP" execution_type="auto" id="IAPProduct_id_basic" purpose="Check if IAPProduct.id is valid">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPProduct.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/IAP" execution_type="auto" id="IAPProduct_price" purpose="Check if IAPProduct.price exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPProduct.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/IAP" execution_type="auto" id="IAPProduct_price_basic" purpose="Check if IAPProduct.price is valid">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPProduct.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/IAP" execution_type="auto" id="IAPProduct_title" purpose="Check if IAPProduct.title exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPProduct.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/IAP" execution_type="auto" id="IAPProduct_title_basic" purpose="Check if IAPProduct.title is valid">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPProduct.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/IAP" execution_type="auto" id="IAPProduct_type" purpose="Check if IAPProduct.type exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPProduct.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/IAP" execution_type="auto" id="IAPProduct_type_basic" purpose="Check if IAPProduct.type is valid">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPProduct.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/IAP" execution_type="auto" id="IAPProduct_description" purpose="Check if IAPProduct.description exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPProduct.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/IAP" execution_type="auto" id="IAPProduct_description_basic" purpose="Check if IAPProduct.description is valid">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPProduct.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/IAP" execution_type="auto" id="IAPTransactionDetails_orderId" purpose="Check if IAPTransactionDetails.orderId exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/IAP" execution_type="auto" id="IAPTransactionDetails_orderId_basic" purpose="Check if IAPTransactionDetails.orderId is valid">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/IAP" execution_type="auto" id="IAPTransactionDetails_packageName" purpose="Check if IAPTransactionDetails.packageName exists and type of number">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/IAP" execution_type="auto" id="IAPTransactionDetails_packageName_basic" purpose="Check if IAPTransactionDetails.packageName is valid">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/IAP" execution_type="auto" id="IAPTransactionDetails_productId" purpose="Check if IAPTransactionDetails.productId exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/IAP" execution_type="auto" id="IAPTransactionDetails_productId_basic" purpose="Check if IAPTransactionDetails.productId is valid">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/IAP" execution_type="auto" id="IAPTransactionDetails_purchaseTime" purpose="Check if IAPTransactionDetails.purchaseTime exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/IAP" execution_type="auto" id="IAPTransactionDetails_purchaseTime_basic" purpose="Check if IAPTransactionDetails.purchaseTime is valid">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/IAP" execution_type="auto" id="IAPTransactionDetails_purchaseState" purpose="Check if IAPTransactionDetails.purchaseState exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/IAP" execution_type="auto" id="IAPTransactionDetails_purchaseState_basic" purpose="Check if IAPTransactionDetails.purchaseState is valid">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/IAP" execution_type="auto" id="IAPTransactionDetails_token" purpose="Check if IAPTransactionDetails.token exists and type of string">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Networking/IAP" execution_type="auto" id="IAPTransactionDetails_token_basic" purpose="Check if IAPTransactionDetails.token is valid">
+        <description>
+          <test_script_entry>/opt/webapi-iap-xwalk-tests/iap/IAPTransactionDetails.html?total_num=12&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
+        </description>
+      </testcase>
+    </set>
   </suite>
 </test_definition>


### PR DESCRIPTION
- Modify the way of using iap
- Failure analysis: The restore method does not suppot
- Block analysis: "In App Purchase" feature does not allowed in China

Impacted tests(approved): new 6, update 24, delete 0
Unit test platform: [Android]
Unit test result summary: pass 6, fail 2, block 22
