### PR TITLE
[usercase-webapi] Add 'No Record' and disable delete button

### DIFF
--- a/misc/webapi-usecase-w3c-tests/tests/IndexedDB/index.html
+++ b/misc/webapi-usecase-w3c-tests/tests/IndexedDB/index.html
@@ -67,6 +67,7 @@ Authors:
              <li data-role="list-divider">Record List</li>
              <div id="error"></div>
              <table id="tableList"></table>
+             <lable id="noRecord"></lable>
          </ul>
         </div>
         <div data-role="footer" data-position="fixed"></div>

--- a/misc/webapi-usecase-w3c-tests/tests/IndexedDB/js/main.js
+++ b/misc/webapi-usecase-w3c-tests/tests/IndexedDB/js/main.js
@@ -69,10 +69,19 @@ App.query = function () {
     }else{
         App.table = document.getElementsByTagName("table")[0];
     }
+    var noRecord = true;
+    document.getElementById("noRecord").innerHTML = "";
+    $("#btnDelete").button("enable");
     cursorRequest.onsuccess = function (e) {
         var result = e.target.result;
-        if (!result || !result.value)
+        if (!result || !result.value){
+            if(noRecord){
+                document.getElementById("noRecord").innerHTML="No Record";
+                $("#btnDelete").button("disable");
+            }
             return false;
+        }
+        noRecord = false;
         render(result.value.key, result.value.value);
         result.continue();
     }


### PR DESCRIPTION
- Add 'No Record' in record list when database is empty
- Change delete button to be disabled when database is empty

Impacted tests(designed|approved): new 0, update 1, delete 0
Unit test platform: [Tizen IVI][Android]
Unit test result summary: pass 1, fail 0, block 0
