### PR TITLE
[webapi] Fix interface name for WebRTC

### DIFF
--- a/webapi/webapi-webrtc-w3c-tests/tests.full.xml
+++ b/webapi/webapi-webrtc-w3c-tests/tests.full.xml
@@ -1159,7 +1159,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if the the setting of RTCSessionDescription.sdp is normally" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P1" id="RTCPeerConnection_sdp">
+      <testcase purpose="Check if the the setting of RTCSessionDescription.sdp is normally" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P1" id="RTCSessionDescription_sdp">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCSessionDescription.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
@@ -1171,7 +1171,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if the the setting of RTCSessionDescription.type is normally" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P1" id="RTCPeerConnection_type">
+      <testcase purpose="Check if the the setting of RTCSessionDescription.type is normally" type="compliance" status="approved" component="WebAPI/Networking/WebRTC" execution_type="auto" priority="P1" id="RTCSessionDescription_type">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCSessionDescription.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>

--- a/webapi/webapi-webrtc-w3c-tests/tests.xml
+++ b/webapi/webapi-webrtc-w3c-tests/tests.xml
@@ -482,12 +482,12 @@
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_updateIce_method.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_sdp" purpose="Check if the the setting of RTCSessionDescription.sdp is normally">
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCSessionDescription_sdp" purpose="Check if the the setting of RTCSessionDescription.sdp is normally">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCSessionDescription.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCPeerConnection_type" purpose="Check if the the setting of RTCSessionDescription.type is normally">
+      <testcase component="WebAPI/Networking/WebRTC" execution_type="auto" id="RTCSessionDescription_type" purpose="Check if the the setting of RTCSessionDescription.type is normally">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/RTCSessionDescription.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/MediaStreamEvent_stream_basic.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/MediaStreamEvent_stream_basic.html
@@ -43,13 +43,22 @@ Authors:
 var t = async_test("Check if the readonly attribute stream of MediaStreamEvent exists and type of MediaStream", {timeout: 20000});
 
 var configuration = {"iceServers": [{"url": "stun:stun.example.org"}]};
