### PR TITLE
[embedding][XWALK-1040] Add new embedding api tests for crosswalk

### DIFF
--- a/embeddingapi/webapi-embeddingapi-xwalk-tests/README
+++ b/embeddingapi/webapi-embeddingapi-xwalk-tests/README
@@ -4,7 +4,7 @@ This test suite is for the unit tests of Embedding API crosswalk module.
 
 ## Pre-conditions
 
-* Please make sure copy xwalk_core_library from crosswalk-cordova-xxxx to /xwalk_core_library folder.
+* Please make sure copy crosswalk-webview-xxxx and rename it to /crosswalk-webview folder.
 
 ## Environment
 

--- a/embeddingapi/webapi-embeddingapi-xwalk-tests/pack.sh
+++ b/embeddingapi/webapi-embeddingapi-xwalk-tests/pack.sh
@@ -42,9 +42,9 @@ function create_apk(){
     cd ..
     rm -rf embeddingapi
 
-    echo "android.library.reference.1=../xwalk_core_library" >> project.properties
-    scp local.properties ../xwalk_core_library
-    rm -rf ../xwalk_core_library/bin/res/crunch
+    echo "android.library.reference.1=../crosswalk-webview" >> project.properties
+    scp local.properties ../crosswalk-webview
+    rm -rf ../crosswalk-webview/bin/res/crunch
     ant debug
     if [ $? -ne 0 ];then
         echo "Create $name.apk fail.... >>>>>>>>>>>>>>>>>>>>>>>>>"

--- a/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/base/XWalkViewTestBase.java
+++ b/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/base/XWalkViewTestBase.java
@@ -527,4 +527,14 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
                 TimeUnit.SECONDS);
     }
 
