### PR TITLE
[webapi] Update 52 Tcs for nativefilesystem

### DIFF
--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/DirectoryEntry_createReader_exist.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/DirectoryEntry_createReader_exist.html
@@ -56,6 +56,8 @@ function successCallback(fs) {
   t.done();
 }
 
-xwalk.experimental.native_file_system.requestNativeFileSystem("music", successCallback, errorCallback);
+xwalk.experimental.native_file_system.requestNativeFileSystem("music", successCallback, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", successCallback, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/DirectoryEntry_getDirectory_exist.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/DirectoryEntry_getDirectory_exist.html
@@ -54,6 +54,14 @@ xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(
     assert_true(flag, "DirectoryEntry.getDirectory() method exists");
   });
   t.done();
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    t.step(function () {
+      var flag = fs.root.getDirectory != undefined && fs.root.getDirectory instanceof Function;
+      assert_true(flag, "DirectoryEntry.getDirectory() method exists");
+    });
+    t.done();
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/DirectoryEntry_getFile_base.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/DirectoryEntry_getFile_base.html
@@ -53,6 +53,10 @@ function successCallback(entry) {
 
 xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(fs) {
   fs.root.getFile("/music/1.txt", {create: true}, successCallback, errorCallback);
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    fs.root.getFile("/sounds/1.txt", {create: true}, successCallback, errorCallback);
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/DirectoryEntry_getFile_exist.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/DirectoryEntry_getFile_exist.html
@@ -54,6 +54,14 @@ xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(
     assert_true(flag, "The method DirectoryEntry.getFile exists");
   });
   t.done();
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    t.step(function () {
+      var flag = (fs.root.getFile != undefined) && (fs.root.getFile instanceof Function);
+      assert_true(flag, "The method DirectoryEntry.getFile exists");
+    });
+    t.done();
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/DirectoryEntry_removeRecursively_exist.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/DirectoryEntry_removeRecursively_exist.html
@@ -54,6 +54,14 @@ xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(
     assert_true(flag, "The method entry.removeRecursively() exists");
   });
   t.done();
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    t.step(function () {
+      var flag = fs.root.removeRecursively != undefined && fs.root.removeRecursively instanceof Function;
+      assert_true(flag, "The method entry.removeRecursively() exists");
+    });
+    t.done();
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/DirectoryReader_readEntries_exist.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/DirectoryReader_readEntries_exist.html
@@ -56,6 +56,16 @@ xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(
     });
     t.done();
   }, errorCallback);
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    fs.root.getDirectory("/sounds/", {create: false}, function (entry) {
+      t.step(function () {
+        var flag = entry.createReader().readEntries != undefined && entry.createReader().readEntries instanceof Function;
+        assert_true(flag, "The method entry.readEntries() exists");
+      });
+      t.done();
+    }, errorCallback);
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/EntriesCallback_handleEvent_entries_type.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/EntriesCallback_handleEvent_entries_type.html
@@ -60,6 +60,14 @@ xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(
     var entries = [];
     dirReader.readEntries(successCallback, errorCallback);
   }, errorCallback);
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    fs.root.getDirectory("/sounds/", {create: true}, function (entry) {
+      var dirReader = entry.createReader();
+      var entries = [];
+      dirReader.readEntries(successCallback, errorCallback);
+    }, errorCallback);
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/EntriesCallback_handleEvent_exist.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/EntriesCallback_handleEvent_exist.html
@@ -57,6 +57,10 @@ function onInitFs(entry) {
 
 xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(fs) {
   fs.root.getDirectory("/music/", {create: true}, onInitFs, errorCallback);
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    fs.root.getDirectory("/sounds/", {create: true}, onInitFs, errorCallback);
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/EntryCallback_handleEvent_entry_type.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/EntryCallback_handleEvent_entry_type.html
@@ -57,6 +57,10 @@ function successCallback(entry) {
 
 xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(fs) {
   fs.root.getDirectory('/music/', {create: true}, successCallback, errorCallback);
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    fs.root.getDirectory('/sounds/', {create: true}, successCallback, errorCallback);
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/EntryCallback_handleEvent_exist.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/EntryCallback_handleEvent_exist.html
@@ -56,6 +56,12 @@ xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(
   fs.root.getFile('/music/aa.txt', {create: true}, function(entry) {
     entry.file(successCallback, errorCallback);
   }, errorCallback);
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    fs.root.getFile('/sounds/aa.txt', {create: true}, function(entry) {
+      entry.file(successCallback, errorCallback);
+    }, errorCallback);
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_copyTo_base.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_copyTo_base.html
@@ -59,6 +59,19 @@ xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(
       }, errorCallback);
     }, errorCallback);
   }, errorCallback)
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    fs.root.getDirectory('/sounds/', {create: true}, function(entry) {
+      fs.root.getFile("/sounds/test.txt", {create: true}, function(fileentry) {
+        fileentry.copyTo(entry, "test1.txt", function(newfileEntry) {
+          t.step(function() {
+            assert_equals(newfileEntry.fullPath, "/sounds/test1.txt");
+          });
+          t.done();
+        }, errorCallback);
+      }, errorCallback);
+    }, errorCallback)
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_copyTo_exist.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_copyTo_exist.html
@@ -53,6 +53,13 @@ xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(
     assert_true(fs.root.copyTo != undefined && fs.root.copyTo instanceof Function, "The Entry.copyTo() exists");
   });
   t.done();
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    t.step(function () {
+      assert_true(fs.root.copyTo != undefined && fs.root.copyTo instanceof Function, "The Entry.copyTo() exists");
+    });
+    t.done();
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_fullPath_exist.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_fullPath_exist.html
@@ -55,6 +55,8 @@ function successCallback(fs) {
   t.done();
 }
 
