### PR TITLE
[webapi] Update 44 TCs for MediaRenderer

### DIFF
--- a/webapi/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html
+++ b/webapi/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html
@@ -39,11 +39,11 @@ Authors:
 <div id="log"></div>
 <script>
 
-setup({explicit_done: true});
+setup({timeout: 30000}, {explicit_done: true});
 
 navigator.mediaRenderer.onrendererfound = function (event) {
   [
-    ["playbackStatus", "playbackStatus", "readonly"],
+    ["object", "playbackStatus", "readonly"],
     ["boolean", "muted", "readonly"],
     ["number", "volume", "readonly"],
     ["number", "track", "readonly"],
@@ -75,8 +75,8 @@ navigator.mediaRenderer.onrendererfound = function (event) {
       case "function":
         assert_equals(typeof event.renderer.controller[name], type, name + " attribute of type");      
         break;
-      case "playbackStatus":
-        assert_equals(Object.prototype.toString.call(event.renderer.controller[name]), "[object PlaybackStatus]", name + " attribute of type");
+      case "object":
+        assert_equals(Object.prototype.toString.call(event.renderer.controller[name]), "[object Object]", name + " attribute of type");
         assert_readonly(event.renderer.controller, name, "expect attribute " + name + " cannot be changed but");
         break;
       default:

--- a/webapi/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html
+++ b/webapi/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html
@@ -39,12 +39,12 @@ Authors:
 <div id="log"></div>
 <script>
 
-setup({explicit_done: true});
+setup({timeout: 30000}, {explicit_done: true});
 
 navigator.mediaRenderer.onrendererfound = function (eve) {
   eve.renderer.controller.onstatuschanged = function (event) {
     [
-      ["playbackStatus", "playbackStatus", "readonly"],
+      ["object", "playbackStatus", "readonly"],
       ["boolean", "muted", "readonly"],
       ["number", "volume", "readonly"],
       ["number", "track", "readonly"],
@@ -64,8 +64,8 @@ navigator.mediaRenderer.onrendererfound = function (eve) {
           }
           assert_equals(typeof event[name], type, name + " attribute of type");      
           break;
-        case "playbackStatus":
-          assert_equals(Object.prototype.toString.call(event[name]), "[object PlaybackStatus]", name + " attribute of type");
+        case "object":
+          assert_equals(Object.prototype.toString.call(event[name]), "[object Object]", name + " attribute of type");
           assert_readonly(event, name, "expect attribute " + name + " cannot be changed but");
           break;
         default:
@@ -73,9 +73,9 @@ navigator.mediaRenderer.onrendererfound = function (eve) {
         }
       }, "Check if " + read + " MediaControllerStatusEvent." + name + " exists and type of " + type);
     });
-    eve.renderer.controller.mute(!(eve.renderer.controller.muted)).then(function(mutes) {}, function(error) {});
     done();
   };
+  eve.renderer.controller.mute(!(eve.renderer.controller.muted));
 };
 
 navigator.mediaRenderer.scanNetwork();

--- a/webapi/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html
+++ b/webapi/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html
@@ -39,7 +39,7 @@ Authors:
 <div id="log"></div>
 <script>
 
