### PR TITLE
[wrt][XWALK-2028] Add 2 tcs to test install/uninstall webapp with no xwalk service

### DIFF
--- a/wrt/wrt-integration-tizen-tests/integration/Crosswalk_WebApp_Install_StopService.html
+++ b/wrt/wrt-integration-tizen-tests/integration/Crosswalk_WebApp_Install_StopService.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:      Lin,Shen <linx.a.shen@intel.com>
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_WebApp_Install_StopService</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>sdb shell</li>
+      <li>keyinput: pgrep xwalk</li>
+      <li>keyinput: kill id</li>
+      <li>xwalkctl –-install webapp</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>connect to device</li>
+      <li>list xwalk deamon id</li>
+      <li>xwalk deamon service is stop(pgrep xwalk, no id list)</li>
+      <li>Webapp can be installed successfully</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-integration-tizen-tests/integration/Crosswalk_WebApp_Update_StopService.html
+++ b/wrt/wrt-integration-tizen-tests/integration/Crosswalk_WebApp_Update_StopService.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2013 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:      Lin,Shen <linx.a.shen@intel.com>
+
+-->
+
+<html>
+  <head>
+    <meta charset='utf-8'>
+    <title>Crosswalk_WebApp_Update_StopService</title>
+    <link rel="author" title="Intel" href="http://www.intel.com">
+  </head>
+  <body>
+    <p>
+      <strong>Test steps:</strong>
+    </p>
+    <ol>
+      <li>sdb push webapp1 and webapp2 to device(webapp2 is webapp1 update app,such version is higher)</li>
+      <li>xwalkctl –-install webapp1</li>
+      <li>keyinput: pgrep xwalk</li>
+      <li>keyinput: kill id</li>
+      <li>xwalkctl –-install webapp2</li>
+    </ol>
+    <p>
+      <strong>Expected Output:</strong>
+    </p>
+    <ol>
+      <li>webapp can be push to device</li>
+      <li>webapp1 can be installed successfully</li>   
+      <li>list xwalk deamon id</li>
+      <li>xwalk deamon service is stop(pgrep xwalk, no id list)</li>
+      <li>Webapp2 can be installed successfully, pkgid is the old webapp1 pkgid</li>
+    </ol>
+  </body>
+</html>

--- a/wrt/wrt-integration-tizen-tests/tests.full.xml
+++ b/wrt/wrt-integration-tizen-tests/tests.full.xml
@@ -322,7 +322,23 @@
           </pre_condition>
           <test_script_entry>/opt/wrt-integration-android-tests/integration/Crosswalk_Audio_Play_Native.html </test_script_entry>
         </description>
-      </testcase>                     
+      </testcase>   
+      <testcase purpose="Validate if webapp can be install after xwalk.service stop" type="Functional" status="designed" component="Integration with Tizen System" execution_type="manual" priority="P1" id="Crosswalk_WebApp_Install_StopService">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-integration-android-tests/integration/Crosswalk_WebApp_Install_StopService.html </test_script_entry>
+        </description>
+      </testcase> 
+      <testcase purpose="Validate if webapp can be update after xwalk.service stop" type="Functional" status="designed" component="Integration with Tizen System" execution_type="manual" priority="P1" id="Crosswalk_WebApp_Update_StopService">
+        <description>
+          <pre_condition>
+            1.Make sure Crosswalk binary is installed;
+          </pre_condition>
+          <test_script_entry>/opt/wrt-integration-android-tests/integration/Crosswalk_WebApp_Update_StopService.html </test_script_entry>
+        </description>
+      </testcase>                                      
     </set>
   </suite>
 </test_definition>


### PR DESCRIPTION
Update webapp fail:
app2.xpk is app1 update app
step1:
1. xwalkctl --install app1.xpk
2. xwalkctl --install app2.xpk
Already installed:pkgid
webapp no update
stpe2:
1. xwalkctl --install app1.xpk
2. pgrep xwalk
3. kill  xwalkid
4. xwalkctl --install app2.xpk
Already installed:pkgid
webapp no update