-xwalk.experimental.native_file_system.requestNativeFileSystem("music", successCallback, errorCallback);
+xwalk.experimental.native_file_system.requestNativeFileSystem("music", successCallback, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", successCallback, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_fullPath_readonly.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_fullPath_readonly.html
@@ -59,6 +59,19 @@ function successCallback(entry) {
   },errorCallback);
 }
 
-xwalk.experimental.native_file_system.requestNativeFileSystem("music", successCallback, errorCallback);
+function successCallback_1(entry) {
+  entry.root.getFile("/sounds/aa.txt", {create: true}, function(fileEntry) {
+    t.step(function () {
+      var fullpath = fileEntry.fullPath;
+      fileEntry.fullPath = "/sounds/aa.txt";
+      assert_equals(fileEntry.fullPath, fullpath);
+    });
+    t.done();
+  },errorCallback);
+}
+
+xwalk.experimental.native_file_system.requestNativeFileSystem("music", successCallback, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", successCallback_1, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_fullPath_type.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_fullPath_type.html
@@ -57,6 +57,17 @@ function successCallback(entry) {
   },errorCallback);
 }
 
-xwalk.experimental.native_file_system.requestNativeFileSystem("music", successCallback, errorCallback);
+function successCallback_1(entry) {
+  entry.root.getFile("/sounds/aa.txt", {create: true}, function(fileEntry) {
+    t.step(function () {
+      assert_equals(typeof fileEntry.fullPath, "string");
+    });
+    t.done();
+  },errorCallback);
+}
+
+xwalk.experimental.native_file_system.requestNativeFileSystem("music", successCallback, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", successCallback_1, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_getMetadata_exist.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_getMetadata_exist.html
@@ -54,6 +54,14 @@ xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(
     assert_true(flag, "The Entry.getMetadata exists");
   });
   t.done();
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    t.step(function () {
+      var flag = fs.root.getMetadata != undefined && fs.root.getMetadata instanceof Function;
+      assert_true(flag, "The Entry.getMetadata exists");
+    });
+    t.done();
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_getParent_exist.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_getParent_exist.html
@@ -54,6 +54,14 @@ xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(
     assert_true(flag, "entry.getParent() exists");
   });
   t.done();
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    t.step(function () {
+      var flag = fs.root.getParent != undefined && fs.root.getParent instanceof Function;
+      assert_true(flag, "entry.getParent() exists");
+    });
+    t.done();
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_isDirectory_exist.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_isDirectory_exist.html
@@ -53,6 +53,13 @@ xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(
     assert_exists(fs.root, "isDirectory");
   });
   t.done();
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    t.step(function () {
+      assert_exists(fs.root, "isDirectory");
+    });
+    t.done();
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_isDirectory_false.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_isDirectory_false.html
@@ -57,6 +57,10 @@ function successCallback(entry) {
 
 xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(fs) {
   fs.root.getFile("/music/aa.txt", {create: true}, successCallback, errorCallback);
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    fs.root.getFile("/sounds/aa.txt", {create: true}, successCallback, errorCallback);
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_isDirectory_readonly.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_isDirectory_readonly.html
@@ -59,6 +59,10 @@ function successCallback(entry) {
 
 xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(fs) {
   fs.root.getDirectory("/music/", {create: true}, successCallback, errorCallback);
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    fs.root.getDirectory("/sounds/", {create: true}, successCallback, errorCallback);
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_isDirectory_true.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_isDirectory_true.html
@@ -57,6 +57,10 @@ function successCallback(entry) {
 
 xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(fs) {
   fs.root.getDirectory("/music/", {create: true}, successCallback, errorCallback);
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    fs.root.getDirectory("/sounds/", {create: true}, successCallback, errorCallback);
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_isDirectory_type.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_isDirectory_type.html
@@ -57,6 +57,10 @@ function successCallback(entry) {
 
 xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(fs) {
   fs.root.getDirectory("/music/", {create: true}, successCallback, errorCallback);
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    fs.root.getDirectory("/sounds/", {create: true}, successCallback, errorCallback);
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_isFile_exist.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_isFile_exist.html
@@ -53,6 +53,13 @@ xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(
     assert_exists(fs.root, "isFile");
   });
   t.done();
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    t.step(function () {
+      assert_exists(fs.root, "isFile");
+    });
+    t.done();
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_isFile_false.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_isFile_false.html
@@ -57,6 +57,10 @@ function successCallback(entry) {
 
 xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(fs) {
   fs.root.getDirectory("/music/", {create: true}, successCallback, errorCallback);
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    fs.root.getDirectory("/sounds/", {create: true}, successCallback, errorCallback);
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_isFile_readonly.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_isFile_readonly.html
@@ -59,6 +59,10 @@ function successCallback(entry) {
 
 xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(fs) {
   fs.root.getFile("/music/tizen.txt", {create: true}, successCallback, errorCallback);
-},errorCallback);
+},function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    fs.root.getFile("/sounds/tizen.txt", {create: true}, successCallback, errorCallback);
+  },errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_isFile_true.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_isFile_true.html
@@ -57,6 +57,10 @@ function successCallback(entry) {
 
 xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(fs) {
   fs.root.getFile("/music/aa.txt", {create: true}, successCallback, errorCallback);
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    fs.root.getFile("/sounds/aa.txt", {create: true}, successCallback, errorCallback);
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_isFile_type.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_isFile_type.html
@@ -57,6 +57,10 @@ function successCallback(entry) {
 
 xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(fs) {
   fs.root.getFile("/music/tizen.txt", {create: true}, successCallback, errorCallback);
-},errorCallback);
+},function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    fs.root.getFile("/sounds/tizen.txt", {create: true}, successCallback, errorCallback);
+  },errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_moveTo_exist.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_moveTo_exist.html
@@ -61,6 +61,14 @@ xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(
     assert_true(flag, "Entry.remove() exists");
   });
   t.done();
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    t.step(function() {
+      var flag = fs.root.moveTo != undefined && fs.root.moveTo instanceof Function;
+      assert_true(flag, "Entry.remove() exists");
+    });
+    t.done();
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_name_exist.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_name_exist.html
@@ -55,6 +55,8 @@ function successCallback(fs) {
   t.done();
 }
 
-xwalk.experimental.native_file_system.requestNativeFileSystem("music", successCallback, errorCallback);
+xwalk.experimental.native_file_system.requestNativeFileSystem("music", successCallback, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", successCallback, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_name_readonly.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_name_readonly.html
@@ -59,6 +59,19 @@ function successCallback(entry) {
   }, errorCallback);
 }
 
-xwalk.experimental.native_file_system.requestNativeFileSystem("music", successCallback, errorCallback);
+function successCallback_1(entry) {
+  entry.root.getFile("/sounds/aa.txt", {create: true}, function(fileEntry) {
+    t.step(function () {
+      var name = fileEntry.name;
+      fileEntry.name = "bb.txt";
+      assert_equals(fileEntry.name, name);
+    });
+    t.done();
+  }, errorCallback);
+}
+
+xwalk.experimental.native_file_system.requestNativeFileSystem("music", successCallback, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", successCallback_1, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_name_type.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_name_type.html
@@ -57,6 +57,17 @@ function successCallback(entry) {
   }, errorCallback);
 }
 
-xwalk.experimental.native_file_system.requestNativeFileSystem("music", successCallback, errorCallback);
+function successCallback_1(entry) {
+  entry.root.getFile("/sounds/aa.txt", {create: true}, function(fileEntry) {
+    t.step(function () {
+      assert_equals(typeof fileEntry.name, "string");
+    });
+    t.done();
+  }, errorCallback);
+}
+
+xwalk.experimental.native_file_system.requestNativeFileSystem("music", successCallback, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", successCallback_1, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_nativefilesystem_exist.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_nativefilesystem_exist.html
@@ -55,6 +55,8 @@ function successCallback(fs) {
   t.done();
 }
 
-xwalk.experimental.native_file_system.requestNativeFileSystem("music", successCallback, errorCallback);
+xwalk.experimental.native_file_system.requestNativeFileSystem("music", successCallback, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", successCallback, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_nativefilesystem_readonly.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_nativefilesystem_readonly.html
@@ -59,6 +59,19 @@ function successCallback(entry) {
   }, errorCallback);
 }
 
-xwalk.experimental.native_file_system.requestNativeFileSystem("music", successCallback, errorCallback);
+function successCallback_1(entry) {
+  entry.root.getFile("/sounds/aa.txt", {create: true}, function(fileEntry) {
+    t.step(function () {
+      var filesystem = fileEntry.filesystem.toString()
+      fileEntry.filesystem = "test";
+      assert_equals(fileEntry.filesystem.toString(), "[object DOMFileSystem]");
+    });
+    t.done();
+  }, errorCallback);
+}
+
+xwalk.experimental.native_file_system.requestNativeFileSystem("music", successCallback, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", successCallback_1, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_nativefilesystem_type.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_nativefilesystem_type.html
@@ -57,6 +57,17 @@ function successCallback(entry) {
   }, errorCallback);
 }
 
-xwalk.experimental.native_file_system.requestNativeFileSystem("music", successCallback, errorCallback);
+function successCallback_1(entry) {
+  entry.root.getFile("/sounds/aa.txt", {create: true}, function(fileEntry) {
+    t.step(function () {
+        assert_equals(Object.prototype.toString.call(fileEntry.filesystem), "[object DOMFileSystem]");
+    });
+    t.done();
+  }, errorCallback);
+}
+
+xwalk.experimental.native_file_system.requestNativeFileSystem("music", successCallback, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", successCallback_1, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_remove_exist.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_remove_exist.html
@@ -54,6 +54,14 @@ xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(
     assert_true(flag, "the entry.remove() method exists");
   });
   t.done();
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    t.step(function () {
+      var flag = fs.root.remove != undefined && fs.root.remove instanceof Function;
+      assert_true(flag, "the entry.remove() method exists");
+    });
+    t.done();
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_toURL_exist.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Entry_toURL_exist.html
@@ -56,6 +56,16 @@ xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(
     });
     t.done();
   }, errorCallback);
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    fs.root.getDirectory('/sounds/', {create: true}, function(entry) {
+      t.step(function () {
+        var flag = entry.toURL != undefined && entry.toURL instanceof Function;
+        assert_true(flag, "The methode entry.toURL() exists");
+      });
+      t.done();
+    }, errorCallback);
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/FileCallback_handleEvent_exist.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/FileCallback_handleEvent_exist.html
@@ -56,6 +56,12 @@ xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(
   fs.root.getFile('/music/log.txt', {create: true}, function(fileEntry) {
     fileEntry.file(successCallback, errorCallback);
   }, errorCallback);
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    fs.root.getFile('/sounds/log.txt', {create: true}, function(fileEntry) {
+      fileEntry.file(successCallback, errorCallback);
+    }, errorCallback);
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/FileEntry_createWriter_exist.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/FileEntry_createWriter_exist.html
@@ -56,6 +56,16 @@ xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(
     });
     t.done();
   }, errorCallback);
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    fs.root.getFile("/sounds/logFile.txt", {create: true}, function (entry) {
+      t.step(function () {
+        var flag = entry.createWriter != undefined && entry.createWriter instanceof Function;
+        assert_true(flag, "FileEntry.createWriter exists");
+      });
+      t.done();
+    }, errorCallback);
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/FileEntry_file_exist.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/FileEntry_file_exist.html
@@ -64,7 +64,16 @@ xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(
     });
     t.done();
   }, errorCallback);
