### PR TITLE
Fix for two ApplicationControl tests

### DIFF
--- a/webapi/tct-application-tizen-tests/application/RequestedApplicationControl_replyResult.html
+++ b/webapi/tct-application-tizen-tests/application/RequestedApplicationControl_replyResult.html
@@ -60,7 +60,7 @@ setup_launch(t, TCT_APPCONTROL_APPID, function () {
         })
     };
 
-    tizen.application.launchAppControl(appControl, null, null, onerror, replyCallback);
+    tizen.application.launchAppControl(appControl, null, null, null, replyCallback);
 });
 
 </script>

--- a/webapi/tct-application-tizen-tests/application/RequestedApplicationControl_replyResult_with_data.html
+++ b/webapi/tct-application-tizen-tests/application/RequestedApplicationControl_replyResult_with_data.html
@@ -69,7 +69,7 @@ setup_launch(t, TCT_APPCONTROL_APPID, function () {
         })
     };
 
-    tizen.application.launchAppControl(appControl, null, null, onerror, replyCallback);
+    tizen.application.launchAppControl(appControl, null, null, null, replyCallback);
 });
 
 </script>


### PR DESCRIPTION
In webkit default onerror is null. In blink it is undefined
API checks for undefined value. Therefore test will never pass
on blink unless it changed to null

BUG=XWALK-2194