-setup({explicit_done: true});
+setup({timeout: 30000}, {explicit_done: true});
 
 navigator.mediaRenderer.onrendererfound = function (event) {
   [
@@ -56,7 +56,7 @@ navigator.mediaRenderer.onrendererfound = function (event) {
     ["string", "iconURL", "readonly"],
     ["string", "deviceType", "readonly"],
     ["string", "protocolInfo", "readonly"],
-    ["mediaController", "controller", "readonly"],
+    ["object", "controller", "readonly"],
     ["function", "openURI", ""],
     ["function", "prefetchURI", ""],
     ["function", "cancel", ""]
@@ -75,8 +75,8 @@ navigator.mediaRenderer.onrendererfound = function (event) {
       case "function":
         assert_equals(typeof event.renderer[name], type, name + " attribute of type");      
         break;
-      case "mediaController":
-        assert_equals(Object.prototype.toString.call(event.renderer[name]), "[object MediaController]", name + " attribute of type");
+      case "object":
+        assert_equals(Object.prototype.toString.call(event.renderer[name]), "[object Object]", name + " attribute of type");
         assert_readonly(event.renderer, name, "expect attribute " + name + " cannot be changed but");
         break;
       default:

--- a/webapi/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererEvent_renderer.html
+++ b/webapi/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererEvent_renderer.html
@@ -39,12 +39,12 @@ Authors:
 <div id="log"></div>
 <script>
 
-var t = async_test("Check if the readonly attribute renderer of MediaRendererEvent exists and type of MediaRenderer");
+var t = async_test("Check if the readonly attribute renderer of MediaRendererEvent exists and type of object");
 setup({timeout: 20000});
 
 navigator.mediaRenderer.onrendererfound = t.step_func(function (event) {
   assert_true("renderer" in event, "renderer attribute in MediaRendererEvent");
-  assert_equals(Object.prototype.toString.call(event.renderer), "[object MediaRenderer]", "channel attribute of type");
+  assert_equals(Object.prototype.toString.call(event.renderer), "[object Object]", "renderer attribute of type");
   assert_readonly(event, "renderer", "expect attribute renderer cannot be changed but");
   t.done();
 });

--- a/webapi/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererIdEvent_id.html
+++ b/webapi/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererIdEvent_id.html
@@ -40,7 +40,7 @@ Authors:
 <script>
 
 var t = async_test("Check if the readonly attribute id of MediaRendererIdEvent exists and type of string");
-setup({timeout: 20000});
+setup({timeout: 30000});
 
 navigator.mediaRenderer.onrendererlost = t.step_func(function (event) {
   assert_true("id" in event, "id attribute in MediaRendererIdEvent");
@@ -48,6 +48,12 @@ navigator.mediaRenderer.onrendererlost = t.step_func(function (event) {
   assert_readonly(event, "id", "expect attribute id cannot be changed but");
   t.done();
 });
+
+navigator.mediaRenderer.onrendererfound = function (eve) {
+  eve.renderer.controller.pause();
+  eve.renderer.controller.stop();
+  eve.renderer.cancel();
+};
 
 navigator.mediaRenderer.scanNetwork();
 

--- a/webapi/webapi-mediarenderer-xwalk-tests/tests.full.xml
+++ b/webapi/webapi-mediarenderer-xwalk-tests/tests.full.xml
@@ -51,7 +51,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if the readonly attribute renderer of MediaRendererEvent exists and type of MediaRenderer" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaRendererEvent_renderer">
+      <testcase purpose="Check if the readonly attribute renderer of MediaRendererEvent exists and type of object" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaRendererEvent_renderer">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererEvent_renderer.html</test_script_entry>
         </description>
@@ -231,7 +231,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if readonly MediaRenderer.controller exists and type of mediaController" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaRenderer_controller">
+      <testcase purpose="Check if readonly MediaRenderer.controller exists and type of object" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaRenderer_controller">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
         </description>
@@ -279,7 +279,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if readonly MediaController.playbackStatus exists and type of playbackStatus" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaController_playbackStatus">
+      <testcase purpose="Check if readonly MediaController.playbackStatus exists and type of object" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaController_playbackStatus">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
@@ -471,7 +471,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if readonly MediaControllerStatusEvent.playbackStatus exists and type of playbackStatus" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaControllerStatusEvent_playbackStatus">
+      <testcase purpose="Check if readonly MediaControllerStatusEvent.playbackStatus exists and type of object" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaControllerStatusEvent_playbackStatus">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>

--- a/webapi/webapi-mediarenderer-xwalk-tests/tests.xml
+++ b/webapi/webapi-mediarenderer-xwalk-tests/tests.xml
@@ -23,202 +23,202 @@
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererManager.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRendererEvent_renderer" purpose="Check if the readonly attribute renderer of MediaRendererEvent exists and type of MediaRenderer">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRendererEvent_renderer" purpose="Check if the readonly attribute renderer of MediaRendererEvent exists and type of object" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererEvent_renderer.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRendererIdEvent_id" purpose="Check if the readonly attribute id of MediaRendererIdEvent exists and type of string">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRendererIdEvent_id" purpose="Check if the readonly attribute id of MediaRendererIdEvent exists and type of string" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererIdEvent_id.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_id" purpose="Check if readonly MediaRenderer.id exists and type of string">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_id" purpose="Check if readonly MediaRenderer.id exists and type of string" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_friendlyName" purpose="Check if readonly MediaRenderer.friendlyName exists and type of string">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_friendlyName" purpose="Check if readonly MediaRenderer.friendlyName exists and type of string" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_manufacturer" purpose="Check if readonly MediaRenderer.manufacturer exists and type of string">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_manufacturer" purpose="Check if readonly MediaRenderer.manufacturer exists and type of string" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_manufacturerURL" purpose="Check if readonly MediaRenderer.manufacturerURL exists and type of string">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_manufacturerURL" purpose="Check if readonly MediaRenderer.manufacturerURL exists and type of string" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_modelDescription" purpose="Check if readonly MediaRenderer.modelDescription exists and type of string">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_modelDescription" purpose="Check if readonly MediaRenderer.modelDescription exists and type of string" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_modelName" purpose="Check if readonly MediaRenderer.modelName exists and type of string">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_modelName" purpose="Check if readonly MediaRenderer.modelName exists and type of string" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_modelNumber" purpose="Check if readonly MediaRenderer.modelNumber exists and type of string">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_modelNumber" purpose="Check if readonly MediaRenderer.modelNumber exists and type of string" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_serialNumber" purpose="Check if readonly MediaRenderer.serialNumber exists and type of string">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_serialNumber" purpose="Check if readonly MediaRenderer.serialNumber exists and type of string" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_UDN" purpose="Check if readonly MediaRenderer.UDN exists and type of string">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_UDN" purpose="Check if readonly MediaRenderer.UDN exists and type of string" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_presentationURL" purpose="Check if readonly MediaRenderer.presentationURL exists and type of string">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_presentationURL" purpose="Check if readonly MediaRenderer.presentationURL exists and type of string" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_iconURL" purpose="Check if readonly MediaRenderer.iconURL exists and type of string">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_iconURL" purpose="Check if readonly MediaRenderer.iconURL exists and type of string" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_deviceType" purpose="Check if readonly MediaRenderer.deviceType exists and type of string">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_deviceType" purpose="Check if readonly MediaRenderer.deviceType exists and type of string" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_protocolInfo" purpose="Check if readonly MediaRenderer.protocolInfo exists and type of string">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_protocolInfo" purpose="Check if readonly MediaRenderer.protocolInfo exists and type of string" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_controller" purpose="Check if readonly MediaRenderer.controller exists and type of mediaController">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_controller" purpose="Check if readonly MediaRenderer.controller exists and type of object" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_openURI" purpose="Check if MediaRenderer.openURI exists and type of function">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_openURI" purpose="Check if MediaRenderer.openURI exists and type of function" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_prefetchURI" purpose="Check if MediaRenderer.prefetchURI exists and type of function">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_prefetchURI" purpose="Check if MediaRenderer.prefetchURI exists and type of function" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=16</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_cancel" purpose="Check if MediaRenderer.cancel exists and type of function">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_cancel" purpose="Check if MediaRenderer.cancel exists and type of function" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_playbackStatus" purpose="Check if readonly MediaController.playbackStatus exists and type of playbackStatus">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_playbackStatus" purpose="Check if readonly MediaController.playbackStatus exists and type of object" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_muted" purpose="Check if readonly MediaController.muted exists and type of boolean">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_muted" purpose="Check if readonly MediaController.muted exists and type of boolean" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_volume" purpose="Check if readonly MediaController.volume exists and type of number">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_volume" purpose="Check if readonly MediaController.volume exists and type of number" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_track" purpose="Check if readonly MediaController.track exists and type of number">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_track" purpose="Check if readonly MediaController.track exists and type of number" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_speed" purpose="Check if readonly MediaController.speed exists and type of number">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_speed" purpose="Check if readonly MediaController.speed exists and type of number" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_playSpeeds" purpose="Check if readonly MediaController.playSpeeds exists and type of number">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_playSpeeds" purpose="Check if readonly MediaController.playSpeeds exists and type of number" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_play" purpose="Check if MediaController.play exists and type of function">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_play" purpose="Check if MediaController.play exists and type of function" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_pause" purpose="Check if MediaController.pause exists and type of function">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_pause" purpose="Check if MediaController.pause exists and type of function" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_stop" purpose="Check if MediaController.stop exists and type of function">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_stop" purpose="Check if MediaController.stop exists and type of function" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_next" purpose="Check if MediaController.next exists and type of function">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_next" purpose="Check if MediaController.next exists and type of function" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_previous" purpose="Check if MediaController.previous exists and type of function">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_previous" purpose="Check if MediaController.previous exists and type of function" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_mute" purpose="Check if MediaController.mute exists and type of function">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_mute" purpose="Check if MediaController.mute exists and type of function" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_setSpeed" purpose="Check if MediaController.setSpeed exists and type of function">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_setSpeed" purpose="Check if MediaController.setSpeed exists and type of function" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_setVolume" purpose="Check if MediaController.setVolume exists and type of function">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_setVolume" purpose="Check if MediaController.setVolume exists and type of function" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_gotoTrack" purpose="Check if MediaController.gotoTrack exists and type of function">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_gotoTrack" purpose="Check if MediaController.gotoTrack exists and type of function" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_onstatuschanged" purpose="Check if MediaController.onstatuschanged exists and type of event">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_onstatuschanged" purpose="Check if MediaController.onstatuschanged exists and type of event" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=16</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaControllerStatusEvent_playbackStatus" purpose="Check if readonly MediaControllerStatusEvent.playbackStatus exists and type of playbackStatus">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaControllerStatusEvent_playbackStatus" purpose="Check if readonly MediaControllerStatusEvent.playbackStatus exists and type of object" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaControllerStatusEvent_muted" purpose="Check if readonly MediaControllerStatusEvent.muted exists and type of boolean">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaControllerStatusEvent_muted" purpose="Check if readonly MediaControllerStatusEvent.muted exists and type of boolean" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaControllerStatusEvent_volume" purpose="Check if readonly MediaControllerStatusEvent.volume exists and type of number">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaControllerStatusEvent_volume" purpose="Check if readonly MediaControllerStatusEvent.volume exists and type of number" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaControllerStatusEvent_track" purpose="Check if readonly MediaControllerStatusEvent.track exists and type of number">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaControllerStatusEvent_track" purpose="Check if readonly MediaControllerStatusEvent.track exists and type of number" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaControllerStatusEvent_speed" purpose="Check if readonly MediaControllerStatusEvent.speed exists and type of number">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaControllerStatusEvent_speed" purpose="Check if readonly MediaControllerStatusEvent.speed exists and type of number" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
         </description>


### PR DESCRIPTION
- Update 44 TCs for MediaRenderer
- Failure analysis: The statuschanged event and rendererlost event cannot be fired

Impacted tests(approved): new 0, update 44, delete 0
Unit test platform: [Tizen IVI]
Unit test result summary: pass 34, fail 4, block 6
