### PR TITLE
Fix tests incompatible with latest WebSocket spec.

### DIFF
--- a/webapi/tct-websocket-w3c-tests/websocket/websocket_WebSocket_onmessage_MessageEvent_origin_initialize.html
+++ b/webapi/tct-websocket-w3c-tests/websocket/websocket_WebSocket_onmessage_MessageEvent_origin_initialize.html
@@ -50,15 +50,14 @@ Authors:
         var isOpenCalled = false;
         var isMessageCalled = false;
 
-        webSocket.onopen = function () {
+        webSocket.onopen = t.step_func(function () {
             isOpenCalled = true;
             webSocket.send("Hello");
-        }
+        });
 
         webSocket.onmessage = t.step_func(function (e) {
             assert_equals(e.origin, _URL, "Event's origin attribute");
             isMessageCalled = true;
-            t.done();
             webSocket.close();
         });
 

--- a/webapi/tct-websocket-w3c-tests/websocket/websocket_WebSocket_onmessage_base.html
+++ b/webapi/tct-websocket-w3c-tests/websocket/websocket_WebSocket_onmessage_base.html
@@ -50,14 +50,13 @@ Authors:
         var isOpenCalled = false;
         var isMessageCalled = false;
 
-        webSocket.onopen = function () {
+        webSocket.onopen = t.step_func(function () {
             isOpenCalled = true;
             webSocket.send("Hello");
-        }
+        });
 
         webSocket.onmessage = t.step_func(function () {
             isMessageCalled = true;
-            t.done();
             webSocket.close();
         });
 

--- a/webapi/tct-websocket-w3c-tests/websocket/websocket_WebSocket_send_number.html
+++ b/webapi/tct-websocket-w3c-tests/websocket/websocket_WebSocket_send_number.html
@@ -60,7 +60,6 @@ Authors:
             isMessageCalled = true;
             assert_true(isOpenCalled, "WebSocket connection should be opened");
             assert_equals(e.data, num_data.toString(), "WebSocket.send can send number");
-            t.done();
             webSocket.close();
         }), true);
 


### PR DESCRIPTION
The tests call WebSocket.close() and expect to get an
onmessage event after the call and before the
connection is closed. This can not happen according to
the WebSocket spec.

There are two important points:

The first point is what WebSocket.close() is supposed
to do:
http://www.w3.org/TR/websockets/#dom-websocket-close
1. -> Otherwise section applies in all tests:
   "Set the readyState attribute's value to CLOSING"

The other point is what happens when readyState is
not OPEN:

http://www.w3.org/TR/websockets/#feedback-from-the-protocol

"When a WebSocket message has been received ... follow
these steps:
1. If the readyState attribute's value is not OPEN, then
   abort these steps."
   
   Chromium aborts at step one, preventing any further
   onmessage events. The event handler would be called in
   step 5.
   
   All these tests call WebSocket.close() before the onmessage
   event is received, preventing the event to be delivered.

Move the call to WebSocket.close() to the end of the
onmessage event handler.

BUGS=XWALK-2208
