### PR TITLE
[webapi][XWALK-549]Modify test cases status for gamepad

### DIFF
--- a/misc/webapi-usecase-w3c-tests/tests.android.xml
+++ b/misc/webapi-usecase-w3c-tests/tests.android.xml
@@ -257,6 +257,18 @@
           <test_script_entry test_script_expected_result="0"/>
         </description>
       </testcase>
+      <testcase component="usecase" execution_type="manual" id="GamePad" purpose="GamePad Test">
+        <description>
+          <pre_condition/>
+          <steps>
+            <step order="1">
+              <step_desc>0</step_desc>
+              <expected>0</expected>
+            </step>
+          </steps>
+          <test_script_entry test_script_expected_result="0"/>
+        </description>
+      </testcase>
     </set>
     <set name="Gesture">
       <testcase component="usecase" execution_type="manual" id="Touch" purpose="Touch Test">

--- a/misc/webapi-usecase-w3c-tests/tests.full.xml
+++ b/misc/webapi-usecase-w3c-tests/tests.full.xml
@@ -308,7 +308,7 @@
           <test_script_entry test_script_expected_result="0"/>
         </description>
       </testcase>
-      <testcase purpose="GamePad Test" type="functional_positive" status="designed" component="usecase" execution_type="manual" platform="android" priority="P0" id="GamePad">
+      <testcase purpose="GamePad Test" type="functional_positive" status="approved" component="usecase" execution_type="manual" platform="android" priority="P0" id="GamePad">
         <capability name="accelerometer"/>
         <description>
           <pre_condition/>

--- a/webapi/webapi-gamepad-w3c-tests/tests.full.xml
+++ b/webapi/webapi-gamepad-w3c-tests/tests.full.xml
@@ -3,7 +3,7 @@
 <test_definition>
   <suite name="webapi-gamepad-w3c-tests" launcher="xwalk" category="W3C/HTML5 APIs">
     <set name="Gamepad">
-      <testcase purpose="Check if the basic of gamepad is valid." type="compliance" status="designed" component="WebAPI/Device APIs/Gamepad" execution_type="manual" priority="P1" id="GamePad_basic">
+      <testcase purpose="Check if the basic of gamepad is valid." type="compliance" status="approved" component="WebAPI/Device APIs/Gamepad" execution_type="manual" priority="P1" id="GamePad_basic">
         <description>
           <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/GamePad_basic-manual.html</test_script_entry>
         </description>
@@ -15,7 +15,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="check if the axes attribute of gamepad interface can return array of values for all axes of the gamepad." type="compliance" status="designed" component="WebAPI/Device APIs/Gamepad" execution_type="manual" priority="P1" id="GamePad_axes">
+      <testcase purpose="check if the axes attribute of gamepad interface can return array of values for all axes of the gamepad." type="compliance" status="approved" component="WebAPI/Device APIs/Gamepad" execution_type="manual" priority="P1" id="GamePad_axes">
         <description>
           <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/GamePad_axes-manual.html</test_script_entry>
         </description>
@@ -27,7 +27,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="check if the buttons attribute of gamepad interface can return the array of buttons on gamepad." type="compliance" status="designed" component="WebAPI/Device APIs/Gamepad" execution_type="manual" priority="P1" id="GamePad_buttons">
+      <testcase purpose="check if the buttons attribute of gamepad interface can return the array of buttons on gamepad." type="compliance" status="approved" component="WebAPI/Device APIs/Gamepad" execution_type="manual" priority="P1" id="GamePad_buttons">
         <description>
           <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/GamePad_buttons-manual.html</test_script_entry>
         </description>
@@ -39,7 +39,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="check if the connected attribute of gamepad interface can return whether the gamepad is connected." type="compliance" status="designed" component="WebAPI/Device APIs/Gamepad" execution_type="manual" priority="P1" id="GamePad_connected">
+      <testcase purpose="check if the connected attribute of gamepad interface can return whether the gamepad is connected." type="compliance" status="approved" component="WebAPI/Device APIs/Gamepad" execution_type="manual" priority="P1" id="GamePad_connected">
         <description>
           <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/GamePad_connected-manual.html</test_script_entry>
         </description>
@@ -51,7 +51,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="check if the id attribute of gamepad interface can return the name of gamepad." type="compliance" status="designed" component="WebAPI/Device APIs/Gamepad" execution_type="manual" priority="P1" id="GamePad_id">
+      <testcase purpose="check if the id attribute of gamepad interface can return the name of gamepad." type="compliance" status="approved" component="WebAPI/Device APIs/Gamepad" execution_type="manual" priority="P1" id="GamePad_id">
         <description>
           <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/GamePad_id-manual.html</test_script_entry>
         </description>
@@ -63,7 +63,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="check if the index attribute of gamepad interface can return the index of the gamepad in the Navigator." type="compliance" status="designed" component="WebAPI/Device APIs/Gamepad" execution_type="manual" priority="P1" id="GamePad_index">
+      <testcase purpose="check if the index attribute of gamepad interface can return the index of the gamepad in the Navigator." type="compliance" status="approved" component="WebAPI/Device APIs/Gamepad" execution_type="manual" priority="P1" id="GamePad_index">
         <description>
           <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/GamePad_index-manual.html</test_script_entry>
         </description>
