### PR TITLE
[Xmlhttprequest] Fix xmlhttprequest tests - abort-upload-event-*

### DIFF
--- a/webapi/tct-xmlhttprequest-w3c-tests/xmlhttprequest-py/w3c/abort-upload-event-abort.htm
+++ b/webapi/tct-xmlhttprequest-w3c-tests/xmlhttprequest-py/w3c/abort-upload-event-abort.htm
@@ -16,7 +16,7 @@
         {
             var xhr = new XMLHttpRequest();
 
-            xhr.onreadystatechange = function()
+            xhr.onloadstart = function()
             {
                 test.step(function()
                 {

--- a/webapi/tct-xmlhttprequest-w3c-tests/xmlhttprequest-py/w3c/abort-upload-event-loadend.htm
+++ b/webapi/tct-xmlhttprequest-w3c-tests/xmlhttprequest-py/w3c/abort-upload-event-loadend.htm
@@ -16,7 +16,7 @@
         {
             var xhr = new XMLHttpRequest();
 
-            xhr.onreadystatechange = function()
+            xhr.onloadstart = function()
             {
                 test.step(function ()
                 {

--- a/webapi/tct-xmlhttprequest-w3c-tests/xmlhttprequest/w3c/abort-upload-event-abort.htm
+++ b/webapi/tct-xmlhttprequest-w3c-tests/xmlhttprequest/w3c/abort-upload-event-abort.htm
@@ -16,7 +16,7 @@
         {
             var xhr = new XMLHttpRequest();
 
-            xhr.onreadystatechange = function()
+            xhr.onloadstart = function()
             {
                 test.step(function()
                 {

--- a/webapi/tct-xmlhttprequest-w3c-tests/xmlhttprequest/w3c/abort-upload-event-loadend.htm
+++ b/webapi/tct-xmlhttprequest-w3c-tests/xmlhttprequest/w3c/abort-upload-event-loadend.htm
@@ -16,7 +16,7 @@
         {
             var xhr = new XMLHttpRequest();
 
-            xhr.onreadystatechange = function()
+            xhr.onloadstart = function()
             {
                 test.step(function ()
                 {

--- a/webapi/tct-xmlhttprequest-w3c-tests/xmlhttprequest/xhr2_XMLHttpRequestEventTarget_onabort_event.html
+++ b/webapi/tct-xmlhttprequest-w3c-tests/xmlhttprequest/xhr2_XMLHttpRequestEventTarget_onabort_event.html
@@ -52,6 +52,7 @@ Authors:
         };
         window.setTimeout(FailTest, 2000);
         client.open("GET", "support/test.xml");
+        client.send();
         client.abort();
     </script>
   </body>


### PR DESCRIPTION
Tests are incompatible with the XMLHTTPRequest
spec: http://www.w3.org/TR/XMLHttpRequest/
In current implementation send() may be called after abort()
This causes tests to fail.

BUGS=XWALK-2205
