### PR TITLE
Fix incorrect urls in WebSocket tests.

### DIFF
--- a/webapi/tct-websocket-w3c-tests/websocket/w3c/005.html
+++ b/webapi/tct-websocket-w3c-tests/websocket/w3c/005.html
@@ -6,6 +6,6 @@
 <div id=log></div>
 <script>
 test(function() {
-  assert_true(new WebSocket("ws://"+location.hostname+"/") instanceof WebSocket);
+  assert_true(new WebSocket(SCHEME_DOMAIN_PORT) instanceof WebSocket);
 });
 </script>

--- a/webapi/tct-websocket-w3c-tests/websocket/w3c/constants.js
+++ b/webapi/tct-websocket-w3c-tests/websocket/w3c/constants.js
@@ -1,6 +1,6 @@
 //FIXME: 
-var DOMAIN_FOR_WS_TESTS = location.hostname;
-var DOMAIN_FOR_WSS_TESTS = location.hostname;
+var DOMAIN_FOR_WS_TESTS = '127.0.0.1';
+var DOMAIN_FOR_WSS_TESTS = '127.0.0.1';
 
 var PORT = "8081";
 var PORT_SSL = "8443";


### PR DESCRIPTION
Replaced location.hostname with "127.0.0.1", as it was empty,
what lead to invalid urls.
