### PR TITLE
[behavior][xwalk-1945] Fix failed to switch full screen

### DIFF
--- a/behavior/index.html
+++ b/behavior/index.html
@@ -70,7 +70,7 @@ Authors:
     </div>
 </div>
 <div data-role="page" id="test_ui">
-    <iframe id="test_frame" width="100%" frameborder="no" border="0" src=""></iframe>
+    <iframe id="test_frame" width="100%" frameborder="no" border="0" src="" allowfullscreen="true"></iframe>
 </div>
 </body>
 </html>

--- a/behavior/tests/FullScreen/js/main.js
+++ b/behavior/tests/FullScreen/js/main.js
@@ -61,15 +61,14 @@ $(document).ready(function () {
      $("#cancelCssFullScreen").on(
         "click",
         function(evt) {
-            window.location.reload();
-            /**if (document.webkitIsFullScreen) {
+            if (document.webkitIsFullScreen) {
                 document.webkitCancelFullScreen();
                 if ($(document)["context"].styleSheets.length == 2) {
                     $(document)["context"].styleSheets[1].deleteRule(1);
                 }
                 document.documentElement.webkitRequestFullScreen();
                 window.location.reload();
-            }*/
+            }
      });
 });
 


### PR DESCRIPTION
- The iframe need to have 'allowfullscreen' attribute, otherwise the iframe can
  not enter fullscreen mode

Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: [Android][Tizen IVI]
Unit test result summary: pass 1, fail 0, block 0