@@ -75,7 +75,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="check if the mapping attribute of gamepad interface can return the mapping in use for this device." type="compliance" status="designed" component="WebAPI/Device APIs/Gamepad" execution_type="manual" priority="P1" id="GamePad_mapping">
+      <testcase purpose="check if the mapping attribute of gamepad interface can return the mapping in use for this device." type="compliance" status="approved" component="WebAPI/Device APIs/Gamepad" execution_type="manual" priority="P1" id="GamePad_mapping">
         <description>
           <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/GamePad_mapping-manual.html</test_script_entry>
         </description>
@@ -87,7 +87,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="check if the timestamp attribute of gamepad interface can return last time the data for this gamepad was updated." type="compliance" status="designed" component="WebAPI/Device APIs/Gamepad" execution_type="manual" priority="P1" id="GamePad_timestamp">
+      <testcase purpose="check if the timestamp attribute of gamepad interface can return last time the data for this gamepad was updated." type="compliance" status="approved" component="WebAPI/Device APIs/Gamepad" execution_type="manual" priority="P1" id="GamePad_timestamp">
         <description>
           <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/GamePad_timestamp-manual.html</test_script_entry>
         </description>
@@ -99,7 +99,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="check if the basic of gamepadbutton interface is valid." type="compliance" status="designed" component="WebAPI/Device APIs/Gamepad" execution_type="manual" priority="P1" id="GamePadButton_basic">
+      <testcase purpose="check if the basic of gamepadbutton interface is valid." type="compliance" status="approved" component="WebAPI/Device APIs/Gamepad" execution_type="manual" priority="P1" id="GamePadButton_basic">
         <description>
           <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/GamePadButton_basic-manual.html</test_script_entry>
         </description>
@@ -111,7 +111,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="check if the function of gamepadbutton interface is valid." type="compliance" status="designed" component="WebAPI/Device APIs/Gamepad" execution_type="manual" priority="P1" id="GamePadButton_function">
+      <testcase purpose="check if the function of gamepadbutton interface is valid." type="compliance" status="approved" component="WebAPI/Device APIs/Gamepad" execution_type="manual" priority="P1" id="GamePadButton_function">
         <description>
           <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/GamePadButton_function-manual.html</test_script_entry>
         </description>
@@ -123,7 +123,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if GamepadEvent exist" type="compliance" status="designed" component="WebAPI/System-level APIs/Gamepad" execution_type="auto" priority="P1" id="GamepadEvent_basic">
+      <testcase purpose="Check if GamepadEvent exist" type="compliance" status="approved" component="WebAPI/System-level APIs/Gamepad" execution_type="auto" priority="P1" id="GamepadEvent_basic">
         <description>
           <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/GamepadEvent_basic.html</test_script_entry>
         </description>
@@ -135,7 +135,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if the gamepad of gamepadevent can return the gamepad which fire the event." type="compliance" status="designed" component="WebAPI/Device APIs/Gamepad" execution_type="manual" priority="P1" id="GamepadEvent_gamepad">
+      <testcase purpose="Check if the gamepad of gamepadevent can return the gamepad which fire the event." type="compliance" status="approved" component="WebAPI/Device APIs/Gamepad" execution_type="manual" priority="P1" id="GamepadEvent_gamepad">
         <description>
           <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/GamepadEvent_gamepad-manual.html</test_script_entry>
         </description>
@@ -147,7 +147,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if the gamepadconnected event can be fired." type="compliance" status="designed" component="WebAPI/Device APIs/Gamepad" execution_type="manual" priority="P1" id="GamepadEvent_gamepadconnected">
+      <testcase purpose="Check if the gamepadconnected event can be fired." type="compliance" status="approved" component="WebAPI/Device APIs/Gamepad" execution_type="manual" priority="P1" id="GamepadEvent_gamepadconnected">
         <description>
           <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/GamepadEvent_gamepadconnected-manual.html</test_script_entry>
         </description>
@@ -159,7 +159,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if the gamepaddisconnected event can be fired." type="compliance" status="designed" component="WebAPI/Device APIs/Gamepad" execution_type="manual" priority="P1" id="GamepadEvent_gamepaddisconnected">
+      <testcase purpose="Check if the gamepaddisconnected event can be fired." type="compliance" status="approved" component="WebAPI/Device APIs/Gamepad" execution_type="manual" priority="P1" id="GamepadEvent_gamepaddisconnected">
         <description>
           <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/GamepadEvent_gamepaddisconnected-manual.html</test_script_entry>
         </description>
@@ -171,7 +171,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if the getGamepads attribute of navigator exist and type of function." type="compliance" status="designed" component="WebAPI/Device APIs/Gamepad" execution_type="manual" priority="P1" id="Navigator_getGamepads_basic">
+      <testcase purpose="Check if the getGamepads attribute of navigator exist and type of function." type="compliance" status="approved" component="WebAPI/Device APIs/Gamepad" execution_type="manual" priority="P1" id="Navigator_getGamepads_basic">
         <description>
           <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/Navigator_getGamepads_basic-manual.html</test_script_entry>
         </description>
