### PR TITLE
Fix for tct-extra-html5-tests/base64.html

### DIFF
--- a/webapi/tct-extra-html5-tests/base64/w3c/base64.html
+++ b/webapi/tct-extra-html5-tests/base64/w3c/base64.html
@@ -7,27 +7,6 @@ to Google. -->
 <script src="../../resources/testharness.js"></script>
 <script src="../../resources/testharnessreport.js"></script>
 <script>
-// From WebIDL:
-//
-// * The value of the Function object’s length property is a Number determined
-//   as follows:
-//
-//   1. Let S be the effective overload set for regular operations (if the
-//      operation is a regular operation) or for static operations (if the
-//      operation is a static operation) with identifier id on interface I and
-//      with argument count 0 (for the ECMAScript language binding).
-//   2. Return the maximum argument list length of the functions in the entries
-//      of S.
-//
-// As far as I understand it, this means the length must be 1 here.
-test(function() {
-	assert_equals(btoa.length, 1);
-}, "btoa.length must equal the maximum number of arguments, namely 1");
-
-test(function() {
-	assert_equals(atob.length, 1);
-}, "atob.length must equal the maximum number of arguments, namely 1");
-
 /**
  * btoa() as defined by the HTML5 spec, which mostly just references RFC4648.
  */
@@ -92,12 +71,16 @@ function btoaLookup(idx) {
 }
 
 /**
- * Implementation of atob() according to the HTML spec.
+ * Implementation of atob() according to the HTML spec, except that instead of
+ * throwing INVALID_CHARACTER_ERR we return null.
  */
 function myatob(input) {
 	// WebIDL requires DOMStrings to just be converted using ECMAScript
 	// ToString, which in our case amounts to calling String().
 	input = String(input);
+
+	// "Remove all space characters from input."
+	input = input.replace(/[ \t\n\f\r]/g, "");
 
 	// "If the length of input divides by 4 leaving no remainder, then: if
 	// input ends with one or two U+003D EQUALS SIGN (=) characters, remove
@@ -120,7 +103,7 @@ function myatob(input) {
 	// U+0061 LATIN SMALL LETTER A to U+007A LATIN SMALL LETTER Z"
 	if (input.length % 4 == 1
 	|| !/^[+/0-9A-Za-z]*$/.test(input)) {
-		return "INVALID_CHARACTER_ERR";
+		return null;
 	}
 
 	// "Let output be a string, initially empty."
@@ -222,7 +205,7 @@ function testBtoa(input) {
 	var normalizedInput = String(input);
 	for (var i = 0; i < normalizedInput.length; i++) {
 		if (normalizedInput.charCodeAt(i) > 255) {
-			assert_throws("INVALID_CHARACTER_ERR", function() { btoa(input); },
+			assert_throws("InvalidCharacterError", function() { btoa(input); },
 				"Code unit " + i + " has value " + normalizedInput.charCodeAt(i) + ", which is greater than 255");
 			return;
 		}
@@ -239,8 +222,7 @@ var tests = ["עברית", "", "a", "ab", "abc", "abcd", "abcde",
 	// Is your DOM implementation binary-safe?
 	"\0", "\0a", "a\0b",
 	// WebIDL tests.
-    // btoa('null') == "bnVsbA=="
-	undefined, "null", 7, 12, 1.5, true, false, NaN, +Infinity, -Infinity, 0, -0,
+	undefined, null, 7, 12, 1.5, true, false, NaN, +Infinity, -Infinity, 0, -0,
 	{toString: function() { return "foo" }},
 ];
 for (var i = 0; i < 258; i++) {
@@ -271,38 +253,13 @@ tests.push(["btoa(first 256 code points concatenated)", everything]);
 generate_tests(testBtoa, tests);
 
 function testAtob(input) {
-	// "If the length of input divides by 4 leaving no remainder, then: if
-	// input ends with one or two U+003D EQUALS SIGN (=) characters, remove
-	// them from input."
-	var normalizedInput = String(input);
-	if (normalizedInput.length % 4 == 0) {
-		normalizedInput = normalizedInput.replace(/==?$/, "");
-	}
-
-	// "If the length of input divides by 4 leaving a remainder of 1, throw an
-	// INVALID_CHARACTER_ERR exception and abort these steps."
-	if (normalizedInput.length % 4 == 1) {
-		assert_throws("INVALID_CHARACTER_ERR", function() { atob(input) },
-			"After stripping one or two trailing equals signs (if appropriate), input has length with remainder 1 when divided by 4");
+	var expected = myatob(input);
+	if (expected === null) {
+		assert_throws("InvalidCharacterError", function() { atob(input) });
 		return;
 	}
 
-	// "If input contains a character that is not in the following list of
-	// characters and character ranges, throw an INVALID_CHARACTER_ERR
-	// exception and abort these steps:
-	//
-	// U+002B PLUS SIGN (+)
-	// U+002F SOLIDUS (/)
-	// U+0030 DIGIT ZERO (0) to U+0039 DIGIT NINE (9)
-	// U+0041 LATIN CAPITAL LETTER A to U+005A LATIN CAPITAL LETTER Z
-	// U+0061 LATIN SMALL LETTER A to U+007A LATIN SMALL LETTER Z"
-	if (!/^[+/0-9A-Za-z]*$/.test(normalizedInput)) {
-		assert_throws("INVALID_CHARACTER_ERR", function() { atob(input) },
-			"After stripping one or two trailing equals signs (if appropriate), input contains an invalid character");
-		return;
-	}
-
-	assert_equals(atob(input), myatob(input));
+	assert_equals(atob(input), expected);
 }
 
 var tests = ["", "abcd", " abcd", "abcd ", "abcd===", " abcd===", "abcd=== ",
@@ -314,7 +271,10 @@ var tests = ["", "abcd", " abcd", "abcd ", "abcd===", " abcd===", "abcd=== ",
 	"abcd=", "abcd==", "abcd===", "abcd====", "abcd=====",
 	"abcde=", "abcde==", "abcde===", "abcde====", "abcde=====",
 	"=a", "=a=", "a=b", "a=b=", "ab=c", "ab=c=", "abc=d", "abc=d=",
-	"ab\ncd",
+	// With whitespace
+	"ab\tcd", "ab\ncd", "ab\fcd", "ab\rcd", "ab cd", "ab\u00a0cd",
+	"ab\t\n\f\r cd", " \t\n\f\r ab\t\n\f\r cd\t\n\f\r ",
+	"ab\t\n\f\r =\t\n\f\r =\t\n\f\r ",
 	// Test if any bits are set at the end.  These should all be fine, since
 	// they end with A, which becomes 0:
 	"A", "/A", "//A", "///A", "////A",
@@ -329,16 +289,14 @@ var tests = ["", "abcd", " abcd", "abcd ", "abcd===", " abcd===", "abcd=== ",
 	// Binary-safety tests
 	"\0", "\0nonsense", "abcd\0nonsense",
 	// WebIDL tests
-    // atob('null') == "ée"
-	undefined, "null", 7, 12, 1.5, true, false, NaN, +Infinity, -Infinity, 0, -0,
+	undefined, null, 7, 12, 1.5, true, false, NaN, +Infinity, -Infinity, 0, -0,
 	{toString: function() { return "foo" }},
 	{toString: function() { return "abcd" }},
 ];
 tests = tests.map(
 	function(elem) {
-		var expected = myatob(elem);
-		if (expected === "INVALID_CHARACTER_ERR") {
-			return ["atob(" + format_value(elem) + ") must raise INVALID_CHARACTER_ERR", elem];
+		if (myatob(elem) === null) {
+			return ["atob(" + format_value(elem) + ") must raise InvalidCharacterError", elem];
 		}
 		return ["atob(" + format_value(elem) + ") == " + format_value(myatob(elem)), elem];
 	}


### PR DESCRIPTION
[Problem] The following test cases from tct-extra-html5-tests/base64 fail
    - base64_atob_ab_cd
    - base64_atob_abcd_space
    - base64_atob_space_abcd
[Cause] Those test cases fails since  Chromium implements the newest
        standard of base64 feature but the test has not been updated yet.

[Solution] Apply latest changes of base64.html from
           http://w3c-test.org/html/webappapis/atob/base64.html

BUG=XWALK-2227
