### PR TITLE
[Multicolumn] Fix failing multicolumn TCT tests.

### DIFF
--- a/webapi/tct-multicolumn-css3-tests/multicolumn/CSS3Multicolumn_column-count_0.html
+++ b/webapi/tct-multicolumn-css3-tests/multicolumn/CSS3Multicolumn_column-count_0.html
@@ -57,9 +57,11 @@ Authors:
         var div = document.querySelector("#test");
         var t = async_test(document.title, {timeout: 500});
         t.step(function () {
+            var originalColumnCount = GetCurrentStyle("column-count");
             div.style[headProp("column-count")] = "0";
             var colcount = GetCurrentStyle("column-count");
-            assert_equals(colcount, "0", "The div column-count");
+            // http://www.w3.org/TR/CSS2/syndata.html#illegalvalues states illegal values should be ignored.
+            assert_equals(colcount, originalColumnCount, "The div column-count");
         });
         t.done();
     </script>

--- a/webapi/tct-multicolumn-css3-tests/multicolumn/CSS3Multicolumn_column-rule-width.html
+++ b/webapi/tct-multicolumn-css3-tests/multicolumn/CSS3Multicolumn_column-rule-width.html
@@ -39,7 +39,7 @@ Authors:
     <meta name="assert" content="Check if the content is divided into several columns,width of the border is 2px between each column" />
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
-    <script src="support/user.js"></script>
+    <script src="support/cssstyle.js"></script>
     <style type="text/css">
         div.test {
             margin: 10px;
@@ -56,11 +56,11 @@ Authors:
         var div = document.querySelector("#test");
         var t = async_test(document.title, {timeout:500});
         t.step(function () {
-            div.style[headProp("columnRuleWidth")] = "2px";
+            div.style[headProp("column-rule-width")] = "2px";
             div.style[headProp("columns")] = "100px 3";
             div.style[headProp("column-rule-style")] = "dotted";
             div.style[headProp("column-rule-color")] = "rgb(255, 192, 203)";
-            var column_rule_width = GetCurrentStyle("columnRuleWidth");
+            var column_rule_width = GetCurrentStyle("column-rule-width");
             assert_equals(column_rule_width, "2px", "The div column-rule-width");
         });
         t.done();

--- a/webapi/tct-multicolumn-css3-tests/multicolumn/CSS3Multicolumn_column-rule-width_0point5em.html
+++ b/webapi/tct-multicolumn-css3-tests/multicolumn/CSS3Multicolumn_column-rule-width_0point5em.html
@@ -39,7 +39,7 @@ Authors:
     <meta name="assert" content="Check if 'column-rule-width: 0.5em' on test div" />
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
-    <script src="support/user.js"></script>
+    <script src="support/cssstyle.js"></script>
     <style type="text/css">
             #test{
             height: 100px;
@@ -60,7 +60,7 @@ Authors:
         div.style[headProp("column-width")] = "150px";
         div.style[headProp("column-rule-width")] = "0.5em";
         div.style[headProp("column-rule-style")] = "dotted";
-        var column_rule_width = GetCurrentStyle("columnRuleWidth");
+        var column_rule_width = GetCurrentStyle("column-rule-width");
         var t = async_test(document.title, {timeout: 500});
         t.step(function () {
             assert_equals(column_rule_width, "8px", "The div column-rule-width");

--- a/webapi/tct-multicolumn-css3-tests/multicolumn/CSS3Multicolumn_column-rule-width_5px.html
+++ b/webapi/tct-multicolumn-css3-tests/multicolumn/CSS3Multicolumn_column-rule-width_5px.html
@@ -39,7 +39,7 @@ Authors:
     <meta name="assert" content="Check if 'column-rule-width: 5px' on test div" />
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
-    <script src="support/user.js"></script>
+    <script src="support/cssstyle.js"></script>
     <style type="text/css">
             #test{
             height: 100px;
@@ -60,7 +60,7 @@ Authors:
         div.style[headProp("column-width")] = "150px";
         div.style[headProp("column-rule-width")] = "5px";
         div.style[headProp("column-rule-style")] = "dotted";
-        var column_rule_width = GetCurrentStyle("columnRuleWidth");
+        var column_rule_width = GetCurrentStyle("column-rule-width");
         var t = async_test(document.title, {timeout: 500});
         t.step(function () {
             assert_equals(column_rule_width, "5px", "The div column-rule-width");

--- a/webapi/tct-multicolumn-css3-tests/multicolumn/CSS3Multicolumn_column-rule-width_5px_p.html
+++ b/webapi/tct-multicolumn-css3-tests/multicolumn/CSS3Multicolumn_column-rule-width_5px_p.html
@@ -39,7 +39,7 @@ Authors:
     <meta name="assert" content="Check if 'column-rule-width: 5px' on test p" />
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
-    <script src="support/user.js"></script>
+    <script src="support/cssstyle.js"></script>
     <style type="text/css">
             #test{
             height: 100px;
@@ -60,7 +60,7 @@ Authors:
         div.style[headProp("column-width")] = "150px";
         div.style[headProp("column-rule-width")] = "5px";
         div.style[headProp("column-rule-style")] = "dotted";
-        var column_rule_width = GetCurrentStyle("columnRuleWidth");
+        var column_rule_width = GetCurrentStyle("column-rule-width");
         var t = async_test(document.title, {timeout: 500});
         t.step(function () {
             assert_equals(column_rule_width, "5px", "The p column-rule-width");

--- a/webapi/tct-multicolumn-css3-tests/multicolumn/CSS3Multicolumn_column-rule-width_initial_value.html
+++ b/webapi/tct-multicolumn-css3-tests/multicolumn/CSS3Multicolumn_column-rule-width_initial_value.html
@@ -39,7 +39,7 @@ Authors:
     <meta name="assert" content="Check if the initial value of column-rule-width is '3px' on test div" />
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
-    <script src="support/user.js"></script>
+    <script src="support/cssstyle.js"></script>
     <style type="text/css">
             #test{
             height: 100px;
@@ -59,7 +59,7 @@ Authors:
         div.style[headProp("column-rule-color")] = "#F00";
         div.style[headProp("column-width")] = "150px";
         div.style[headProp("column-rule-style")] = "dotted";
-        var column_rule_width = GetCurrentStyle("columnRuleWidth");
+        var column_rule_width = GetCurrentStyle("column-rule-width");
         var t = async_test(document.title, {timeout: 500});
         t.step(function () {
             assert_equals(column_rule_width, "3px", "The div column-rule-width");

--- a/webapi/tct-multicolumn-css3-tests/multicolumn/CSS3Multicolumn_column-rule-width_medium.html
+++ b/webapi/tct-multicolumn-css3-tests/multicolumn/CSS3Multicolumn_column-rule-width_medium.html
@@ -39,7 +39,7 @@ Authors:
     <meta name="assert" content="Check if 'column-rule-width: medium' on test div" />
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
-    <script src="support/user.js"></script>
+    <script src="support/cssstyle.js"></script>
     <style type="text/css">
             #test{
             height: 100px;
@@ -60,7 +60,7 @@ Authors:
         div.style[headProp("column-width")] = "150px";
         div.style[headProp("column-rule-width")] = "medium";
         div.style[headProp("column-rule-style")] = "dotted";
-        var column_rule_width = GetCurrentStyle("columnRuleWidth");
+        var column_rule_width = GetCurrentStyle("column-rule-width");
         var t = async_test(document.title, {timeout: 500});
         t.step(function () {
             assert_equals(column_rule_width, "3px", "The div column-rule-width");

--- a/webapi/tct-multicolumn-css3-tests/multicolumn/CSS3Multicolumn_column-rule-width_neg5px.html
+++ b/webapi/tct-multicolumn-css3-tests/multicolumn/CSS3Multicolumn_column-rule-width_neg5px.html
@@ -39,7 +39,7 @@ Authors:
     <meta name="assert" content="Check if 'column-rule-width: -5px' on test div" />
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
-    <script src="support/user.js"></script>
+    <script src="support/cssstyle.js"></script>
     <style type="text/css">
             #test{
             height: 100px;
@@ -60,7 +60,7 @@ Authors:
         div.style[headProp("column-width")] = "150px";
         div.style[headProp("column-rule-width")] = "-5px";
         div.style[headProp("column-rule-style")] = "dotted";
-        var column_rule_width = GetCurrentStyle("columnRuleWidth");
+        var column_rule_width = GetCurrentStyle("column-rule-width");
         var t = async_test(document.title, {timeout: 500});
         t.step(function () {
             assert_equals(column_rule_width, "3px", "The div column-rule-width");

--- a/webapi/tct-multicolumn-css3-tests/multicolumn/CSS3Multicolumn_column-rule-width_thick.html
+++ b/webapi/tct-multicolumn-css3-tests/multicolumn/CSS3Multicolumn_column-rule-width_thick.html
@@ -39,7 +39,7 @@ Authors:
     <meta name="assert" content="Check if 'column-rule-width: thick' on test div" />
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
-    <script src="support/user.js"></script>
+    <script src="support/cssstyle.js"></script>
     <style type="text/css">
             #test{
             height: 100px;
@@ -60,7 +60,7 @@ Authors:
         div.style[headProp("column-width")] = "150px";
         div.style[headProp("column-rule-width")] = "thick";
         div.style[headProp("column-rule-style")] = "dotted";
-        var column_rule_width = GetCurrentStyle("columnRuleWidth");
+        var column_rule_width = GetCurrentStyle("column-rule-width");
         var t = async_test(document.title, {timeout: 500});
         t.step(function () {
             assert_equals(column_rule_width, "5px", "The div column-rule-width");

--- a/webapi/tct-multicolumn-css3-tests/multicolumn/CSS3Multicolumn_column-rule-width_thin.html
+++ b/webapi/tct-multicolumn-css3-tests/multicolumn/CSS3Multicolumn_column-rule-width_thin.html
@@ -39,7 +39,7 @@ Authors:
     <meta name="assert" content="Check if 'column-rule-width: thin' on test div" />
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
-    <script src="support/user.js"></script>
+    <script src="support/cssstyle.js"></script>
     <style type="text/css">
             #test{
             height: 100px;
@@ -60,7 +60,7 @@ Authors:
         div.style[headProp("column-width")] = "150px";
         div.style[headProp("column-rule-width")] = "thin";
         div.style[headProp("column-rule-style")] = "dotted";
-        var column_rule_width = GetCurrentStyle("columnRuleWidth");
+        var column_rule_width = GetCurrentStyle("column-rule-width");
         var t = async_test(document.title, {timeout: 500});
         t.step(function () {
             assert_equals(column_rule_width, "1px", "The div column-rule-width");

--- a/webapi/tct-multicolumn-css3-tests/multicolumn/CSS3Multicolumn_column-width_neg10cm.html
+++ b/webapi/tct-multicolumn-css3-tests/multicolumn/CSS3Multicolumn_column-width_neg10cm.html
@@ -57,11 +57,10 @@ Authors:
         var div = document.querySelector("#test");
         var t = async_test(document.title, {timeout: 500});
         t.step(function () {
+            var originalPropValue = GetCurrentStyle("column-width");
             div.style[headProp("column-width")] = "-10cm";
-            var propvalue = GetCurrentStyle("column-width");
-            var endprop = propvalue.lastIndexOf("px") != -1;
-            var startprop = propvalue.indexOf("-") != -1;
-            assert_true(endprop&&startprop, "The element column-width is not supported for the units of measurement in cm");
+            var propValue = GetCurrentStyle("column-width");
+            assert_equals(propValue, originalPropValue, "column-width can not be negative");
         });
         t.done();
     </script>

--- a/webapi/tct-multicolumn-css3-tests/multicolumn/CSS3Multicolumn_column-width_neg10em.html
+++ b/webapi/tct-multicolumn-css3-tests/multicolumn/CSS3Multicolumn_column-width_neg10em.html
@@ -57,11 +57,10 @@ Authors:
         var div = document.querySelector("#test");
         var t = async_test(document.title, {timeout: 500});
         t.step(function () {
+            var originalPropValue = GetCurrentStyle("column-width");
             div.style[headProp("column-width")] = "-10em";
-            var propvalue = GetCurrentStyle("column-width");
-            var endprop = propvalue.lastIndexOf("px") != -1;
-            var startprop = propvalue.indexOf("-") != -1;
-            assert_true(endprop&&startprop, "The element column-width is not supported for the units of measurement in em");
+            var propValue = GetCurrentStyle("column-width");
+            assert_equals(propValue, originalPropValue, "column-width can not be negative");
         });
         t.done();
     </script>

--- a/webapi/tct-multicolumn-css3-tests/multicolumn/CSS3Multicolumn_column-width_neg10px.html
+++ b/webapi/tct-multicolumn-css3-tests/multicolumn/CSS3Multicolumn_column-width_neg10px.html
@@ -57,9 +57,10 @@ Authors:
         var div = document.querySelector("#test");
         var t = async_test(document.title, {timeout: 500});
         t.step(function () {
+            var originalPropValue = GetCurrentStyle("column-width");
             div.style[headProp("column-width")] = "-10px";
-            var colwidth = GetCurrentStyle("column-width");
-            assert_equals(colwidth, "-10px", "The div column-width");
+            var propValue = GetCurrentStyle("column-width");
+            assert_equals(propValue, originalPropValue, "column-width can not be negative");
         });
         t.done();
     </script>

--- a/webapi/tct-multicolumn-css3-tests/multicolumn/CSS3Multicolumn_columns_auto_20px.html
+++ b/webapi/tct-multicolumn-css3-tests/multicolumn/CSS3Multicolumn_columns_auto_20px.html
@@ -57,13 +57,13 @@ Authors:
         var div = document.querySelector("#test");
         var t = async_test(document.title, {timeout: 500});
         t.step(function () {
+            var originalColumnCount = GetCurrentStyle("column-count");
             div.style[headProp("columns")] = "auto 20px";
             var columnCount = GetCurrentStyle("column-count");
-            var propcolumnCount = columnCount.indexOf("auto") != -1;
-            assert_true(propcolumnCount, "The element column-count should not be auto");
+            assert_equals(columnCount, originalColumnCount, "The element column-count should not be 20px");
             var columnWidth = GetCurrentStyle("column-width");
             var propcolumnWidth = columnWidth.indexOf("auto") != -1;
-            assert_true(propcolumnWidth, "The element column-width should not be auto");
+            assert_false(propcolumnWidth, "The element column-width should be auto");
         });
         t.done();
     </script>

--- a/webapi/tct-multicolumn-css3-tests/multicolumn/CSS3Multicolumn_columns_neg30px.html
+++ b/webapi/tct-multicolumn-css3-tests/multicolumn/CSS3Multicolumn_columns_neg30px.html
@@ -57,13 +57,13 @@ Authors:
         var div = document.querySelector("#test");
         var t = async_test(document.title, {timeout: 500});
         t.step(function () {
+            var originalPropColumnWidth = GetCurrentStyle("column-width");
             div.style[headProp("columns")] = "-30px";
             var columnCount = GetCurrentStyle("column-count");
             var propcolumnCount = columnCount.indexOf("auto") != -1;
             assert_true(propcolumnCount, "The element column-count should not be auto");
             var columnWidth = GetCurrentStyle("column-width");
-            var propcolumnWidth = columnWidth.indexOf("-30px") != -1;
-            assert_true(propcolumnWidth, "The element column-width should not be -30px");
+            assert_equals(columnWidth, originalPropColumnWidth, "The element column-width should not be -30px");
         });
         t.done();
     </script>


### PR DESCRIPTION
Tests are incompatible with the multicolumn
w3c spec: http://www.w3.org/TR/css3-multicol/

Most tests needed to use proper CSS property
names. Some tests try to set invalid
negative values.

BUG=XWALK-2202
