### PR TITLE
[embedding][XWALK-895] Add new embedding api tests for xwalk

### DIFF
--- a/embeddingapi/webapi-embeddingapi-xwalk-tests/pack.sh
+++ b/embeddingapi/webapi-embeddingapi-xwalk-tests/pack.sh
@@ -13,12 +13,21 @@ type="apk"
 
 SRC_ROOT=$PWD
 
+# init
+function init_workspace(){
+    echo "init workspace... >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+    cp libs/chromium/*.jar libs/
+    cp libs/testkit/*.jar libs/
+}
+
+
 # clean
 function clean_workspace(){
     echo "cleaning workspace... >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
-    rm -rf bin/ gen/ libs/
+    #rm -rf bin/ gen/ libs/
     rm local.properties build.xml project.properties
     rm -rf opt/
+    rm libs/*.jar
 }
 
 ## function for create apk ##
@@ -70,6 +79,9 @@ function zip_for_apk(){
         exit 1
     fi
 }
+
+## init workspace ##
+init_workspace
 
 ## create apk package ##
 case $type in

--- a/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/MainActivity.java
+++ b/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/MainActivity.java
@@ -14,27 +14,25 @@ import android.view.Window;
 import android.view.WindowManager;
 
 public class MainActivity extends Activity {
-     
+
     protected XWalkView mXWalkView;
-    
+
     public XWalkView getXWalkView()
     {
-        
         return mXWalkView;
     }
-    
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        
+
         this.requestWindowFeature(Window.FEATURE_NO_TITLE);
         this.getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);
-        
+
         setContentView(R.layout.xwview_layout);
         mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
     }
-    
-    
+
     /*
      * When the activity is paused, XWalkView.onHide() and XWalkView.pauseTimers() need to be called.
      */
@@ -69,5 +67,5 @@ public class MainActivity extends Activity {
             mXWalkView.onDestroy();
         }
     }
-    
+
 }

--- a/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/base/TestHelperBridge.java
+++ b/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/base/TestHelperBridge.java
@@ -8,10 +8,10 @@ import org.chromium.content.browser.test.util.TestCallbackHelperContainer.OnPage
 import org.chromium.content.browser.test.util.TestCallbackHelperContainer.OnPageStartedHelper;
 
 class TestHelperBridge {
-    
+
     private final OnPageStartedHelper mOnPageStartedHelper;
     private final OnPageFinishedHelper mOnPageFinishedHelper;
-    
+
     public TestHelperBridge() {
         mOnPageStartedHelper = new OnPageStartedHelper();
         mOnPageFinishedHelper = new OnPageFinishedHelper();
@@ -28,6 +28,5 @@ class TestHelperBridge {
     public void onPageFinished(String url) {
         mOnPageFinishedHelper.notifyCalled(url);
     }
-    
 
 }

--- a/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/base/XWalkViewTestBase.java
+++ b/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/base/XWalkViewTestBase.java
@@ -27,29 +27,29 @@ import android.os.SystemClock;
 
 
 public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActivity> {
-    
-     public XWalkViewTestBase(Class<MainActivity> activityClass) {
-            super(activityClass);
-        }
-     
-     final String mExpectedStr = "xwalk";
-     
+
+    public XWalkViewTestBase(Class<MainActivity> activityClass) {
+        super(activityClass);
+    }
+
+    final String mExpectedStr = "xwalk";
+
     protected final static int WAIT_TIMEOUT_SECONDS = 15;
-    
-    protected XWalkView mXWalkView ;
+
+    protected XWalkView mXWalkView;
     protected MainActivity mainActivity;
-    
+    final TestHelperBridge mTestHelperBridge = new TestHelperBridge();
+
     private String mUrls[]=new String[3];
-    
+
     protected static final int NUM_NAVIGATIONS = 3;
-    
+
     private static final String PATHS[] = {
         "file:///android_asset/p1bar.html",
         "file:///android_asset/p2bar.html",
         "file:///android_asset/p3bar.html",
 };
-    
-    
+
     protected void setResourceClient(final XWalkResourceClient client) {
         getInstrumentation().runOnMainSync(new Runnable() {
             @Override
@@ -59,7 +59,6 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
         });
     }
 
-
     public XWalkViewTestBase() {
         super(MainActivity.class);
     }
@@ -67,21 +66,15 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        
         mainActivity = (MainActivity) getActivity();
-        
         getInstrumentation().runOnMainSync(new Runnable() {
             @Override
             public void run() {
-                
                 mXWalkView = mainActivity.getXWalkView();
                 mXWalkView.setUIClient(new TestXWalkUIClient());
             }
         });
-        
-        
     }
-
 
     protected void loadUrlAsync(final String url) throws Exception {
         getInstrumentation().runOnMainSync(new Runnable() {
@@ -91,7 +84,7 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
             }
         });
     }
-    
+
     protected void loadUrlAsync(final String url,final String content) throws Exception {
         getInstrumentation().runOnMainSync(new Runnable() {
             @Override
@@ -100,11 +93,9 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
             }
         });
     }
-    
-    
 
     protected void loadDataAsync(final String url, final String data, final String mimeType,
-             final boolean isBase64Encoded) throws Exception {
+            final boolean isBase64Encoded) throws Exception {
         getInstrumentation().runOnMainSync(new Runnable() {
             @Override
             public void run() {
@@ -112,7 +103,6 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
             }
         });
     }
-
 
     protected String getTitleOnUiThread() throws Exception {
         return runTestOnUiThreadAndGetResult(new Callable<String>() {
@@ -160,7 +150,7 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
             }
         });
     }
-    
+
     protected boolean hasEnteredFullScreenOnUiThread() throws Throwable {
         return runTestOnUiThreadAndGetResult(new Callable<Boolean>() {
             @Override
@@ -197,7 +187,7 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
             }
         });
     }
