### PR TITLE
[webapi][XWALK-2218] Updating workers TCs so that error info can be prin...

### DIFF
--- a/webapi/tct-workers-w3c-tests/workers/SharedWorkerConstructor.html
+++ b/webapi/tct-workers-w3c-tests/workers/SharedWorkerConstructor.html
@@ -41,10 +41,10 @@ Authors:
     <script>
         setup({timeout:500});
         var FileName = './support/shared-worker-constructor.js';
-        var worker = new SharedWorker(FileName);
-        worker.port.postMessage('shared worker constructor.');
         test(function()
         {
+            var worker = new SharedWorker(FileName);
+            worker.port.postMessage('shared worker constructor.');
             assert_equals(worker.toString(), "[object SharedWorker]");
         }, "Test Description: shared worker constructor Test 1: shared worker constructor.");
     </script>

--- a/webapi/tct-workers-w3c-tests/workers/SharedWorkerShared_name_except.html
+++ b/webapi/tct-workers-w3c-tests/workers/SharedWorkerShared_name_except.html
@@ -57,10 +57,10 @@ Date                        Author                                 Description
     var FileName = './support/shared-worker-shared.js';
 
     // Loading a worker named "name" tests that workers shutdown when the parent document exits, because other tests also create workers with that same name but with different URLs.
-    var worker = new SharedWorker(FileName, 'name');
     var result = 'FAIL';
 
     try {
+        var worker = new SharedWorker(FileName, 'name');
         new SharedWorker('some-other-url.js', 'name');
         console.log("FAIL: Creating SharedWorker with different URLs but the same name should fail");
         result = 'FAIL: Creating SharedWorker with different URLs but the same name should fail';

--- a/webapi/tct-workers-w3c-tests/workers/WebWorker_SharedWorker_constructor_name.html
+++ b/webapi/tct-workers-w3c-tests/workers/WebWorker_SharedWorker_constructor_name.html
@@ -42,9 +42,9 @@ Authors:
     <script>
         setup({timeout:500});
         var FileName = './support/shared-worker-constructor.js';
-        var worker = new SharedWorker(FileName,'name');
         test(function()
         {
+            var worker = new SharedWorker(FileName,'name');
             assert_equals(worker.toString(), "[object SharedWorker]")
         }, "Test Description: shared worker can construct object with name: shared worker constructor.");
     </script>


### PR DESCRIPTION
...t
- SharedWorker object defined in tests{}, so that if any undefined info can be print

Impacted TCs num(approved): New 0, Update 3, Delete 0
Unit test Platform: Tizen IVI
Tizen test result summary: Pass 3, Fail 0, Blocked 0