-}, errorCallback);
-
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    fs.root.getFile("/sounds/logFile.txt", {create: true}, function (entry) {
+      t.step(function() {
+        var flag = entry.file != undefined && entry.file instanceof Function;
+        assert_true(flag, "The FileEntry.file() method exist");
+      });
+      t.done();
+    }, errorCallback);
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/FileWriterCallback_handleEvent_exist.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/FileWriterCallback_handleEvent_exist.html
@@ -57,6 +57,14 @@ xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(
       fileEntry.createWriter(successCallback, errorCallback);
     }, errorCallback);
   }, errorCallback);
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    fs.root.getFile('/sounds/log.txt', {create: true}, function(fileEntry) {
+      fileEntry.createWriter(function(fileWriter) {
+        fileEntry.createWriter(successCallback, errorCallback);
+      }, errorCallback);
+    }, errorCallback);
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/MetadataCallback_handleEvent_exist.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/MetadataCallback_handleEvent_exist.html
@@ -56,6 +56,12 @@ xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(
   fs.root.getDirectory('/music/', {create: true}, function(fileEntry) {
     fileEntry.getMetadata(successCallback, errorCallback);
   }, errorCallback);
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    fs.root.getDirectory('/sounds/', {create: true}, function(fileEntry) {
+      fileEntry.getMetadata(successCallback, errorCallback);
+    }, errorCallback);
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/MetadataCallback_handleEvent_metadata_type.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/MetadataCallback_handleEvent_metadata_type.html
@@ -59,6 +59,12 @@ xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(
   fs.root.getDirectory('/music/', {create: true}, function(fileEntry) {
     fileEntry.getMetadata(successCallback, errorCallback);
   }, errorCallback);
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    fs.root.getDirectory('/sounds/', {create: true}, function(fileEntry) {
+      fileEntry.getMetadata(successCallback, errorCallback);
+    }, errorCallback);
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Metadata_modificationTime.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Metadata_modificationTime.html
@@ -59,6 +59,10 @@ function successCallback(metadata) {
 
 xwalk.experimental.native_file_system.requestNativeFileSystem("music", function (fs) {
   fs.root.getMetadata(successCallback, errorCallback);
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function (fs) {
+    fs.root.getMetadata(successCallback, errorCallback);
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Metadata_size.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/Metadata_size.html
@@ -59,6 +59,10 @@ function successCallback(metadata) {
 
 xwalk.experimental.native_file_system.requestNativeFileSystem("music", function (fs) {
   fs.root.getMetadata(successCallback, errorCallback);
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function (fs) {
+    fs.root.getMetadata(successCallback, errorCallback);
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/NativeFileSystem_name_base.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/NativeFileSystem_name_base.html
@@ -55,6 +55,15 @@ xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(
     assert_true(name && name.length > 0, "The value of NativeFileSystem.name is " + name);
   });
   t.done();
-},errorCallback);
+},function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fileSystem) {
+    t.step(function () {
+      var name = fileSystem.name;
+      // The specifics of naming filesystems is unspecified
+      assert_true(name && name.length > 0, "The value of NativeFileSystem.name is " + name);
+    });
+    t.done();
+  },errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/NativeFileSystem_name_exist.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/NativeFileSystem_name_exist.html
@@ -55,6 +55,13 @@ xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(
     assert_exists(fileSystem, "name");
   });
   t.done();
-},errorCallback);
+},function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fileSystem) {
+    t.step(function () {
+      assert_exists(fileSystem, "name");
+    });
+    t.done();
+  },errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/NativeFileSystem_name_readonly.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/NativeFileSystem_name_readonly.html
@@ -59,6 +59,19 @@ function successCallback(fs) {
   }, errorCallback);
 }
 
