### PR TITLE
[usecase-webapi] Disable forward button and show history state

### DIFF
--- a/misc/webapi-usecase-w3c-tests/tests/SessionHistory/js/main.js
+++ b/misc/webapi-usecase-w3c-tests/tests/SessionHistory/js/main.js
@@ -41,6 +41,9 @@ $(document).live('pageshow', function () {
     for (var i = 0; i<11;i++) {
         window.history.pushState(i);
     }
+    var state = window.history.state;
+    $("#sessionID").text(state);
+    $("#forward").button("disable");
     window.addEventListener("popstate", function(e) {
         var state = window.history.state;
         $("#sessionID").text(state);


### PR DESCRIPTION
- At the begining of test, forward button should be disabled, and show history state at the begining.

Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: [Tizen IVI][Android]
Unit test result summary: pass 1, fail 0, block 0