-    
+
     protected String getCurrentItemUrlOnUiThread() throws Exception {
         return runTestOnUiThreadAndGetResult(new Callable<String>() {
             @Override
@@ -206,7 +196,7 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
             }
         });
     }
-    
+
     protected String getNavigationUrlOnUiThread() throws Exception {
         return runTestOnUiThreadAndGetResult(new Callable<String>() {
             @Override
@@ -216,7 +206,7 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
             }
         });
     }
-    
+
     protected String getNavigationOriginalUrlOnUiThread() throws Exception {
         return runTestOnUiThreadAndGetResult(new Callable<String>() {
             @Override
@@ -226,7 +216,7 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
             }
         });
     }
-    
+
     protected String getNavigationTitleOnUiThread() throws Exception {
         return runTestOnUiThreadAndGetResult(new Callable<String>() {
             @Override
@@ -235,7 +225,7 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
             }
         });
     }
-    
+
     protected String getSizeOnUiThread() throws Exception {
         return runTestOnUiThreadAndGetResult(new Callable<String>() {
             @Override
@@ -244,7 +234,7 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
             }
         });
     }
-    
+
     protected String hasItemAtOnUiThread() throws Exception {
         return runTestOnUiThreadAndGetResult(new Callable<String>() {
             @Override
@@ -253,7 +243,7 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
             }
         });
     }
-    
+
     protected String getOriginalUrlOnUiThread() throws Exception {
         return runTestOnUiThreadAndGetResult(new Callable<String>() {
             @Override
@@ -289,8 +279,8 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
             }
         });
     }
-   
-    
+
+
     protected String getUrlFromManifestOnUiThread(final String path1,final String path2) throws Exception {
         return runTestOnUiThreadAndGetResult(new Callable<String>() {
             @Override
@@ -307,7 +297,7 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
             }
         });
     }
-    
+
     private String getAssetsFileContent(AssetManager assetManager, String fileName)
             throws IOException {
         String result = "";
@@ -325,7 +315,7 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
         }
         return result;
     }
-    
+
     public class PerformExecute implements Runnable
     {
         protected StringBuffer urlBuf;
@@ -338,7 +328,7 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
             
         }
     }
-    
+
     protected void goBackSync(final int n) throws Throwable {
         runTestWaitPageFinished(new Runnable(){
             @Override
@@ -377,8 +367,7 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
             SystemClock.sleep(1000);
         }
     }
-    
-    
+
     protected void saveAndRestoreStateOnUiThread() throws Throwable {
         getInstrumentation().runOnMainSync(new Runnable() {
             @Override
@@ -389,7 +378,7 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
             }
         });
     }
-    
+
     protected void checkHistoryItemList() throws Throwable {
         XWalkNavigationHistory history = getNavigationHistoryOnUiThread(mXWalkView);
         assertEquals(6, history.size());
@@ -399,25 +388,23 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
             assertEquals(mUrls[i], history.getItemAt(i).getUrl());
         }
     }
-    
+
     private XWalkNavigationHistory getNavigationHistoryOnUiThread(
             final XWalkView content) throws Throwable{
-            return runTestOnUiThreadAndGetResult(new Callable<XWalkNavigationHistory>() {
+        return runTestOnUiThreadAndGetResult(new Callable<XWalkNavigationHistory>() {
             @Override
             public XWalkNavigationHistory call() throws Exception {
                 return content.getNavigationHistory();
             }
         });
     }
-    
+
     @Override
     protected void tearDown() throws Exception {
-        
         mainActivity.finish();
         super.tearDown();
     }
-    
-    
+
     public class TestJavascriptInterface {
         public String getTextWithoutAnnotation() {
             return mExpectedStr;
@@ -427,20 +414,14 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
             return mExpectedStr;
         }
     }
-    
-    
-    
-    
-    //-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  
-   
-    
-     class TestXWalkUIClientBase extends XWalkUIClient {
+
+    class TestXWalkUIClientBase extends XWalkUIClient {
         TestHelperBridge mInnerContentsClient;
         public TestXWalkUIClientBase(TestHelperBridge client) {
             super(getXWalkView());
             mInnerContentsClient = client;
         }
-        
+
         @Override
         public void onPageLoadStarted(XWalkView view, String url) {
             mInnerContentsClient.onPageStarted(url);
@@ -451,44 +432,36 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
             mInnerContentsClient.onPageFinished(url);
         }
     }
-    
+
     public class TestXWalkUIClient extends TestXWalkUIClientBase {
         public TestXWalkUIClient() {
             super(mTestHelperBridge);
         }
     }
-    
-   final TestHelperBridge mTestHelperBridge = new TestHelperBridge();
+
     protected void loadUrlSync(final String url) throws Exception {
         CallbackHelper pageFinishedHelper = mTestHelperBridge.getOnPageFinishedHelper();
         int currentCallCount = pageFinishedHelper.getCallCount();
         loadUrlAsync(url);
-        
+
         pageFinishedHelper.waitForCallback(currentCallCount, 1, WAIT_TIMEOUT_SECONDS,
                 TimeUnit.SECONDS);
     }
-    
+
     protected void loadUrlSync(final String url, final String content) throws Exception {
-        CallbackHelper pageFinishedHelper = mTestHelperBridge.getOnPageFinishedHelper();
-        int currentCallCount = pageFinishedHelper.getCallCount();
         loadUrlAsync(url, content);
-        
-        pageFinishedHelper.waitForCallback(currentCallCount, 1, WAIT_TIMEOUT_SECONDS,
-                TimeUnit.SECONDS);
     }
-    
 
     protected void loadAssetFile(String fileName) throws Exception {
-         CallbackHelper pageFinishedHelper = mTestHelperBridge.getOnPageFinishedHelper();
-         int currentCallCount = pageFinishedHelper.getCallCount();
+        CallbackHelper pageFinishedHelper = mTestHelperBridge.getOnPageFinishedHelper();
+        int currentCallCount = pageFinishedHelper.getCallCount();
         String fileContent = getFileContent(fileName);
         loadDataAsync(fileName, fileContent, "text/html", false);
-        
+
         pageFinishedHelper.waitForCallback(currentCallCount, 1, WAIT_TIMEOUT_SECONDS,
                 TimeUnit.SECONDS);
     }
-    
-    
+
     protected StringBuffer loadUrlSync2(final String url) throws Exception {
         final StringBuffer urlBuf = new StringBuffer() ;
         runTestWaitPageFinished(new Runnable() {
@@ -502,10 +475,10 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
                     }
                 });
             }
-         });
-         return urlBuf;
+        });
+        return urlBuf;
     }