+    public boolean checkMethodInClass(Class<?> clazz, String methodName){
+        Method[] methods = clazz.getMethods();
+        for(Method method : methods)
+        {
+            if(method.getName().equals(methodName)){
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/test/XWalkExtensionTest.java
+++ b/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/test/XWalkExtensionTest.java
@@ -1,0 +1,299 @@
+// Copyright (c) 2014 Intel Corporation. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.xwalk.embedding.test;
+
+
+import org.chromium.base.test.util.Feature;
+import org.xwalk.core.XWalkExtension;
+import org.xwalk.embedding.MainActivity;
+import org.xwalk.embedding.base.XWalkViewTestBase;
+
+import android.annotation.SuppressLint;
+import android.test.suitebuilder.annotation.SmallTest;
+
+@SuppressLint("NewApi")
+public class XWalkExtensionTest extends XWalkViewTestBase {
+
+    public XWalkExtensionTest() {
+        super(MainActivity.class);
+    }
+
+
+    @SmallTest
+    public void testXWalkExtension() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkExtension xWalkExtension = new XWalkExtension("xwalkExtension", "xwalkExtension") {
+
+                        @Override
+                        public String onSyncMessage(int arg0, String arg1) {
+                            return null;
+                        }
+
+                        @Override
+                        public void onMessage(int arg0, String arg1) {
+
+                        }
+                    };
+                    assertTrue(true);
+                }
+            });
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testXWalkExtension_StringArray() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkExtension xwalkExtension = new XWalkExtension("xwalkExtension", "xwalkExtension", new String[]{"111","222"}) {
+                        @Override
+                        public void onMessage(int arg0, String arg1) {
+
+                        }
+
+                        @Override
+                        public String onSyncMessage(int arg0, String arg1) {
+
+                            return null;
+                        }
+                    };
+                    assertTrue(true);
+                }
+            });
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testXWalkExtension_emptyArray() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkExtension xwalkExtension = new XWalkExtension("xwalkExtension", "xwalkExtension", new String[]{}) {
+
+                        @Override
+                        public void onMessage(int arg0, String arg1) {
+
+                        }
+
+                        @Override
+                        public String onSyncMessage(int arg0, String arg1) {
+                            return null;
+                        }
+                    };
+                    assertTrue(true);
+                }
+            });
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testDestoryExtensionExist() {
+        try {
+            assertTrue(checkMethodInClass(XWalkExtension.class, "destoryExtension"));
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testPostMessage() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkExtension xWalkExtension = new XWalkExtension("xwalkExtension", "xwalkExtension") {
+
+                        @Override
+                        public void onMessage(int arg0, String arg1) {
+
+                        }
+
+                        @Override
+                        public String onSyncMessage(int arg0, String arg1) {
+
+                            return null;
+                        }
+                    };
+                    xWalkExtension.postMessage(0, "test");
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testPostMessage_nullString() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkExtension xwalkExtension = new XWalkExtension("xwalkExtension", "xwalkExtension") {
+
+                        @Override
+                        public void onMessage(int arg0, String arg1) {
+
+                        }
+
+                        @Override
+                        public String onSyncMessage(int arg0, String arg1) {
+
+                            return null;
+                        }
+                    };
+                    xwalkExtension.postMessage(1, null);
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testBroadcastMessage() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkExtension xwalkExtension = new XWalkExtension("xwalkExtension", "xwalkExtension") {
+                        @Override
+                        public void onMessage(int arg0, String arg1) {
+
+                        }
+
+                        @Override
+                        public String onSyncMessage(int arg0, String arg1) {
+
+                            return null;
+                        }
+                    };
+                    xwalkExtension.broadcastMessage("Message");
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testBroadcastMessage_nullString() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkExtension xwalkExtension= new XWalkExtension("xwalkExtension", "xwalkExtension") {
+
+                        @Override
+                        public void onMessage(int arg0, String arg1) {
+
+                        }
+
+                        @Override
+                        public String onSyncMessage(int arg0, String arg1) {
+
+                            return null;
+                        }
+                    };
+                    xwalkExtension.broadcastMessage(null);
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    @Feature({"ExtensionEcho"})
+    public void testOnMessage() throws Throwable {
+    	try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkExtension xwalkExtension= new XWalkExtension("xwalkExtension", "xwalkExtension") {
+
+                        @Override
+                        public void onMessage(int arg0, String arg1) {
+
+                        }
+
+                        @Override
+                        public String onSyncMessage(int arg0, String arg1) {
+
+                            return null;
+                        }
+                    };
+                    xwalkExtension.onMessage(4, "Pass");
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    @Feature({"ExtensionEcho"})
+    public void testOnSyncMessage() throws Throwable {
+    	try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkExtension xwalkExtension= new XWalkExtension("xwalkExtension", "xwalkExtension") {
+
+                        @Override
+                        public void onMessage(int arg0, String arg1) {
+
+                        }
+
+                        @Override
+                        public String onSyncMessage(int arg0, String arg1) {
+
+                            return null;
+                        }
+                    };
+                    xwalkExtension.onSyncMessage(2, "Pass");
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+}

--- a/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/test/XWalkUIClientTest.java
+++ b/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/test/XWalkUIClientTest.java
@@ -4,15 +4,16 @@
 
 package org.xwalk.embedding.test;
 
-
 import org.xwalk.core.XWalkJavascriptResult;
 import org.xwalk.core.XWalkUIClient;
+import org.xwalk.core.XWalkUIClient.LoadStatus;
 import org.xwalk.embedding.MainActivity;
 import org.xwalk.embedding.base.XWalkViewTestBase;
 
 import android.annotation.SuppressLint;
 import android.net.Uri;
 import android.test.suitebuilder.annotation.SmallTest;
+import android.view.KeyEvent;
 import android.webkit.ValueCallback;
 
 @SuppressLint("NewApi")
@@ -124,7 +125,7 @@ public class XWalkUIClientTest extends XWalkViewTestBase {
     @SmallTest
     public void testOnPageStartedExist() {
         try {
-            assertTrue(false);
+            assertTrue(checkMethodInClass(XWalkUIClient.class, "onPageStarted"));
         } catch (Exception e) {
             e.printStackTrace();
             assertTrue(false);
@@ -134,7 +135,7 @@ public class XWalkUIClientTest extends XWalkViewTestBase {
     @SmallTest
     public void testOnPageFinishedExist() {
         try {
-            assertTrue(false);
+            assertTrue(checkMethodInClass(XWalkUIClient.class, "onPageFinished"));
         } catch (Exception e) {
             e.printStackTrace();
             assertTrue(false);
@@ -144,7 +145,7 @@ public class XWalkUIClientTest extends XWalkViewTestBase {
     @SmallTest
     public void testOnReceivedAppNameExist() {
         try {
-            assertTrue(false);
+            assertTrue(checkMethodInClass(XWalkUIClient.class, "onReceivedAppName"));
         } catch (Exception e) {
             e.printStackTrace();
             assertTrue(false);
@@ -154,7 +155,7 @@ public class XWalkUIClientTest extends XWalkViewTestBase {
     @SmallTest
     public void testOnReceivedIconExist() {
         try {
-            assertTrue(false);
+            assertTrue(checkMethodInClass(XWalkUIClient.class, "onReceivedIcon"));
         } catch (Exception e) {
             e.printStackTrace();
             assertTrue(false);
@@ -164,7 +165,7 @@ public class XWalkUIClientTest extends XWalkViewTestBase {
     @SmallTest
     public void testOnJsAlertExist() {
         try {
-            assertTrue(false);
+            assertTrue(checkMethodInClass(XWalkUIClient.class, "onJsAlert"));
         } catch (Exception e) {
             e.printStackTrace();
             assertTrue(false);
@@ -174,7 +175,7 @@ public class XWalkUIClientTest extends XWalkViewTestBase {
     @SmallTest
     public void testOnJsConfirmExist() {
         try {
-            assertTrue(false);
+            assertTrue(checkMethodInClass(XWalkUIClient.class, "onJsConfirm"));
         } catch (Exception e) {
             e.printStackTrace();
             assertTrue(false);
@@ -184,7 +185,7 @@ public class XWalkUIClientTest extends XWalkViewTestBase {
     @SmallTest
     public void testOnJsPromptExist() {
         try {
-            assertTrue(false);
+            assertTrue(checkMethodInClass(XWalkUIClient.class, "onJsPrompt"));
         } catch (Exception e) {
             e.printStackTrace();
             assertTrue(false);
@@ -230,5 +231,219 @@ public class XWalkUIClientTest extends XWalkViewTestBase {
             assertTrue(false);
         }
 
+    }
+
+
+    @SmallTest
+    public void testGetDefaultVideoPosterExist() {
+        try {
+            assertTrue(checkMethodInClass(XWalkUIClient.class, "getDefaultVideoPoster"));
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testGetVideoLoadingProgressViewExist() {
+        try {
+            assertTrue(checkMethodInClass(XWalkUIClient.class, "getVideoLoadingProgressView"));
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnCreateWindowExist() {
+        try {
+            assertTrue(checkMethodInClass(XWalkUIClient.class, "onCreateWindow"));
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnReceivedTitle() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkUIClient uiClient = new XWalkUIClient(mXWalkView);
+                    uiClient.onReceivedTitle(mXWalkView, "title");
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnReceivedTouchIconUrlExist() {
+        try {
+            assertTrue(checkMethodInClass(XWalkUIClient.class, "onReceivedTouchIconUrl"));
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testShouldOverrideKeyEvent() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkUIClient uiClient = new XWalkUIClient(mXWalkView);
+                    uiClient.shouldOverrideKeyEvent(mXWalkView, new KeyEvent(0, 65));
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnUnhandledKeyEvent() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkUIClient uiClient = new XWalkUIClient(mXWalkView);
+                    uiClient.onUnhandledKeyEvent(mXWalkView, new KeyEvent(0,65));
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnPageStarted() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkUIClient uiClient = new XWalkUIClient(mXWalkView);
+                    uiClient.onPageLoadStarted(mXWalkView, "file:///android_asset/p2bar.html");
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnPageStarted_nullUrl() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkUIClient uiClient = new XWalkUIClient(mXWalkView);
+                    uiClient.onPageLoadStarted(mXWalkView, null);
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testShouldOverrideUrlLoading() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkUIClient uiClient = new XWalkUIClient(mXWalkView);
+                    uiClient.shouldOverrideKeyEvent(mXWalkView, new KeyEvent(0, 65));
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnCreateWindowRequestExist() {
+        try {
+            assertTrue(checkMethodInClass(XWalkUIClient.class, "onCreateWindowRequest"));
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+
+    @SmallTest
+    public void testOnPageStopped() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkUIClient uiClient = new XWalkUIClient(mXWalkView);
+                    uiClient.onPageLoadStopped(mXWalkView, "file:///android_asset/p2bar.html", LoadStatus.CANCELLED);
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnPageStopped_nullUrl() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkUIClient uiClient = new XWalkUIClient(mXWalkView);
+                    uiClient.onPageLoadStopped(mXWalkView, null, LoadStatus.CANCELLED);
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnPageStopped_nullView() {
+        try {
+            getInstrumentation().runOnMainSync(new Runnable() {
+
+                @Override
+                public void run() {
+                    XWalkUIClient uiClient = new XWalkUIClient(mXWalkView);
+                    uiClient.onPageLoadStopped(null, null, LoadStatus.CANCELLED);
+                }
+            });
+            assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
     }
 }

--- a/embeddingapi/webapi-embeddingapi-xwalk-tests/tests.xml
+++ b/embeddingapi/webapi-embeddingapi-xwalk-tests/tests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="./testcase.xsl"?>
 <test_definition>
-  <suite name="tct-embedding-tests" category="Android embedding APIs">
+  <suite name="webapi-embeddingapi-xwalk-tests" category="Android embedding APIs">
     <set name="LoadTest" test_set_src="org.xwalk.embedding.test.LoadTest"></set>
     <set name="NavigationTest" test_set_src="org.xwalk.embedding.test.NavigationTest"></set>
     <set name="XWalkNavigationItemTest" test_set_src="org.xwalk.embedding.test.XWalkNavigationItemTest"></set>
@@ -11,5 +11,6 @@
     <set name="XWalkPreferenceTest" test_set_src="org.xwalk.embedding.test.XWalkPreferenceTest"></set>
     <set name="XWalkJavascriptResultTest" test_set_src="org.xwalk.embedding.test.XWalkJavascriptResultTest"></set>
     <set name="FullScreenTest" test_set_src="org.xwalk.embedding.test.FullScreenTest"></set>
+    <set name="XWalkExtensionTest" test_set_src="org.xwalk.embedding.test.XWalkExtensionTest"></set>
   </suite>
 </test_definition>


### PR DESCRIPTION
- Add 25 cases about tests for embedding api. 11 of them are for XWalkExtension interface, others are for XWalkUIClient interface.
- Failure analysis:6 cases are failed because the methods of embedding api are not exist.

Impacted tests(approved): new 25, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 19, fail 6, block 0
