### PR TITLE
[wrt] Update case status for wrt-packertoolauto-android-tests

### DIFF
--- a/wrt/wrt-packertoolauto-android-tests/tests.full.xml
+++ b/wrt/wrt-packertoolauto-android-tests/tests.full.xml
@@ -3,7 +3,7 @@
 <test_definition>
   <suite category="wrt-packertoolauto-android-tests" name="wrt-packertoolauto-android-tests" launcher="xwalk">
     <set description="allpairs" name="allpairs">
-      <testcase purpose="Check if packer tool work properly" type="Functional" status="designed" component="wrt-packertoolauto-android-tests" execution_type="auto" priority="P1" id="Crosswalk_Packer_Tool_Check">
+      <testcase purpose="Check if packer tool work properly" type="Functional" status="approved" component="wrt-packertoolauto-android-tests" execution_type="auto" priority="P1" id="Crosswalk_Packer_Tool_Check">
         <description>
           <test_script_entry test_script_expected_result="0" timeout="100000" >python $HOME/tct/opt/wrt-packertoolauto-android-tests/test.py
           </test_script_entry>


### PR DESCRIPTION
Impacted TCs num: New 174,Update 0 Delete 0
Unit test Platform: Android
Unit test result summary: Pass 110, Fail 64, Block 0
Commnet:
section “name” can be any string accroding to the w3c feature,but in fact it is not.
