### PR TITLE
[usecase-webapi] Fix the bug that the 'Pass' button is disabled when click the 'Cancle CSS FullScreen' button.

### DIFF
--- a/misc/webapi-usecase-w3c-tests/tests/FullScreen/js/main.js
+++ b/misc/webapi-usecase-w3c-tests/tests/FullScreen/js/main.js
@@ -63,11 +63,11 @@ $(document).ready(function () {
         function(evt) {
             if (document.webkitIsFullScreen) {
                 document.webkitCancelFullScreen();
-                if ($(document)["context"].styleSheets.length == 2) {
-                    $(document)["context"].styleSheets[1].deleteRule(1);
+                if ($(document)["context"].styleSheets.length > 2) {
+                     $(document)["context"].styleSheets[2].deleteRule(1);
                 }
                 document.documentElement.webkitRequestFullScreen();
-                window.location.reload();
+                requestElement("");
             }
      });
 });


### PR DESCRIPTION
Impacted tests(approved): New 0, Update 1, Delete 0
Unit test platform: [TIZEN IVI]
Unit test result summary: Pass 1, Fail 0, Block 0
