### PR TITLE
[Indexeddb] Changed attribute name from multientry to multiEntry

### DIFF
--- a/webapi/tct-indexeddb-w3c-tests/indexeddb/IDBIndex_multientry_exist.html
+++ b/webapi/tct-indexeddb-w3c-tests/indexeddb/IDBIndex_multientry_exist.html
@@ -61,7 +61,7 @@ Authors:
                     }
                     var objStore = db.createObjectStore(objectStoreName, {keyPath : "key"});
                     var index = objStore.createIndex(indexName, "indexedProperty");
-                    if ("multientry" in index) {
+                    if ("multiEntry" in index) {
                         pass();
                     } else {
                         fail("IDBIndex.multientry attribute does not exist");

--- a/webapi/tct-indexeddb-w3c-tests/indexeddb/IDBIndex_name_exist.html
+++ b/webapi/tct-indexeddb-w3c-tests/indexeddb/IDBIndex_name_exist.html
@@ -59,7 +59,7 @@ Authors:
                         db.deleteObjectStore(objectStoreName);
                     }
                     var objStore = db.createObjectStore(objectStoreName, {keyPath : "key"});
-                    var index = objStore.createIndex(indexName, "indexedProperty", {multientry: true});
+                    var index = objStore.createIndex(indexName, "indexedProperty", {multiEntry: true});
                     if ("name" in index) {
                         pass();
                     } else {

--- a/webapi/tct-indexeddb-w3c-tests/indexeddb/IDBIndex_objectStore_exists.html
+++ b/webapi/tct-indexeddb-w3c-tests/indexeddb/IDBIndex_objectStore_exists.html
@@ -59,7 +59,7 @@ Authors:
                         db.deleteObjectStore(objectStoreName);
                     }
                     var objStore = db.createObjectStore(objectStoreName, {keyPath : "key"});
-                    var index = objStore.createIndex(indexName, "indexedProperty", {multientry : true});
+                    var index = objStore.createIndex(indexName, "indexedProperty", {multiEntry : true});
                     if ("objectStore" in index) {
                         pass();
                     } else {


### PR DESCRIPTION
According to the deprecated standard, IndexedDB's Index object should
have attribute named "multientry". The latest standard says that
this attribute should be named "multiEntry" (e is uppercase).

BUG=XWALK-2203