-xwalk.experimental.native_file_system.requestNativeFileSystem("music", successCallback, errorCallback);
+function successCallback_1(fs) {
+  fs.root.getFile("/sounds/1.txt", {create: true}, function(entry) {
+    var name = entry.name;
+    entry.name = "2.txt";
+    t.step(function () {
+        assert_equals(entry.name, name);
+    });
+    t.done();
+  }, errorCallback);
+}
+
+xwalk.experimental.native_file_system.requestNativeFileSystem("music", successCallback, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", successCallback_1, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/NativeFileSystem_name_type.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/NativeFileSystem_name_type.html
@@ -55,6 +55,8 @@ function successCallback(fs) {
   t.done();
 }
 
-xwalk.experimental.native_file_system.requestNativeFileSystem("music", successCallback, errorCallback);
+xwalk.experimental.native_file_system.requestNativeFileSystem("music", successCallback, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", successCallback, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/NativeFileSystem_requestNativeFileSystem_base.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/NativeFileSystem_requestNativeFileSystem_base.html
@@ -52,6 +52,8 @@ function successCallback(fs) {
   t.done();
 }
 
-xwalk.experimental.native_file_system.requestNativeFileSystem("music", successCallback, errorCallback);
+xwalk.experimental.native_file_system.requestNativeFileSystem("music", successCallback, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", successCallback, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/NativeFileSystem_root_base.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/NativeFileSystem_root_base.html
@@ -54,6 +54,13 @@ xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(
     assert_equals(fileSystem.root.fullPath, "/");
   });
   t.done();
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fileSystem) {
+    t.step(function () {
+      assert_equals(fileSystem.root.fullPath, "/");
+    });
+    t.done();
+  }, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/NativeFileSystem_root_readonly.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/NativeFileSystem_root_readonly.html
@@ -57,6 +57,8 @@ function successCallback(fs) {
   t.done();
 }
 
-xwalk.experimental.native_file_system.requestNativeFileSystem("music", successCallback, errorCallback);
+xwalk.experimental.native_file_system.requestNativeFileSystem("music", successCallback, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", successCallback, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/NativeFileSystem_root_type.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/NativeFileSystem_root_type.html
@@ -55,6 +55,8 @@ function successCallback(fs) {
   t.done();
 }
 
-xwalk.experimental.native_file_system.requestNativeFileSystem("music", successCallback, errorCallback);
+xwalk.experimental.native_file_system.requestNativeFileSystem("music", successCallback, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", successCallback, errorCallback);
+});
 
 </script>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/VoidCallback_handleEvent_exists.html
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/nativefilesystem/VoidCallback_handleEvent_exists.html
@@ -59,6 +59,12 @@ xwalk.experimental.native_file_system.requestNativeFileSystem("music", function(
   fs.root.getFile('/music/test.txt', {create: true}, function(fileEntry) {
     fileEntry.remove(successCallback, errorCallback);
   }, errorCallback);
-}, errorCallback);
+}, function (e) {
+  xwalk.experimental.native_file_system.requestNativeFileSystem("sounds", function(fs) {
+    fs.root.getFile('/sounds/test.txt', {create: true}, function(fileEntry) {
+      fileEntry.remove(successCallback, errorCallback);
+    }, errorCallback);
+  }, errorCallback);
+});
 
 </script>


### PR DESCRIPTION
- On android phone and tizen IVI support diffent dir lists. Cannot
  make sure which dir is supported on device, so test dirs one by one

Impacted tests(approved): new 0, update 52, delete 0
Unit test platform: [Android][Tizen IVI]
Unit test result summary: pass 52, fail 0, block 0