-    
+
     protected void runTestWaitPageFinished(Runnable runnable) throws Exception{
         CallbackHelper pageFinishedHelper = mTestHelperBridge.getOnPageFinishedHelper();
         int currentCallCount = pageFinishedHelper.getCallCount();

--- a/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/test/FullScreenTest.java
+++ b/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/test/FullScreenTest.java
@@ -1,0 +1,71 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedding.test;
+
+import org.xwalk.core.XWalkUIClient;
+import org.xwalk.embedding.MainActivity;
+import org.xwalk.embedding.base.XWalkViewTestBase;
+
+import android.test.suitebuilder.annotation.SmallTest;
+
+public class FullScreenTest extends XWalkViewTestBase {
+
+
+    public FullScreenTest() {
+        super(MainActivity.class);
+    }
+
+    /**
+     * fail
+     */
+    @SmallTest
+    public void testHasEnteredFullScreen() {
+        try {
+            loadUrlSync("file:///android_asset/p1bar.html");
+            assertEquals(true, hasEnteredFullScreenOnUiThread());
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        } catch (Throwable e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
+    @SmallTest
+    public void testHasEnteredFullScreen2() {
+        try {
+            XWalkUIClient client = new XWalkUIClient(mXWalkView);
+            client.onFullscreenToggled(mXWalkView, true);
+            loadUrlSync("file:///android_asset/p1bar.html");
+            assertEquals(true, hasEnteredFullScreenOnUiThread());
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        } catch (Throwable e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
+    @SmallTest
+    public void testLeaveFullScreen() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+                @Override
+                public void run() {
+                    mXWalkView.leaveFullscreen();
+                }
+            });
+            assertEquals(false, hasEnteredFullScreenOnUiThread());
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        } catch (Throwable e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+}

--- a/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/test/LoadTest.java
+++ b/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/test/LoadTest.java
@@ -1,0 +1,179 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedding.test;
+
+
+import org.xwalk.core.XWalkNavigationHistory;
+import org.xwalk.core.XWalkView;
+import org.xwalk.embedding.MainActivity;
+import org.xwalk.embedding.base.XWalkViewTestBase;
+
+import android.test.suitebuilder.annotation.SmallTest;
+
+public class LoadTest extends XWalkViewTestBase {
+
+    public LoadTest() {
+        super(MainActivity.class);
+    }
+
+    @SmallTest
+    public void testLoadUrl1()
+    {
+        try {
+            String url = "file:///android_asset/p2bar.html";
+            loadUrlSync(url,"Hello");
+            assertEquals("about:blank", getUrlOnUiThread());
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testLoadUrl2()
+    {
+        try {
+            String url = "file:///android_asset/p1bar.html";
+            StringBuffer sb = loadUrlSync2(url);
+            assertEquals(url, sb.toString());
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testLoadAppFromManifest()
+    {
+        try {
+            String path = "file:///android_asset/";
+            String name = "manifest.json";
+            String url = "file:///android_asset/index.html";
+            assertEquals(url, getUrlFromManifestOnUiThread(path,name));
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testReload() {
+        try {
+            String url = "file:///android_asset/p1bar.html";
+            loadUrlSync(url);
+            reloadSync(XWalkView.RELOAD_IGNORE_CACHE);
+            assertEquals("Test", getTitleOnUiThread());
+        } catch (InterruptedException e) {
+            assertTrue(false);
+            e.printStackTrace();
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+       }
+    }
+
+    @SmallTest
+    public void testReload2() {
+        try {
+            String url = "file:///android_asset/p1bar.html";
+            loadUrlSync(url);
+            reloadSync(XWalkView.RELOAD_NORMAL);
+            assertEquals("Test", getTitleOnUiThread());
+
+        } catch (InterruptedException e) {
+            assertTrue(false);
+            e.printStackTrace();
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
+    @SmallTest
+    public void testStopLoading() throws Throwable {
+        try {
+        String url = "file:///android_asset/p1bar.html";
+        loadUrlSync(url);
+            getInstrumentation().runOnMainSync(new Runnable() {
+                @Override
+                public void run() {
+                    mXWalkView.stopLoading();
+                }
+            });
+            assertTrue(true);
+       } catch (Exception e) {
+           assertTrue(false);
+           e.printStackTrace();
+       }
+    }
+
+    @SmallTest
+    public void testGetUrl() {
+        try {
+            String url = "file:///android_asset/p1bar.html";
+            loadUrlSync(url);
+            assertEquals(url, getUrlOnUiThread());
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testGetOriginalUrl() {
+        try {
+            String originalUrl = "file:///android_asset/p2bar.html";
+            String url = "file:///android_asset/p1bar.html";
+            loadUrlSync(originalUrl);
+            loadUrlSync(url);
+            assertEquals(originalUrl, getOriginalUrlOnUiThread());
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testGetTitle() {
+        try {
+            final String name = "p1bar.html";
+            loadAssetFile(name);
+            String title = getTitleOnUiThread();
+            assertEquals("Test", title);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testGetTitle2() {
+        try {
+            loadUrlSync("file:///android_asset/p1bar.html");
+            String title = getTitleOnUiThread();
+            assertEquals("Test", title);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testGetNavigationHistory() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkNavigationHistory xnh = mXWalkView.getNavigationHistory();
+                    assertNotNull(xnh);
+                }
+            });
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+    }
+
+}

--- a/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/test/NavigationTest.java
+++ b/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/test/NavigationTest.java
@@ -1,0 +1,289 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedding.test;
+
+import org.xwalk.core.XWalkNavigationItem;
+import org.xwalk.embedding.MainActivity;
+import org.xwalk.embedding.base.XWalkViewTestBase;
+
+import android.os.SystemClock;
+import android.test.suitebuilder.annotation.SmallTest;
+
+
+public class NavigationTest extends XWalkViewTestBase {
+
+    public NavigationTest() {
+        super(MainActivity.class);
+    }
+
+    @SmallTest
+    public void testSize() {
+        try {
+            final String url1 = "about:blank";
+            final String url2 = "file:///android_asset/manifest.json";
+            loadUrlSync(url1);
+            loadUrlSync(url2);
+            goBackSync(1);
+            assertEquals("2", getSizeOnUiThread());
+        }catch (Throwable e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
+    @SmallTest
+    public void testHasItemAt() {
+         try {
+           final String url1 = "about:blank";
+           final String url2 = "file:///android_asset/manifest.json";
+           loadUrlSync(url1);
+           loadUrlSync(url2);
+           goBackSync(1);
+           assertEquals("true", hasItemAtOnUiThread());
+         }catch (Throwable e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
+    @SmallTest
+    public void testGetItemAt() {
+        try {
+            final String url1 = "about:blank";
+            final String url2 = "file:///android_asset/manifest.json";
+            loadUrlSync(url1);
+            loadUrlSync(url2);
+            goBackSync(1);
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkNavigationItem item = mXWalkView.getNavigationHistory().getItemAt(1);
+                    assertNotNull(item);
+                }
+            });
+        }catch (Throwable e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
+    @SmallTest
+    public void testGetCurrentItem() {
+        try {
+            final String url1 = "about:blank";
+            final String url2 = "file:///android_asset/manifest.json";
+            loadUrlSync(url1);
+            loadUrlSync(url2);
+            goBackSync(1);
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkNavigationItem item = mXWalkView.getNavigationHistory().getCurrentItem();
+                    XWalkNavigationItem item1 = mXWalkView.getNavigationHistory().getItemAt(0);
+                    assertEquals(item1.getUrl(), item.getUrl());
+                }
+            });
+        }catch (Throwable e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
+    @SmallTest
+    public void testGetCurrentItem2() {
+        try {
+            final String url1 = "about:blank";
+            final String url2 = "file:///android_asset/manifest.json";
+            loadUrlSync(url1);
+            loadUrlSync(url2);
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkNavigationItem item = mXWalkView.getNavigationHistory().getCurrentItem();
+                    assertEquals(url2, item.getUrl());
+                }
+            });
+        }catch (Throwable e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
+    @SmallTest
+    public void testGetCurrentIndex() {
+        try {
+            final String url1 = "about:blank";
+            final String url2 = "file:///android_asset/manifest.json";
+            final String url3 = "file:///android_asset/p1bar.html";
+            loadUrlSync(url1);
+            loadUrlSync(url2);
+            loadUrlSync(url3);
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    int index = mXWalkView.getNavigationHistory().getCurrentIndex();
+                    assertEquals(2, index);
+                }
+            });
+        }catch (Throwable e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
+    @SmallTest
+    public void testCanGoBack()
+    {
+        try {
+            final String url1 = "about:blank";
+            final String url2 = "file:///android_asset/manifest.json";
+            assertFalse(canGoBackOnUiThread());
+            loadUrlSync(url1);
+            assertFalse(canGoBackOnUiThread());
+            loadUrlSync(url2);
+            assertTrue(canGoBackOnUiThread());
+        } catch (Throwable e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
+    @SmallTest
+    public void testCanGoForward() {
+        try {
+            final String url1 = "about:blank";
+            final String url2 = "file:///android_asset/manifest.json";
+            assertFalse(canGoForwardOnUiThread());
+            loadUrlSync(url1);
+            loadUrlSync(url2);
+            getUrlOnUiThread();
+            assertFalse(canGoForwardOnUiThread());
+            goBackSync(1);
+            SystemClock.sleep(1000);
+            assertTrue(canGoForwardOnUiThread());
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        } catch (Throwable e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
+    @SmallTest
+    public void testNavigateBack() {
+        try {
+            final String url1 = "about:blank";
+            final String url2 = "file:///android_asset/manifest.json";
+            loadUrlSync(url1);
+            loadUrlSync(url2);
+            goBackSync(1);
+            assertEquals(url1, getUrlOnUiThread());
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        } catch (Throwable e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+     }
+
+    @SmallTest
+    public void testNavigateForward() {
+        try {
+            final String url1 = "about:blank";
+            final String url2 = "file:///android_asset/manifest.json";
+            loadUrlSync(url1);
+            loadUrlSync(url2);
+            goBackSync(1);
+            goForwardSync(1);
+            assertEquals(url2, getUrlOnUiThread());
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        } catch (Throwable e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
+    @SmallTest
+    public void testNavigateBack2() {
+        try {
+            final String url1 = "about:blank";
+            final String url2 = "file:///android_asset/manifest.json";
+            final String url3 = "file:///android_asset/p1bar.html";
+            loadUrlSync(url1);
+            loadUrlSync(url2);
+            loadUrlSync(url3);
+            goBackSync(2);
+            assertEquals(url1, getUrlOnUiThread());
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        } catch (Throwable e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
+    @SmallTest
+    public void testNavigateForward2() {
+        try {
+            final String url1 = "about:blank";
+            final String url2 = "file:///android_asset/manifest.json";
+            final String url3 = "file:///android_asset/p1bar.html";
+            loadUrlSync(url1);
+            loadUrlSync(url2);
+            loadUrlSync(url3);
+            goBackSync(1);
+            goBackSync(1);
+            goForwardSync(2);
+            assertEquals(url3,  getCurrentItemUrlOnUiThread());
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        } catch (Throwable e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
+
+    @SmallTest
+    public void testClear() {
+        try {
+            final String url1 = "about:blank";
+            final String url2 = "file:///android_asset/manifest.json";
+            loadUrlSync(url1);
+            loadUrlSync(url2);
+            goBackSync(1);
+            assertEquals(url1, getUrlOnUiThread());
+            goForwardSync(1);
+
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    mXWalkView.getNavigationHistory().clear();
+                    XWalkNavigationItem item = mXWalkView.getNavigationHistory().getCurrentItem();
+                    int index = mXWalkView.getNavigationHistory().getCurrentIndex();
+                    assertEquals(url2, item.getUrl());
+                    assertEquals(0,index);
+                }
+            });
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        } catch (Throwable e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+}

--- a/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/test/XWalkJavascriptResultTest.java
+++ b/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/test/XWalkJavascriptResultTest.java
@@ -1,0 +1,143 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedding.test;
+
+
+import org.xwalk.core.XWalkJavascriptResult;
+import org.xwalk.core.XWalkUIClient;
+import org.xwalk.embedding.MainActivity;
+import org.xwalk.embedding.base.XWalkViewTestBase;
+
+import android.annotation.SuppressLint;
+import android.test.suitebuilder.annotation.SmallTest;
+
+@SuppressLint("NewApi")
+public class XWalkJavascriptResultTest extends XWalkViewTestBase {
+
+    public XWalkJavascriptResultTest() {
+        super(MainActivity.class);
+    }
+
+    @SmallTest
+    public void testConfirmWithResult() {
+        try {
+            final String url1 = "file:///android_asset/p1bar.html";
+            final String url2 = "file:///android_asset/p2bar.html";
+
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                XWalkUIClient client = new XWalkUIClient(mXWalkView);
+                XWalkJavascriptResult result = new XWalkJavascriptResult() {
+
+                    @Override
+                    public void confirmWithResult(String arg0) {
+
+                    }
+                    
+                    @Override
+                    public void confirm() {
+                        mXWalkView.load(url2, null);
+                    }
+                    
+                    @Override
+                    public void cancel() {
+
+                    }
+                };
+
+                @Override
+                public void run() {
+                    client.onJavascriptModalDialog(mXWalkView, XWalkUIClient.JavascriptMessageType.JAVASCRIPT_PROMPT, url1, "11", "22", result);
+
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+     }
+
+
+    @SmallTest
+    public void testConfirm() {
+        try {
+            final String url1 = "file:///android_asset/p1bar.html";
+            final String url2 = "file:///android_asset/p2bar.html";
+
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                XWalkUIClient client = new XWalkUIClient(mXWalkView);
+                XWalkJavascriptResult result = new XWalkJavascriptResult() {
+
+                    @Override
+                    public void confirmWithResult(String arg0) {
+
+                    }
+
+                    @Override
+                    public void confirm() {
+                        mXWalkView.load(url2, null);
+                    }
+                    
+                    @Override
+                    public void cancel() {
+
+                    }
+                };
+
+                @Override
+                public void run() {
+                    client.onJavascriptModalDialog(mXWalkView, XWalkUIClient.JavascriptMessageType.JAVASCRIPT_PROMPT, url1, "11", "22", result);
+                    result.confirm();
+                }
+            });
+            assertEquals(url2, getUrlOnUiThread());
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
+    @SmallTest
+    public void testCancel() {
+        try {
+            final String url1 = "file:///android_asset/p1bar.html";
+            final String url2 = "file:///android_asset/p2bar.html";
+
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                XWalkUIClient client = new XWalkUIClient(mXWalkView);
+                XWalkJavascriptResult result = new XWalkJavascriptResult() {
+
+                    @Override
+                    public void confirmWithResult(String arg0) {
+
+                    }
+
+                    @Override
+                    public void confirm() {
+
+                    }
+
+                    @Override
+                    public void cancel() {
+                        mXWalkView.load(url2, null);
+                    }
+                };
+
+                @Override
+                public void run() {
+                    client.onJavascriptModalDialog(mXWalkView, XWalkUIClient.JavascriptMessageType.JAVASCRIPT_PROMPT, url1, "11", "22", result);
+                    result.cancel();
+                }
+            });
+            assertEquals(url2, getUrlOnUiThread());
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+}

--- a/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/test/XWalkNavigationItemTest.java
+++ b/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/test/XWalkNavigationItemTest.java
@@ -12,86 +12,73 @@ import android.annotation.SuppressLint;
 import android.test.suitebuilder.annotation.SmallTest;
 
 @SuppressLint("NewApi")
-public class XWalkNavigationItemTest extends  XWalkViewTestBase {
+public class XWalkNavigationItemTest extends XWalkViewTestBase {
 
-    
     public XWalkNavigationItemTest() {
         super(MainActivity.class);
     }
 
     @SmallTest
-    public void testGetNavigationItemUrl()
-    {
-          try
-          {
-              final String url1 = "about:blank";
-              final String url2 = "file:///android_asset/manifest.json";
-              loadUrlSync(url1);
-              loadUrlSync(url2);
-              String url = getNavigationUrlOnUiThread();
-              assertEquals(url2, url);
-          } catch (Exception e) {
-              e.printStackTrace();
-              assertTrue(false);
+    public void testGetNavigationItemUrl() {
+        try {
+            final String url1 = "about:blank";
+            final String url2 = "file:///android_asset/manifest.json";
+            loadUrlSync(url1);
+            loadUrlSync(url2);
+            String url = getNavigationUrlOnUiThread();
+            assertEquals(url2, url);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
         }
     }
-    
+
     @SmallTest
-    public void testGetNavigationItemOriginalUrl()
-    {
-          try
-          {
-              final String url1 = "about:blank";
-              final String url2 = "file:///android_asset/manifest.json";
-              final String url3 = "file:///android_asset/p1bar.html";
-              loadUrlSync(url1);
-              loadUrlSync(url2);
-             loadUrlSync(url3);
-             
-             goBackSync(2);
-              String url = getNavigationOriginalUrlOnUiThread();
-              assertEquals(url3, url);
-          } catch (Exception e) {
-              e.printStackTrace();
-              assertTrue(false);
+    public void testGetNavigationItemOriginalUrl() {
+        try {
+            final String url1 = "about:blank";
+            final String url2 = "file:///android_asset/manifest.json";
+            final String url3 = "file:///android_asset/p1bar.html";
+            loadUrlSync(url1);
+            loadUrlSync(url2);
+            loadUrlSync(url3);
+            goBackSync(2);
+            String url = getNavigationOriginalUrlOnUiThread();
+            assertEquals(url3, url);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
         } catch (Throwable e) {
             e.printStackTrace();
         }
     }
-    
+
     @SmallTest
-    public void testGetNavigationItemTitle()
-    {
-          try
-          {
-              final String url1 = "about:blank";
-              final String url2 = "file:///android_asset/manifest.json";
-              final String url3 = "file:///android_asset/p1bar.html";
-              loadUrlSync(url1);
-              loadUrlSync(url2);
-             loadUrlSync(url3);
-             
-              String title = getNavigationTitleOnUiThread();
-              assertEquals("Test", title);
-          } catch (Exception e) {
-              e.printStackTrace();
-              assertTrue(false);
+    public void testGetNavigationItemTitle() {
+        try {
+            final String url1 = "about:blank";
+            final String url2 = "file:///android_asset/manifest.json";
+            final String url3 = "file:///android_asset/p1bar.html";
+            loadUrlSync(url1);
+            loadUrlSync(url2);
+            loadUrlSync(url3);
+            String title = getNavigationTitleOnUiThread();
+            assertEquals("Test", title);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
         } catch (Throwable e) {
             e.printStackTrace();
         }
     }
-     
-    
+
     @SmallTest
-    public void testGetFaviconExist()
-    {
-          try
-          {
-              assertTrue(false);
-          } catch (Exception e) {
-              e.printStackTrace();
-              assertTrue(false);
+    public void testGetFaviconExist() {
+        try {
+            assertTrue(false);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
         } 
     }
-     
 }

--- a/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/test/XWalkPreferenceTest.java
+++ b/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/test/XWalkPreferenceTest.java
@@ -1,0 +1,92 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedding.test;
+
+
+import org.xwalk.core.XWalkPreferences;
+import org.xwalk.embedding.MainActivity;
+import org.xwalk.embedding.base.XWalkViewTestBase;
+
+import android.test.suitebuilder.annotation.SmallTest;
+
+public class XWalkPreferenceTest extends XWalkViewTestBase {
+
+    public XWalkPreferenceTest() {
+        super(MainActivity.class);
+    }
+
+     
+    @SmallTest
+    public void testSetValue1() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkPreferences.setValue(XWalkPreferences.REMOTE_DEBUGGING, false);
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testSetValue2() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkPreferences.setValue(XWalkPreferences.REMOTE_DEBUGGING, true);
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testGetValue1() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run()  {
+                    boolean flag = XWalkPreferences.getValue(XWalkPreferences.REMOTE_DEBUGGING);
+                    assertEquals(false, flag);
+                }
+            });
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testGetValue2() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run()  {
+                    XWalkPreferences.setValue(XWalkPreferences.REMOTE_DEBUGGING, true);
+                    boolean flag = XWalkPreferences.getValue(XWalkPreferences.REMOTE_DEBUGGING);
+                    assertEquals(true, flag);
+                }
+            });
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+}

--- a/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/test/XWalkResourceClientTest.java
+++ b/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/test/XWalkResourceClientTest.java
@@ -1,0 +1,165 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedding.test;
+
+import org.xwalk.core.XWalkResourceClient;
+import org.xwalk.core.internal.XWalkClient;
+import org.xwalk.embedding.MainActivity;
+import org.xwalk.embedding.base.XWalkViewTestBase;
+
+import android.annotation.SuppressLint;
+import android.test.suitebuilder.annotation.SmallTest;
+import android.webkit.ValueCallback;
+
+public class XWalkResourceClientTest extends XWalkViewTestBase {
+
+
+    public XWalkResourceClientTest() {
+        super(MainActivity.class);
+    }
+
+
+    @SmallTest
+    public void testOnLoadStarted() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkResourceClient client = new XWalkResourceClient(getXWalkView());
+                    mXWalkView.setResourceClient(client);
+                    client.onLoadStarted(mXWalkView, "http://www.baidu.com");
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnLoadFinished() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run()  {
+                    XWalkResourceClient client = new XWalkResourceClient(getXWalkView());
+                    mXWalkView.setResourceClient(client);
+                    client.onLoadFinished(mXWalkView, "http://www.baidu.com");
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnProgressChanged() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkResourceClient client = new XWalkResourceClient(getXWalkView());
+                    mXWalkView.setResourceClient(client);
+                    client.onProgressChanged(mXWalkView, NUM_NAVIGATIONS);
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testShouldInterceptLoadRequest() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run()  {
+                    XWalkResourceClient client = new XWalkResourceClient(mXWalkView);
+                    mXWalkView.setResourceClient(client);
+                    client.shouldInterceptLoadRequest(mXWalkView, "http://www.baidu.com/");
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnReceivedLoadError() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkResourceClient client = new XWalkResourceClient(mXWalkView);
+                    mXWalkView.setResourceClient(client);
+                    client.onReceivedLoadError(mXWalkView, NUM_NAVIGATIONS, null, "http://www.baidu.com/");
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testShouldOverrideUrlLoading() {
+        try {
+            loadUrlSync("about:blank");
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkResourceClient client = new XWalkResourceClient(mXWalkView);
+                    assertFalse(client.shouldOverrideUrlLoading(mXWalkView,"about:blank"));
+                }
+            });
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnReceivedSslError() {
+        try {
+            loadUrlSync("about:blank");
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @SuppressLint("NewApi")
+                @Override
+                public void run() {
+                    XWalkClient client = new XWalkClient(mXWalkView);
+                    ValueCallback<Boolean> callback =
+                            new ValueCallback<Boolean>() {
+
+                        @Override
+                        public void onReceiveValue(Boolean arg0) {
+
+                        }
+                    };
+                    client.onReceivedSslError(mXWalkView, callback, null);
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+}

--- a/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/test/XWalkUIClientTest.java
+++ b/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/test/XWalkUIClientTest.java
@@ -1,0 +1,234 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedding.test;
+
+
+import org.xwalk.core.XWalkJavascriptResult;
+import org.xwalk.core.XWalkUIClient;
+import org.xwalk.embedding.MainActivity;
+import org.xwalk.embedding.base.XWalkViewTestBase;
+
+import android.annotation.SuppressLint;
+import android.net.Uri;
+import android.test.suitebuilder.annotation.SmallTest;
+import android.webkit.ValueCallback;
+
+@SuppressLint("NewApi")
+public class XWalkUIClientTest extends XWalkViewTestBase {
+
+    public XWalkUIClientTest() {
+        super(MainActivity.class);
+    }
+
+
+    @SmallTest
+    public void testOnRequestFocus() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkUIClient uiClient = new XWalkUIClient(mXWalkView);
+                    uiClient.onRequestFocus(mXWalkView);
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnJavascriptCloseWindow() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkUIClient uiClient = new XWalkUIClient(mXWalkView);
+                    uiClient.onJavascriptCloseWindow(mXWalkView);
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnFullscreenToggled() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run()  {
+                    XWalkUIClient uiClient = new XWalkUIClient(mXWalkView);
+                    uiClient.onFullscreenToggled(mXWalkView, true);
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOpenFileChooser() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkUIClient uiClient = new XWalkUIClient(mXWalkView);
+                    ValueCallback<Uri> uploadFile = new ValueCallback<Uri>() {
+
+                        @Override
+                        public void onReceiveValue(Uri arg0) {
+
+                        }
+
+                    };
+                    uiClient.openFileChooser(mXWalkView, uploadFile, "", "hello");
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnScaleChanged() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkUIClient uiClient = new XWalkUIClient(mXWalkView);
+                    uiClient.onScaleChanged(mXWalkView, WAIT_TIMEOUT_SECONDS, NUM_NAVIGATIONS);
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnPageStartedExist() {
+        try {
+            assertTrue(false);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnPageFinishedExist() {
+        try {
+            assertTrue(false);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnReceivedAppNameExist() {
+        try {
+            assertTrue(false);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnReceivedIconExist() {
+        try {
+            assertTrue(false);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnJsAlertExist() {
+        try {
+            assertTrue(false);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnJsConfirmExist() {
+        try {
+            assertTrue(false);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnJsPromptExist() {
+        try {
+            assertTrue(false);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testTOnJavascriptModalDialog() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                XWalkUIClient uiClient = new XWalkUIClient(mXWalkView);
+
+                    XWalkJavascriptResult result = new XWalkJavascriptResult() {
+
+                        @Override
+                        public void confirmWithResult(String arg0) {
+
+                        }
+
+                        @Override
+                        public void confirm() {
+
+                        }
+
+                        @Override
+                        public void cancel() {
+
+                        }
+                    };
+
+                    uiClient.onJavascriptModalDialog(mXWalkView, XWalkUIClient.JavascriptMessageType.JAVASCRIPT_ALERT, "http://www.baidu.com/", "11", "22", result);
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }catch (Throwable t)
+        {
+            assertTrue(false);
+        }
+
+    }
+}

--- a/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/test/XWalkViewTest.java
+++ b/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/test/XWalkViewTest.java
@@ -1,0 +1,399 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedding.test;
+
+
+import java.util.concurrent.Callable;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.xwalk.core.XWalkResourceClient;
+import org.xwalk.core.XWalkUIClient;
+import org.xwalk.embedding.MainActivity;
+import org.xwalk.embedding.base.XWalkViewTestBase;
+
+import android.annotation.SuppressLint;
+import android.content.Intent;
+import android.os.Bundle;
+import android.test.suitebuilder.annotation.SmallTest;
+import android.view.KeyEvent;
+import android.webkit.ValueCallback;
+
+@SuppressLint("NewApi")
+public class XWalkViewTest extends XWalkViewTestBase {
+
+
+    public XWalkViewTest() {
+        super(MainActivity.class);
+    }
+
+    @SmallTest
+    public void testAddJavascriptInterface() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run()  {
+                    mXWalkView.addJavascriptInterface(new TestJavascriptInterface(), "testInterface");
+
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testEvaluateJavascript() {
+        try {
+            final String name = "p1bar.html";
+            final String code = "document.title=\"xwalk\"";
+            loadAssetFile(name);
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    mXWalkView.evaluateJavascript(code, new ValueCallback<String>() {
+
+                        @Override
+                        public void onReceiveValue(String arg0) {
+
+                        }
+                    });
+                }
+            });
+            assertTrue(true);
+       } catch (Exception e) {
+           e.printStackTrace();
+           assertTrue(false);
+       }
+    }
+    
+    @SmallTest
+    public void testClearCache() throws Throwable {
+
+        try {
+            String url = "file:///android_asset/p1bar.html/";
+            loadUrlSync(url);
+            clearCacheOnUiThread(false);
+            assertTrue(true);
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
+    @SmallTest
+    public void testClearCache2() throws Throwable {
+
+        try {
+            String url = "file:///android_asset/p1bar.html";
+            loadUrlSync(url);
+            clearCacheOnUiThread(true);
+            assertTrue(true);
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
+    @SmallTest
+    public void testPauseTimers() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    mXWalkView.pauseTimers();
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testResumeTimers() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run()  {
+                    mXWalkView.pauseTimers();
+                    mXWalkView.resumeTimers();
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnHide() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    mXWalkView.onHide();
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnShow() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    mXWalkView.onShow();
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnDestroy() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    mXWalkView.onDestroy();
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnActivityResult() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    mXWalkView.onActivityResult(WAIT_TIMEOUT_SECONDS, NUM_NAVIGATIONS, null);
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnNewIntent() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable()  {
+
+                @Override
+                public void run()  {
+                    Intent intent = new Intent();
+                    intent.setClassName("org.xwalk.embedding", MainActivity.class.getName());
+                    mXWalkView.onNewIntent(intent);
+
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testSaveState() throws Throwable {
+        final Bundle state = new Bundle();
+        state.putByteArray("XWALKVIEW_STATE", "valid state".getBytes());
+        boolean result = runTestOnUiThreadAndGetResult(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return mXWalkView.saveState(state);
+            }
+        });
+        assertTrue(result);
+    }
+
+    @SmallTest
+    public void testSaveState2() throws Throwable {
+        setServerResponseAndLoad(NUM_NAVIGATIONS);
+        saveAndRestoreStateOnUiThread();
+        checkHistoryItemList();
+    }
+
+    @SmallTest
+    public void testRestoreStateTrue() throws Throwable {
+        try {
+            final Bundle state = new Bundle();
+            state.putByteArray("XWALKVIEW_STATE", "valid state".getBytes());
+            loadUrlSync("file:///android_asset/p1bar.html/");
+            boolean result = runTestOnUiThreadAndGetResult(new Callable<Boolean>() {
+                @Override
+                public Boolean call() throws Exception {
+                    mXWalkView.saveState(state);
+                    return mXWalkView.restoreState(state);
+                }
+            });
+            assertTrue(result);
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
+    @SmallTest
+    public void testRestoreStateFalse() throws Throwable {
+        try {
+            final Bundle state = new Bundle();
+            state.putByteArray("XWALKVIEW_STATE", "valid state".getBytes());
+            loadUrlSync("file:///android_asset/p1bar.html/");
+            boolean result = runTestOnUiThreadAndGetResult(new Callable<Boolean>() {
+                @Override
+                public Boolean call() throws Exception {
+                    return mXWalkView.restoreState(state);
+                }
+            });
+            assertFalse(result);
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+     }
+
+    @SmallTest
+    public void testRestoreStateFalse2() throws Throwable {
+        try {
+            final Bundle state = new Bundle();
+            state.putByteArray("XWALKVIEW_STATE", "valid state".getBytes());
+            boolean result = runTestOnUiThreadAndGetResult(new Callable<Boolean>() {
+                @Override
+                public Boolean call() throws Exception {
+                    mXWalkView.saveState(state);
+                    return mXWalkView.restoreState(state);
+                }
+            });
+            assertFalse(result);
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
+    @SmallTest
+    public void testGetAPIVersion() throws Throwable {
+        try {
+            String version = getAPIVersionOnUiThread();
+            Pattern pattern = Pattern.compile("^[0-9]+(.[0-9]+)$");
+            Matcher matcher = pattern.matcher(version);
+            assertTrue("The API version is invalid.", matcher.find());
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+     }
+
+    @SmallTest
+    public void testGetXWalkVersion() throws Throwable {
+        try {
+            String version = getXWalkVersionOnUiThread();
+            Pattern pattern = Pattern.compile("\\d+\\.\\d+\\.\\d+\\.\\d+");
+            Matcher matcher = pattern.matcher(version);
+            assertTrue("The Crosswalk version is invalid.", matcher.find());
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
+    @SmallTest
+    public void testSetResourceClient() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    mXWalkView.setResourceClient(new XWalkResourceClient(mXWalkView));
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testSetUIClient() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run()  {
+                    mXWalkView.setUIClient(new XWalkUIClient(mXWalkView));
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnKeyUp() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run()  {
+                    mXWalkView.onKeyUp(0, null);
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnKeyDown() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    mXWalkView.onKeyDown(65, new KeyEvent(0, 65));
+
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+}

--- a/embeddingapi/webapi-embeddingapi-xwalk-tests/tests.xml
+++ b/embeddingapi/webapi-embeddingapi-xwalk-tests/tests.xml
@@ -2,6 +2,14 @@
 <?xml-stylesheet type="text/xsl" href="./testcase.xsl"?>
 <test_definition>
   <suite name="tct-embedding-tests" category="Android embedding APIs">
+    <set name="LoadTest" test_set_src="org.xwalk.embedding.test.LoadTest"></set>
+    <set name="NavigationTest" test_set_src="org.xwalk.embedding.test.NavigationTest"></set>
     <set name="XWalkNavigationItemTest" test_set_src="org.xwalk.embedding.test.XWalkNavigationItemTest"></set>
+    <set name="XWalkViewTest" test_set_src="org.xwalk.embedding.test.XWalkViewTest"></set>
+    <set name="XWalkUIClientTest" test_set_src="org.xwalk.embedding.test.XWalkUIClientTest"></set>
+    <set name="XWalkResourceClientTest" test_set_src="org.xwalk.embedding.test.XWalkResourceClientTest"></set>
+    <set name="XWalkPreferenceTest" test_set_src="org.xwalk.embedding.test.XWalkPreferenceTest"></set>
+    <set name="XWalkJavascriptResultTest" test_set_src="org.xwalk.embedding.test.XWalkJavascriptResultTest"></set>
+    <set name="FullScreenTest" test_set_src="org.xwalk.embedding.test.FullScreenTest"></set>
   </suite>
 </test_definition>


### PR DESCRIPTION
- Add 80 cases about the unit tests for embedding api.
- Failure analysis:8 cases are failed because the methods of embedding api are not exist.
  Others are failed or blocked because the methods of embedding api do not support.

Impacted tests(designed|approved): new 80, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 68, fail 12, block 4
