### PR TITLE
Fix tct-extra-html5-tests/interfaces

### DIFF
--- a/webapi/tct-extra-html5-tests/w3c/semantics/interfaces.html
+++ b/webapi/tct-extra-html5-tests/w3c/semantics/interfaces.html
@@ -15,7 +15,7 @@ var data = [
   ["audio", "Audio"],
   ["b", ""],
   ["base", "Base"],
-  ["basefont", "BaseFont"],
+  ["basefont", "Unknown"],
   ["bdo", ""],
   //["bgsound", "Unknown"],
   ["big", ""],


### PR DESCRIPTION
interfaces - FAIL
The basefont tag is obsolete http://www.w3.org/TR/html5/obsolete.html#obsolete and it's not supported in modern browsers.
Support for this tag has been removed in chromium at april 2013 http://code.google.com/p/chromium/issues/detail?id=231042
Remove the test

month9 - FAIL
The browser behaviour is correct according to W3C specification. http://www.w3.org/TR/html5/forms.html#month-state-(type=month)
"If the value of the element is not a valid month string, then set it to the empty string instead."
Change the test expectation

BUGS=XWALK-2213
