### PR TITLE
[wrt][xwalk-2064] Fix no test cases shown when running wrt-i18n-tizen-tests

### DIFF
--- a/wrt/wrt-i18n-tizen-tests/tests.xml
+++ b/wrt/wrt-i18n-tizen-tests/tests.xml
@@ -114,6 +114,7 @@
           </pre_condition>
           <test_script_entry>/opt/wrt-i18n-tizen-tests/i18n/Crosswalk_I18n_TestFr.html</test_script_entry>
         </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>


### PR DESCRIPTION
- Add testcase in tests.xml