-var pc1 = new webkitRTCPeerConnection(configuration);
+var pc1;
+if (typeof RTCPeerConnection != "undefined") {
+  pc1 = new RTCPeerConnection(configuration);
+} else {
+  pc1 = new webkitRTCPeerConnection(configuration);
+}
 var pc2;
 var pc1_offer;
 var fake_audio;
 
 t.step(function () {
-  navigator.webkitGetUserMedia({audio: true, vedio: true}, gotStream, function () {});
+  if (typeof (navigator.getUserMedia) != "undefined") {
+    navigator.getUserMedia({audio: true, vedio: true}, gotStream, function () {});
+  } else {
+    navigator.webkitGetUserMedia({audio: true, vedio: true}, gotStream, function () {});
+  }
 });
 
 function gotStream(stream) {
@@ -65,7 +74,11 @@ function requestSucceeded1 (offer) {
 
 
 function requestSucceeded2 () {
-  pc2 = new webkitRTCPeerConnection(null, null);
+  if (typeof RTCPeerConnection != "undefined") {
+    pc2 = new RTCPeerConnection(null, null);
+  } else {
+    pc2 = new webkitRTCPeerConnection(null, null);
+  }
   pc2.addStream(fake_audio);
   pc2.onaddstream = t.step_func(function (evt) {
     assert_true("stream" in evt, "stream attribute in MediaStreamEvent");

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCDTMFSender_basic.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCDTMFSender_basic.html
@@ -46,8 +46,16 @@ var ds;
 
 setup(function () {
   var configuration = {"iceServers": [{"url": "stun:stun.example.org"}]};
-  pc = new webkitRTCPeerConnection(configuration);
-  navigator.webkitGetUserMedia({audio: true, video: true}, gotStream, function () {});
+  if (typeof RTCPeerConnection != "undefined") {
+    pc = new RTCPeerConnection(configuration);
+  } else {
+    pc = new webkitRTCPeerConnection(configuration);
+  }
+  if (typeof (navigator.getUserMedia) != "undefined") {
+    navigator.getUserMedia({audio: true, video: true}, gotStream, function () {});
+  } else {
+    navigator.webkitGetUserMedia({audio: true, video: true}, gotStream, function () {});
+  }
 }, {explicit_done: true});
 
 

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCDTMFSender_canInsertDTMF.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCDTMFSender_canInsertDTMF.html
@@ -47,10 +47,19 @@ Authors:
       var t = async_test(document.title, {timeout: 5000});
 
       var configuration = {"iceServers": [{"url": "stun:stun.example.org"}]};
-      var pc = new webkitRTCPeerConnection(configuration);
+      var pc;
+      if (typeof RTCPeerConnection != "undefined") {
+        pc = new RTCPeerConnection(configuration);
+      } else {
+        pc = new webkitRTCPeerConnection(configuration);
+      }
 
       t.step(function () {
-        navigator.webkitGetUserMedia({audio:true, video:true}, gotStream, error);
+        if (typeof (navigator.getUserMedia) != "undefined") {
+          navigator.getUserMedia({audio:true, video:true}, gotStream, error);
+        } else {
+          navigator.webkitGetUserMedia({audio:true, video:true}, gotStream, error);
+        }
       });
 
       function gotStream(stream) {

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCDTMFToneChangeEvent_tone_basic.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCDTMFToneChangeEvent_tone_basic.html
@@ -43,10 +43,19 @@ Authors:
 var t = async_test("Check if the readonly attribute tone of RTCDTMFToneChangeEvent exists and type of string", {timeout: 5000});
 
 var configuration = {"iceServers": [{"url": "stun:stun.example.org"}]};
-var pc = new webkitRTCPeerConnection(configuration);
+var pc;
+if (typeof RTCPeerConnection != "undefined") {
+  pc = new RTCPeerConnection(configuration);
+} else {
+  pc = new webkitRTCPeerConnection(configuration);
+}
 
 t.step(function () {
-  navigator.webkitGetUserMedia({audio: true, video: true}, gotStream, error);
+  if (typeof (navigator.getUserMedia) != "undefined") {
+    navigator.getUserMedia({audio:true, video:true}, gotStream, error);
+  } else {
+    navigator.webkitGetUserMedia({audio:true, video:true}, gotStream, error);
+  }
 });
 
 function gotStream(stream) {

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel.html
@@ -47,7 +47,11 @@ Authors:
       var pc;
 
       setup(function () {
-        pc = new RTCPeerConnection(null,null);
+        if (typeof RTCPeerConnection != "undefined") {
+          pc = new RTCPeerConnection(null,null);
+        } else {
+          pc = new webkitRTCPeerConnection(null,null);
+        }
         RTCDataChannel = pc.createDataChannel("label");
       });
 

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCDataChannelEvent_channel_basic.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCDataChannelEvent_channel_basic.html
@@ -45,7 +45,12 @@ setup({timeout: 20000});
 
 var pc1_offer;
 var pc2_answer;
-var pc1 = new webkitRTCPeerConnection(null, null);
+var pc1;
+if (typeof RTCPeerConnection != "undefined") {
+  pc1 = new RTCPeerConnection(null, null);
+} else {
+  pc1 = new webkitRTCPeerConnection(null, null);
+}
 var pc2;
 
 function requestSucceeded1 (offer) {
@@ -61,7 +66,11 @@ function requestFailed1 () {
 }
 
 function requestSucceeded2 () {
-  pc2 = new webkitRTCPeerConnection(null, null);
+  if (typeof RTCPeerConnection != "undefined") {
+    pc2 = new RTCPeerConnection(null, null);
+  } else {
+    pc2 = new webkitRTCPeerConnection(null, null);
+  }
   pc2.ondatachannel = t.step_func(function (event) {
     assert_true("channel" in event, "channel attribute in RTCDataChannelEvent");
     assert_equals(Object.prototype.toString.call(event.channel), "[object RTCDataChannel]", "channel attribute of type");

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCDataChannel_basic.html
@@ -44,7 +44,11 @@ var pc;
 var channel;
 
 setup(function () {
-  pc = new webkitRTCPeerConnection(null,null);
+  if (typeof RTCPeerConnection != "undefined") {
+    pc = new RTCPeerConnection(null,null);
+  } else {
+    pc = new webkitRTCPeerConnection(null,null);
+  }
   channel = pc.createDataChannel("label");
 });
 

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCIdentityErrorEvent_basic.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCIdentityErrorEvent_basic.html
@@ -44,7 +44,12 @@ setup({timeout: 20000}, {explicit_done: true});
 
 var pc1_offer;
 var pc2_answer;
-var pc1 = new webkitRTCPeerConnection(null, null);
+var pc1;
+if (typeof RTCPeerConnection != "undefined") {
+  pc1 = new RTCPeerConnection(null, null);
+} else {
+  pc1 = new webkitRTCPeerConnection(null, null);
+}
 var pc2;
 
 function requestSucceeded1 (offer) {
@@ -53,7 +58,11 @@ function requestSucceeded1 (offer) {
 }
 
 function requestSucceeded2 () {
-  pc2 = new webkitRTCPeerConnection(null, null);
+  if (typeof RTCPeerConnection != "undefined") {
+    pc2 = new RTCPeerConnection(null, null);
+  } else {
+    pc2 = new webkitRTCPeerConnection(null, null);
+  }
   pc2.addEventLister("onidpvalidationerror", function(event) {
     [
       ["idp"], ["protocol"], ["loginUrl"],

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCIdentityEvent_assertion_basic.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCIdentityEvent_assertion_basic.html
@@ -45,7 +45,12 @@ setup({timeout: 20000});
 
 var pc1_offer;
 var pc2_answer;
-var pc1 = new webkitRTCPeerConnection(null, null);
+var pc1;
+if (typeof RTCPeerConnection != "undefined") {
+  pc1 = new RTCPeerConnection(null, null);
+} else {
+  pc1 = new webkitRTCPeerConnection(null, null);
+}
 var pc2;
 
 function requestSucceeded1 (offer) {
@@ -61,7 +66,11 @@ function requestFailed1 () {
 }
 
 function requestSucceeded2 () {
-  pc2 = new webkitRTCPeerConnection(null, null);
+  if (typeof RTCPeerConnection != "undefined") {
+    pc2 = new RTCPeerConnection(null, null);
+  } else {
+    pc2 = new webkitRTCPeerConnection(null, null);
+  }
   pc2.setRemoteDescription(pc1_offer, requestSucceeded3, requestFailed3);
 }
 

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection.html
@@ -53,9 +53,15 @@ Authors:
 
       setup(function () {
         var configuration = {"iceServers": [{"url": "stun:stun.example.org"}]};
-        pc = new RTCPeerConnection(configuration);
-        pc1 = new RTCPeerConnection(configuration);
-        pc2 = new RTCPeerConnection(configuration);
+        if (typeof RTCPeerConnection != "undefined") {
+          pc = new RTCPeerConnection(configuration);
+          pc1 = new RTCPeerConnection(configuration);
+          pc2 = new RTCPeerConnection(configuration);
+        } else {
+          pc = new webkitRTCPeerConnection(configuration);
+          pc1 = new webkitRTCPeerConnection(configuration);
+          pc2 = new webkitRTCPeerConnection(configuration);
+        }
       });
 
       t.step(function () {
@@ -75,7 +81,11 @@ Authors:
       });
 
       t1.step(function () {
-        navigator.webkitGetUserMedia({audio: true, video: true}, gotStream, error);
+        if (typeof (navigator.getUserMedia) != "undefined") {
+          navigator.getUserMedia({audio: true, video: true}, gotStream, error);
+        } else {
+          navigator.webkitGetUserMedia({audio: true, video: true}, gotStream, error);
+        }        
       });
 
       function gotStream(stream) {
@@ -96,7 +106,12 @@ Authors:
 
       test(function () {
         var cg = {"iceServers": [{"url": "stun:stun.example.org"}]};
-        var rc = new RTCPeerConnection(cg);
+        var rc;
+        if (typeof RTCPeerConnection != "undefined") {
+          rc = new RTCPeerConnection(cg);
+        } else {
+          rc = new webkitRTCPeerConnection(cg);
+        }
         rc.close();
         assert_equals(rc.iceConnectionState, "closed", "the pc.close()");
       }, "Check if the method of close is valid");

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnectionIceEvent_candidate.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnectionIceEvent_candidate.html
@@ -45,7 +45,12 @@ Authors:
     <script>
       var t = async_test("Check if the setting of RTCPeerConnectionIceEvent.candidate is normally", {timeout: 10000});
 
-      var pc = new RTCPeerConnection(null, null);
+      var pc;
+      if (typeof RTCPeerConnection != "undefined") {
+        pc = new RTCPeerConnection(null, null);
+      } else {
+        pc = new webkitRTCPeerConnection(null, null);
+      }
       var signalingChannel = pc.createDataChannel("label1");
 
       t.step(function () {

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnectionIceEvent_candidate_basic.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnectionIceEvent_candidate_basic.html
@@ -42,7 +42,12 @@ Authors:
 
 var t = async_test("Check if the readonly attribute candidate of RTCPeerConnectionIceEvent exists and type of string", {timeout: 10000});
 
-var pc = new RTCPeerConnection(null, null);
+var pc;
+if (typeof RTCPeerConnection != "undefined") {
+  pc = new RTCPeerConnection(null, null);
+} else {
+  pc = new webkitRTCPeerConnection(null, null);
+}
 var signalingChannel = pc.createDataChannel("label1");
 
 t.step(function () {

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_EventHandler.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_EventHandler.html
@@ -44,7 +44,11 @@ var pc;
 
 setup(function () {
   var configuration = { "iceServers": [{ "url": "stun:stun.example.org" }] };
-  pc = new RTCPeerConnection(configuration);
+  if (typeof RTCPeerConnection != "undefined") {
+    pc = new RTCPeerConnection(configuration);
+  } else {
+    pc = new webkitRTCPeerConnection(configuration);
+  }
 });
 
 test(function() {

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_basic.html
@@ -44,7 +44,11 @@ var pc;
 
 setup(function () {
   var configuration = {"iceServers": [{"url": "stun:stun.example.org"}]};
-  pc = new webkitRTCPeerConnection(configuration);
+  if (typeof RTCPeerConnection != "undefined") {
+    pc = new RTCPeerConnection(configuration);
+  } else {
+    pc = new webkitRTCPeerConnection(configuration);
+  }
 });
 
 [

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_close.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_close.html
@@ -42,7 +42,12 @@ Authors:
 
 test(function() {
   var configuration = {"iceServers": [{"url": "stun:stun.example.org"}]};
-  var pc = new RTCPeerConnection(configuration);
+  var pc;
+  if (typeof RTCPeerConnection != "undefined") {
+    pc = new RTCPeerConnection(configuration);
+  } else {
+    pc = new webkitRTCPeerConnection(configuration);
+  }
   pc.close();
   assert_throws("InvalidStateError", function () {
     pc.createDataChannel("lable");

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_createDTMFSender_basic.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_createDTMFSender_basic.html
@@ -47,11 +47,19 @@ var ds;
 
 setup(function () {
   var configuration = {"iceServers": [{"url": "stun:stun.example.org"}]};
-  pc = new webkitRTCPeerConnection(configuration);
+  if (typeof RTCPeerConnection != "undefined") {
+    pc = new RTCPeerConnection(configuration);
+  } else {
+    pc = new webkitRTCPeerConnection(configuration);
+  }
 });
 
 t.step(function () {
-  navigator.webkitGetUserMedia({audio: true, video: true}, gotStream, error);
+  if (typeof (navigator.getUserMedia) != "undefined") {
+    navigator.getUserMedia({audio: true, video: true}, gotStream, error);
+  } else {
+    navigator.webkitGetUserMedia({audio: true, video: true}, gotStream, error);
+  } 
 });
 
 function gotStream(stream) {

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_datachannel_event.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_datachannel_event.html
@@ -48,7 +48,12 @@ Authors:
 
       var pc1_offer;
       var pc2_answer;
-      var pc1 = new RTCPeerConnection(null, null);
+      var pc1;
+      if (typeof RTCPeerConnection != "undefined") {
+        pc1 = new RTCPeerConnection(null, null);
+      } else {
+        pc1 = new webkitRTCPeerConnection(null, null);
+      }
       var pc2;
 
       function requestSucceeded1 (offer) {
@@ -64,7 +69,11 @@ Authors:
       }
 
       function requestSucceeded2 () {
-        pc2 = new RTCPeerConnection(null, null);
+        if (typeof RTCPeerConnection != "undefined") {
+          pc2 = new RTCPeerConnection(null, null);
+        } else {
+          pc2 = new webkitRTCPeerConnection(null, null);
+        }
         pc2.ondatachannel = t.step_func(function (event) {
           t.done();
         });

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_getIdentityAssertion.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_getIdentityAssertion.html
@@ -42,7 +42,12 @@ Authors:
 
 test(function() {
   var configuration = { "iceServers": [{ "url": "stun:stun.example.org" }] };
-  var pc = new RTCPeerConnection(configuration);
+  var pc;
+  if (typeof RTCPeerConnection != "undefined") {
+    pc = new RTCPeerConnection(configuration);
+  } else {
+    pc = new webkitRTCPeerConnection(configuration);
+  }
   assert_equals(pc.getIdentityAssertion(), null, "the RTCPeerConnection.setIdentityProvider");
 }, "Check if the RTCPeerConnection.getIdentityAssertion of the return value is right");
 

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_getLocalStreams.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_getLocalStreams.html
@@ -42,7 +42,12 @@ Authors:
 
 test(function() {
   var configuration = { "iceServers": [{ "url": "stun:stun.example.org" }] };
-  var pc = new RTCPeerConnection(configuration);
+  var pc;
+  if (typeof RTCPeerConnection != "undefined") {
+    pc = new RTCPeerConnection(configuration);
+  } else {
+    pc = new webkitRTCPeerConnection(configuration);
+  }
   assert_equals(Object.prototype.toString.call(pc.getLocalStreams()), "[object Array]", "the RTCPeerConnection.getLocalStreams()");
 }, "Check if the RTCPeerConnection.getLocalStreams() return a sequence of MediaStream objects");
 

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_getRemoteStreams.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_getRemoteStreams.html
@@ -42,7 +42,12 @@ Authors:
 
 test(function() {
   var configuration = { "iceServers": [{ "url": "stun:stun.example.org" }] };
-  var pc = new RTCPeerConnection(configuration);
+  var pc;
+  if (typeof RTCPeerConnection != "undefined") {
+    pc = new RTCPeerConnection(configuration);
+  } else {
+    pc = new webkitRTCPeerConnection(configuration);
+  }
   assert_equals(Object.prototype.toString.call(pc.getRemoteStreams()), "[object Array]", "the RTCPeerConnection.getRemoteStreams()");
 }, "Check if the RTCPeerConnection.getRemoteStreams() return a sequence of MediaStream objects");
 

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_iceconnectionstatechange_event.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_iceconnectionstatechange_event.html
@@ -45,7 +45,12 @@ Authors:
     <script>
       var t = async_test("Check if the event of iceconnectionstatechange can fire at the RTCPeerConnection object", {timeout:2000});
       t.step(function () {
-        var pc = new RTCPeerConnection(null);
+        var pc;
+        if (typeof RTCPeerConnection != "undefined") {
+          pc = new RTCPeerConnection(null);
+        } else {
+          pc = new webkitRTCPeerConnection(null);
+        }
         pc.addEventListener("iceconnectionstatechange", function () {
           t.step(function(){
             assert_equals(pc.iceConnectionState, "closed", "the event of iceconnectionstatechange");

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_setIdentityProvider.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_setIdentityProvider.html
@@ -42,7 +42,12 @@ Authors:
 
 test(function() {
   var configuration = { "iceServers": [{ "url": "stun:stun.example.org" }] };
-  var pc = new RTCPeerConnection(configuration);
+  var pc;
+  if (typeof RTCPeerConnection != "undefined") {
+    pc = new RTCPeerConnection(configuration);
+  } else {
+    pc = new webkitRTCPeerConnection(configuration);
+  }
   assert_not_equals(pc.setIdentityProvider("example.com", "default", "alice@example.com"), null, "the RTCPeerConnection.setIdentityProvider");
 }, "Check if the RTCPeerConnection.setIdentityProvider is valid");
 

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_signalingstatechange_event.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_signalingstatechange_event.html
@@ -45,7 +45,12 @@ Authors:
     <script>
       var t = async_test("Check if the event of signalingstatechange can fire at the RTCPeerConnection object", {timeout: 2000});
       t.step(function () {
-        var pc = new RTCPeerConnection(null, null);
+        var pc;
+        if (typeof RTCPeerConnection != "undefined") {
+          pc = new RTCPeerConnection(null, null);
+        } else {
+          pc = new webkitRTCPeerConnection(null, null);
+        }
         pc.addEventListener("signalingstatechange", function () {
           t.step(function () {
              assert_equals(pc.signalingState, "closed");

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_updateIce_method.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection_updateIce_method.html
@@ -45,7 +45,12 @@ Authors:
     <script>
       test(function () {
         var configuration = {"iceServers": [{"url": "stun:stun.example.org"}]};
-        pc = new RTCPeerConnection(configuration);
+        var pc;
+        if (typeof RTCPeerConnection != "undefined") {
+          pc = new RTCPeerConnection(configuration);
+        } else {
+          pc = new webkitRTCPeerConnection(configuration);
+        }
         assert_throws("SyntaxError",
           function () {
             pc.updateIce(1);

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCSdpError_sdpLineNumber_basic.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCSdpError_sdpLineNumber_basic.html
@@ -42,7 +42,12 @@ Authors:
 
 var t = async_test("Check if the readonly attribute sdpLineNumber of RTCSdpError exists and type of number");
 
-var pc = new webkitRTCPeerConnection(null, null);
+var pc;
+if (typeof RTCPeerConnection != "undefined") {
+  pc = new RTCPeerConnection(null, null);
+} else {
+  pc = new webkitRTCPeerConnection(null, null);
+}
 
 t.step(function () {
   pc.createOffer(localDescCreated, logError);

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCStatsReport_RTCStats_basic.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCStatsReport_RTCStats_basic.html
@@ -43,10 +43,19 @@ Authors:
 var t = async_test("Check if RTCStatsReport.RTCStats exists and type of function", {timeout: 5000});
 
 var configuration = {"iceServers": [{"url": "stun:stun.example.org"}]};
-var pc = new webkitRTCPeerConnection(configuration);
+var pc;
+if (typeof RTCPeerConnection != "undefined") {
+  pc = new RTCPeerConnection(configuration);
+} else {
+  pc = new webkitRTCPeerConnection(configuration);
+}
 
 t.step(function () {
-  navigator.webkitGetUserMedia({audio: true, video: true}, gotStream, error);
+  if (typeof (navigator.getUserMedia) != "undefined") {
+    navigator.getUserMedia({audio: true, video: true}, gotStream, error);
+  } else {
+    navigator.webkitGetUserMedia({audio: true, video: true}, gotStream, error);
+  }
 });
 
 function gotStream(stream) {

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-AddRemoveStream.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-AddRemoveStream.html
@@ -28,7 +28,11 @@ function error() {
 
 function getUserMedia(dictionary, callback) {
   t.step(function () {
-    navigator.webkitGetUserMedia(dictionary, callback, error);
+    if (typeof (navigator.getUserMedia) != "undefined") {
+      navigator.getUserMedia(dictionary, callback, error);
+    } else {
+      navigator.webkitGetUserMedia(dictionary, callback, error);
+    }
   });
 }
 
@@ -70,7 +74,11 @@ function gotStream2(s) {
   stream2 = s;
   t.step(function () {
     assert_not_equals(stream.id, stream2.id);
-    pc = new webkitRTCPeerConnection(null, null);
+    if (typeof RTCPeerConnection != "undefined") {
+      pc = new RTCPeerConnection(null, null);
+    } else {
+      pc = new webkitRTCPeerConnection(null, null);
+    }
     pc.onnegotiationneeded = onAddStream;
     pc.addStream(stream);
   });

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-createAnswer.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-createAnswer.html
@@ -15,8 +15,15 @@ https://github.com/crosswalk-project/blink-crosswalk/blob/master/LayoutTests/fas
 
 var t = async_test(document.title);
 
-var pc = new webkitRTCPeerConnection(null, null);
-var pc2 = new webkitRTCPeerConnection(null, null);
+var pc;
+var pc2;
+if (typeof RTCPeerConnection != "undefined") {
+  pc = new RTCPeerConnection(null, null);
+  pc2 = new RTCPeerConnection(null, null);
+} else {
+  pc = new webkitRTCPeerConnection(null, null);
+  pc2 = new webkitRTCPeerConnection(null, null);
+}
 var pc1_offer;
 
 function requestFailed4(reason) {

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-createOffer.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-createOffer.html
@@ -15,7 +15,12 @@ https://github.com/crosswalk-project/blink-crosswalk/blob/master/LayoutTests/fas
 
 var t = async_test(document.title);
 
-var pc = new webkitRTCPeerConnection(null, null);
+var pc;
+if (typeof RTCPeerConnection != "undefined") {
+  pc = new RTCPeerConnection(null, null);
+} else {
+  pc = new webkitRTCPeerConnection(null, null);
+}
 
 function requestFailed2(reason) {
   errorReason = reason;

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-datachannel.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-datachannel.html
@@ -101,7 +101,11 @@ function pc_onicechange() {
 }
 
 setup(function () {
-  pc = new webkitRTCPeerConnection(null, null);
+  if (typeof RTCPeerConnection != "undefined") {
+    pc = new RTCPeerConnection(null, null);
+  } else {
+    pc = new webkitRTCPeerConnection(null, null);
+  }
 }, {timeout: 5000});
 
 test(function () {
@@ -149,7 +153,11 @@ test(function () {
 }, "the RTCPeerConnection.createDataChannel('label6', {maxRetransmitTime:0})");
 
 t.step(function () {
-  pc = new webkitRTCPeerConnection(null, null);
+  if (typeof RTCPeerConnection != "undefined") {
+    pc = new RTCPeerConnection(null, null);
+  } else {
+    pc = new webkitRTCPeerConnection(null, null);
+  }
   pc.oniceconnectionstatechange = pc_onicechange;
   pc.ondatachannel = pc_ondatachannel;
 });

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-dtmf.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-dtmf.html
@@ -70,12 +70,20 @@ function gotStream(s) {
     assert_equals(stream.getVideoTracks().length, 0);
   });
 
-  pc = new webkitRTCPeerConnection(null, null);
+  if (typeof RTCPeerConnection != "undefined") {
+    pc = new RTCPeerConnection(null, null);
+  } else {
+    pc = new webkitRTCPeerConnection(null, null);
+  }
   pc.oniceconnectionstatechange = pc_onicechange;
 }
 
 t.step(function () {
-  navigator.webkitGetUserMedia({audio: true, video: false}, gotStream, error);
+  if (typeof (navigator.getUserMedia) != "undefined") {
+    navigator.getUserMedia({audio: true, video: false}, gotStream, error);
+  } else {
+    navigator.webkitGetUserMedia({audio: true, video: false}, gotStream, error);
+  }
 });
 
 </script>

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-ice.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-ice.html
@@ -58,7 +58,11 @@ function onIceChange1() {
 }
 
 t.step(function () {
-  pc = new webkitRTCPeerConnection(null, null);
+  if (typeof RTCPeerConnection != "undefined") {
+    pc = new RTCPeerConnection(null, null);
+  } else {
+    pc = new webkitRTCPeerConnection(null, null);
+  }
   pc.oniceconnectionstatechange = onIceChange1;
 });
 

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-localDescription.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-localDescription.html
@@ -34,7 +34,11 @@ function requestFailed1 () {
 }
 
 function requestSucceeded2() {
-  pc2 = new webkitRTCPeerConnection(null, null);
+  if (typeof RTCPeerConnection != "undefined") {
+    pc2 = new RTCPeerConnection(null, null);
+  } else {
+    pc2 = new webkitRTCPeerConnection(null, null);
+  }
   pc2.setRemoteDescription(pc1_offer, requestSucceeded3, requestFailed3);
 }
 
@@ -83,7 +87,11 @@ function requestFailed5() {
 }
 
 t.step(function() {
-  pc = new webkitRTCPeerConnection(null, null);
+  if (typeof RTCPeerConnection != "undefined") {
+    pc = new RTCPeerConnection(null, null);
+  } else {
+    pc = new webkitRTCPeerConnection(null, null);
+  }
   pc.createOffer(requestSucceeded1, requestFailed1);
 });
 

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-onnegotiationneeded.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-onnegotiationneeded.html
@@ -26,12 +26,20 @@ function error() {
 }
 
 function getUserMedia(dictionary, callback) {
-  pc = new webkitRTCPeerConnection(null, null);
+  if (typeof RTCPeerConnection != "undefined") {
+    pc = new RTCPeerConnection(null, null);
+  } else {
+    pc = new webkitRTCPeerConnection(null, null);
+  }
   pc.onnegotiationneeded = t.step_func(function (event) {
     t.done();
   });
   t.step(function () {
-    navigator.webkitGetUserMedia(dictionary, callback, error);
+    if (typeof (navigator.getUserMedia) != "undefined") {
+      navigator.getUserMedia(dictionary, callback, error);
+    } else {
+      navigator.webkitGetUserMedia(dictionary, callback, error);
+    }
   });
 }
 

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-remoteDescription.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-remoteDescription.html
@@ -24,7 +24,11 @@ function requestFailed2() {
 }
 
 function requestSucceeded2() {
-  pc2 = new webkitRTCPeerConnection(null, null);
+  if (typeof RTCPeerConnection != "undefined") {
+    pc2 = new RTCPeerConnection(null, null);
+  } else {
+    pc2 = new webkitRTCPeerConnection(null, null);
+  }
   pc2.setRemoteDescription(pc1_offer, t.step_func(function () {
     t.done();
   }), function () {
@@ -50,7 +54,11 @@ function requestSucceeded1 (offer) {
 }
 
 t.step(function () {
-  pc = new webkitRTCPeerConnection(null, null);
+  if (typeof RTCPeerConnection != "undefined") {
+    pc = new RTCPeerConnection(null, null);
+  } else {
+    pc = new webkitRTCPeerConnection(null, null);
+  }
   pc.createOffer(requestSucceeded1, requestFailed1);
 });
 

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-state.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-state.html
@@ -18,7 +18,11 @@ var pc = null;
 var t = async_test(document.title, {timeout: 2000});
 
 t.step(function () {
-  pc = new webkitRTCPeerConnection({ "iceServers": [{ "url": "stun:stun.example.org" }]});
+  if (typeof RTCPeerConnection != "undefined") {
+    pc = new RTCPeerConnection({ "iceServers": [{ "url": "stun:stun.example.org" }]});
+  } else {
+    pc = new webkitRTCPeerConnection({ "iceServers": [{ "url": "stun:stun.example.org" }]});
+  }
   assert_equals(pc.signalingState, 'stable');
   pc.onsignalingstatechange = t.step_func(function (){
     assert_equals(pc.signalingState, 'closed');

--- a/webapi/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-stats.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-stats.html
@@ -23,7 +23,11 @@ var t = async_test(document.title, {timeout: 2000});
 
 function getUserMedia(dictionary, callback) {
   try {
-    navigator.webkitGetUserMedia(dictionary, callback, error);
+    if (typeof (navigator.getUserMedia) != "undefined") {
+      navigator.getUserMedia(dictionary, callback, error);
+    } else {
+      navigator.webkitGetUserMedia(dictionary, callback, error);
+    }
   } catch (e) {
     t.step(function () {
       assert_unreached("requestSucceeded was called.");
@@ -94,7 +98,11 @@ function statsHandler2(status) {
 var startTime = new Date().getTime();
 
 t.step(function () {
-  pc = new webkitRTCPeerConnection(null);
+  if (typeof RTCPeerConnection != "undefined") {
+    pc = new RTCPeerConnection(null);
+  } else {
+    pc = new webkitRTCPeerConnection(null);
+  }
   getUserMedia({audio:true, video:true}, gotStream);
 });
 


### PR DESCRIPTION
- Fix interface name
- Failure analysis: The ondatachannel event, onidpvalidationerror event and onidentityresult event cannot be fired. The Identity API extends the RTCPeerConnection interface is not support.

Impacted tests(approved): new 0, update 143, delete 0
Unit test platform: [Tizen IVI]
Unit test result summary: pass 111, fail 15, block 17