@@ -183,7 +183,7 @@
           </spec>
         </specs>
       </testcase>     
-      <testcase purpose="Check if getGamepads of navigator can return array of gamepads" type="compliance" status="designed" component="WebAPI/Device APIs/Gamepad" execution_type="manual" priority="P1" id="Navigator_getGamepads_function">
+      <testcase purpose="Check if getGamepads of navigator can return array of gamepads" type="compliance" status="approved" component="WebAPI/Device APIs/Gamepad" execution_type="manual" priority="P1" id="Navigator_getGamepads_function">
         <description>
           <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/Navigator_getGamepads_function-manual.html</test_script_entry>
         </description>

--- a/webapi/webapi-gamepad-w3c-tests/tests.xml
+++ b/webapi/webapi-gamepad-w3c-tests/tests.xml
@@ -3,6 +3,86 @@
 <test_definition>
   <suite category="W3C/HTML5 APIs" launcher="xwalk" name="webapi-gamepad-w3c-tests">
     <set name="Gamepad">
+      <testcase component="WebAPI/Device APIs/Gamepad" execution_type="manual" id="GamePad_basic" purpose="Check if the basic of gamepad is valid.">
+        <description>
+          <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/GamePad_basic-manual.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Device APIs/Gamepad" execution_type="manual" id="GamePad_axes" purpose="check if the axes attribute of gamepad interface can return array of values for all axes of the gamepad.">
+        <description>
+          <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/GamePad_axes-manual.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Device APIs/Gamepad" execution_type="manual" id="GamePad_buttons" purpose="check if the buttons attribute of gamepad interface can return the array of buttons on gamepad.">
+        <description>
+          <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/GamePad_buttons-manual.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Device APIs/Gamepad" execution_type="manual" id="GamePad_connected" purpose="check if the connected attribute of gamepad interface can return whether the gamepad is connected.">
+        <description>
+          <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/GamePad_connected-manual.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Device APIs/Gamepad" execution_type="manual" id="GamePad_id" purpose="check if the id attribute of gamepad interface can return the name of gamepad.">
+        <description>
+          <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/GamePad_id-manual.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Device APIs/Gamepad" execution_type="manual" id="GamePad_index" purpose="check if the index attribute of gamepad interface can return the index of the gamepad in the Navigator.">
+        <description>
+          <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/GamePad_index-manual.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Device APIs/Gamepad" execution_type="manual" id="GamePad_mapping" purpose="check if the mapping attribute of gamepad interface can return the mapping in use for this device.">
+        <description>
+          <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/GamePad_mapping-manual.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Device APIs/Gamepad" execution_type="manual" id="GamePad_timestamp" purpose="check if the timestamp attribute of gamepad interface can return last time the data for this gamepad was updated.">
+        <description>
+          <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/GamePad_timestamp-manual.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Device APIs/Gamepad" execution_type="manual" id="GamePadButton_basic" purpose="check if the basic of gamepadbutton interface is valid.">
+        <description>
+          <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/GamePadButton_basic-manual.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Device APIs/Gamepad" execution_type="manual" id="GamePadButton_function" purpose="check if the function of gamepadbutton interface is valid.">
+        <description>
+          <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/GamePadButton_function-manual.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/System-level APIs/Gamepad" execution_type="auto" id="GamepadEvent_basic" purpose="Check if GamepadEvent exist">
+        <description>
+          <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/GamepadEvent_basic.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Device APIs/Gamepad" execution_type="manual" id="GamepadEvent_gamepad" purpose="Check if the gamepad of gamepadevent can return the gamepad which fire the event.">
+        <description>
+          <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/GamepadEvent_gamepad-manual.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Device APIs/Gamepad" execution_type="manual" id="GamepadEvent_gamepadconnected" purpose="Check if the gamepadconnected event can be fired.">
+        <description>
+          <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/GamepadEvent_gamepadconnected-manual.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Device APIs/Gamepad" execution_type="manual" id="GamepadEvent_gamepaddisconnected" purpose="Check if the gamepaddisconnected event can be fired.">
+        <description>
+          <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/GamepadEvent_gamepaddisconnected-manual.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Device APIs/Gamepad" execution_type="manual" id="Navigator_getGamepads_basic" purpose="Check if the getGamepads attribute of navigator exist and type of function.">
+        <description>
+          <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/Navigator_getGamepads_basic-manual.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Device APIs/Gamepad" execution_type="manual" id="Navigator_getGamepads_function" purpose="Check if getGamepads of navigator can return array of gamepads">
+        <description>
+          <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/Navigator_getGamepads_function-manual.html</test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>


### PR DESCRIPTION
- Fail Reason: the gamepad can not connect to android device.

Impacted TCs num(approved): New 0, Update 17, Delete 0
Unit test Platform: Andriod
Test result summary: Pass 0, Fail 17, Blocked 0
