### PR TITLE
[webapi][XWALK-428]Fix logic issue for alarm

### DIFF
--- a/webapi/tct-alarm-tizen-tests/alarm/AlarmManager_removeAll_extra_argument.html
+++ b/webapi/tct-alarm-tizen-tests/alarm/AlarmManager_removeAll_extra_argument.html
@@ -52,9 +52,9 @@ test(function (){
     });
 
     var i, alarm, alarmAll, retVal, argumentsList = [null, undefined, "string", 1, false, ["one", "two"], {arg: 1}, function () {}];
-    tizen.alarm.removeAll();
-    alarm =  createAbsAlarm();
     for (i = 0; i < argumentsList.length; i++) {
+        tizen.alarm.removeAll();
+        alarm =  createAbsAlarm();
         tizen.alarm.add(alarm, APPLICATION_ID);
         alarmAll = tizen.alarm.getAll();
         assert_equals(alarmAll.length, 1 , "number of added alarms should be 1");


### PR DESCRIPTION
- Because the removeAll method is called only once,  when the cycle to the second, alarm be added again,  this case will fail. So move  removeAll method and create alarm method into the circulation.

Impacted TCs num(approved): New 0, Update 1, Delete 0
Unit test Platform: [Tizen IVI]
Test result summary: Pass 1, Fail 0, Blocked 0
