### PR TITLE
[webapi]Change ref test in tct-flexiblebox-css3-tests

### DIFF
--- a/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-001.htm
+++ b/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-001.htm
@@ -1,25 +1,26 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD//XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>CSS Test: A flex container with the 'align-items' property set to 'flex-start'</title>
+        <title>CSS Test: A multi-line flex container with the 'align-content' property set to 'center'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
-        <link rel="help" href="http://www.w3.org/TR/css3-flexbox/#align-items-property" />
+        <link rel="help" href="http://www.w3.org/TR/css3-flexbox/#align-content-property" />
+        <link rel="match" href="reference/align-content-001-ref.html" />
         <meta name="flags" content="">
-        <meta name="assert" content="This test checks that the flex container with 'align-items: flex-start' places each flex item's margin box flush with the cross-start edge of line." />
+        <meta name="assert" content="This test checks that a multi-line flex container with 'align-content: center' centers lines in the flex container." />
         <style type="text/css">
             #flexbox
             {
-                background: linear-gradient(to bottom, red 0, red 50px, green 50px, green 100px);
-                align-items: center;
-                align-items: flex-start;
+                background: linear-gradient(to bottom, green 0, green 25px, red 25px, red 75px, green 75px, green 100px);
+                align-content: center;
                 display: flex;
+                flex-flow: wrap;
                 height: 100px;
                 width: 300px;
             }
             div div
             {
                 background-color: green;
-                height: 51px;
+                height: 26px;
                 width: 150px;
             }
         </style>
@@ -27,6 +28,8 @@
     <body>
         <p>Test passes if there is no red visible on the page.</p>
         <div id="flexbox">
+            <div></div>
+            <div></div>
             <div></div>
             <div></div>
         </div>

--- a/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-002.htm
+++ b/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-002.htm
@@ -1,17 +1,17 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD//XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>CSS Test: A multi-line flex container with the 'align-content' property set to 'stretch'</title>
+        <title>CSS Test: A multi-line flex container with the 'align-content' property set to 'flex-start'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/css3-flexbox/#align-content-property" />
+        <link rel="match" href="reference/align-content-001-ref.html" />
         <meta name="flags" content="">
-        <meta name="assert" content="This test checks that a multi-line flex container with 'align-content: stretch' stretches lines to take up the remaining space." />
+        <meta name="assert" content="This test checks that a multi-line flex container with 'align-content: flex-start' packs lines toward the start of the flex container." />
         <style type="text/css">
             #flexbox
             {
-                background: red;
-                align-content: center;
-                align-content: stretch;
+                background: linear-gradient(to bottom, red 0, red 50px, green 50px, green 100px);
+                align-content: flex-start;
                 display: flex;
                 flex-flow: wrap;
                 height: 100px;
@@ -20,6 +20,7 @@
             div div
             {
                 background-color: green;
+                height: 26px;
                 width: 150px;
             }
         </style>

--- a/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-003.htm
+++ b/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-003.htm
@@ -1,25 +1,26 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD//XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>CSS Test: A flex container with the 'align-items' property set to 'flex-end'</title>
+        <title>CSS Test: A multi-line flex container with the 'align-content' property set to 'flex-end'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
-        <link rel="help" href="http://www.w3.org/TR/css3-flexbox/#align-items-property" />
+        <link rel="help" href="http://www.w3.org/TR/css3-flexbox/#align-content-property" />
+        <link rel="match" href="reference/align-content-001-ref.html" />
         <meta name="flags" content="">
-        <meta name="assert" content="This test checks that the flex container with 'align-items: flex-end' places each flex item's margin box flush with the cross-end edge of line." />
+        <meta name="assert" content="This test checks that a multi-line flex container with 'align-content: flex-end' packs lines toward the end of the flex container." />
         <style type="text/css">
             #flexbox
             {
                 background: linear-gradient(to bottom, green 0, green 50px, red 50px, red 100px);
-                align-items: center;
-                align-items: flex-end;
+                align-content: flex-end;
                 display: flex;
+                flex-flow: wrap;
                 height: 100px;
                 width: 300px;
             }
             div div
             {
                 background-color: green;
-                height: 51px;
+                height: 26px;
                 width: 150px;
             }
         </style>
@@ -27,6 +28,8 @@
     <body>
         <p>Test passes if there is no red visible on the page.</p>
         <div id="flexbox">
+            <div></div>
+            <div></div>
             <div></div>
             <div></div>
         </div>

--- a/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-005.htm
+++ b/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-005.htm
@@ -4,6 +4,7 @@
         <title>CSS Test: A multi-line flex container with the 'align-content' property set to 'space-around'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/css3-flexbox/#align-content-property" />
+        <link rel="match" href="reference/align-content-001-ref.html" />
         <meta name="flags" content="">
         <meta name="assert" content="This test checks that a multi-line flex container with 'align-content: space-around' distributes lines evenly in the flex container, with half-size spaces on either end." />
         <style type="text/css">

--- a/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-006.htm
+++ b/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-006.htm
@@ -1,16 +1,20 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD//XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>CSS Test: An element with the 'display' property set to 'flex' establishes a new block-level flex container</title>
+        <title>CSS Test: A multi-line flex container with the 'align-content' property set to 'stretch'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
-        <link rel="help" href="http://www.w3.org/TR/css3-flexbox/#flex-containers" />
+        <link rel="help" href="http://www.w3.org/TR/css3-flexbox/#align-content-property" />
+        <link rel="match" href="reference/align-content-001-ref.html" />
         <meta name="flags" content="">
-        <meta name="assert" content="This test checks that an element with 'display' property set to 'flex' establishes a new block-level flex container." />
+        <meta name="assert" content="This test checks that a multi-line flex container with 'align-content: stretch' stretches lines to take up the remaining space." />
         <style type="text/css">
             #flexbox
             {
-                background-color: red;
+                background: red;
+                align-content: center;
+                align-content: stretch;
                 display: flex;
+                flex-flow: wrap;
                 height: 100px;
                 width: 300px;
             }
@@ -24,6 +28,8 @@
     <body>
         <p>Test passes if there is no red visible on the page.</p>
         <div id="flexbox">
+            <div></div>
+            <div></div>
             <div></div>
             <div></div>
         </div>

--- a/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-items-001.htm
+++ b/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-items-001.htm
@@ -1,17 +1,17 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD//XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>CSS Test: A flex container with the 'align-items' property set to 'stretch'</title>
+        <title>CSS Test: A flex container with the 'align-items' property set to 'center'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/css3-flexbox/#align-items-property" />
+        <link rel="match" href="reference/align-content-001-ref.html" />
         <meta name="flags" content="">
-        <meta name="assert" content="This test checks that the flex container with 'align-items: stretch' places each flex item's margin box so that its cross size is the same as the cross size of the line." />
+        <meta name="assert" content="This test checks that the flex container with 'align-items: center' centers each flex item's margin box in the cross-axis of its line." />
         <style type="text/css">
             #flexbox
             {
-                background: red;
+                background: linear-gradient(to bottom, green 0, green 25px, red 25px, red 75px, green 75px, green 100px);
                 align-items: center;
-                align-items: stretch;
                 display: flex;
                 height: 100px;
                 width: 300px;
@@ -19,6 +19,7 @@
             div div
             {
                 background-color: green;
+                height: 52px;
                 width: 150px;
             }
         </style>

--- a/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-items-002.htm
+++ b/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-items-002.htm
@@ -1,16 +1,18 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD//XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>CSS Test: A flex container with the 'align-items' property set to 'center'</title>
+        <title>CSS Test: A flex container with the 'align-items' property set to 'flex-start'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/css3-flexbox/#align-items-property" />
+        <link rel="match" href="reference/align-content-001-ref.html" />
         <meta name="flags" content="">
-        <meta name="assert" content="This test checks that the flex container with 'align-items: center' centers each flex item's margin box in the cross-axis of its line." />
+        <meta name="assert" content="This test checks that the flex container with 'align-items: flex-start' places each flex item's margin box flush with the cross-start edge of line." />
         <style type="text/css">
             #flexbox
             {
-                background: linear-gradient(to bottom, green 0, green 25px, red 25px, red 75px, green 75px, green 100px);
+                background: linear-gradient(to bottom, red 0, red 50px, green 50px, green 100px);
                 align-items: center;
+                align-items: flex-start;
                 display: flex;
                 height: 100px;
                 width: 300px;
@@ -18,7 +20,7 @@
             div div
             {
                 background-color: green;
-                height: 52px;
+                height: 51px;
                 width: 150px;
             }
         </style>

--- a/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-items-003.htm
+++ b/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-items-003.htm
@@ -1,25 +1,26 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD//XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>CSS Test: A multi-line flex container with the 'align-content' property set to 'flex-start'</title>
+        <title>CSS Test: A flex container with the 'align-items' property set to 'flex-end'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
-        <link rel="help" href="http://www.w3.org/TR/css3-flexbox/#align-content-property" />
+        <link rel="help" href="http://www.w3.org/TR/css3-flexbox/#align-items-property" />
+        <link rel="match" href="reference/align-content-001-ref.html" />
         <meta name="flags" content="">
-        <meta name="assert" content="This test checks that a multi-line flex container with 'align-content: flex-start' packs lines toward the start of the flex container." />
+        <meta name="assert" content="This test checks that the flex container with 'align-items: flex-end' places each flex item's margin box flush with the cross-end edge of line." />
         <style type="text/css">
             #flexbox
             {
-                background: linear-gradient(to bottom, red 0, red 50px, green 50px, green 100px);
-                align-content: flex-start;
+                background: linear-gradient(to bottom, green 0, green 50px, red 50px, red 100px);
+                align-items: center;
+                align-items: flex-end;
                 display: flex;
-                flex-flow: wrap;
                 height: 100px;
                 width: 300px;
             }
             div div
             {
                 background-color: green;
-                height: 26px;
+                height: 51px;
                 width: 150px;
             }
         </style>
@@ -27,8 +28,6 @@
     <body>
         <p>Test passes if there is no red visible on the page.</p>
         <div id="flexbox">
-            <div></div>
-            <div></div>
             <div></div>
             <div></div>
         </div>

--- a/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-items-005.htm
+++ b/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-items-005.htm
@@ -1,25 +1,25 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD//XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>CSS Test: A multi-line flex container with the 'align-content' property set to 'flex-end'</title>
+        <title>CSS Test: A flex container with the 'align-items' property set to 'stretch'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
-        <link rel="help" href="http://www.w3.org/TR/css3-flexbox/#align-content-property" />
+        <link rel="help" href="http://www.w3.org/TR/css3-flexbox/#align-items-property" />
+        <link rel="match" href="reference/align-content-001-ref.html" />
         <meta name="flags" content="">
-        <meta name="assert" content="This test checks that a multi-line flex container with 'align-content: flex-end' packs lines toward the end of the flex container." />
+        <meta name="assert" content="This test checks that the flex container with 'align-items: stretch' places each flex item's margin box so that its cross size is the same as the cross size of the line." />
         <style type="text/css">
             #flexbox
             {
-                background: linear-gradient(to bottom, green 0, green 50px, red 50px, red 100px);
-                align-content: flex-end;
+                background: red;
+                align-items: center;
+                align-items: stretch;
                 display: flex;
-                flex-flow: wrap;
                 height: 100px;
                 width: 300px;
             }
             div div
             {
                 background-color: green;
-                height: 26px;
                 width: 150px;
             }
         </style>
@@ -27,8 +27,6 @@
     <body>
         <p>Test passes if there is no red visible on the page.</p>
         <div id="flexbox">
-            <div></div>
-            <div></div>
             <div></div>
             <div></div>
         </div>

--- a/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/display-flex-001.htm
+++ b/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/display-flex-001.htm
@@ -1,25 +1,23 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD//XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>CSS Test: A multi-line flex container with the 'align-content' property set to 'center'</title>
+        <title>CSS Test: An element with the 'display' property set to 'flex' establishes a new block-level flex container</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
-        <link rel="help" href="http://www.w3.org/TR/css3-flexbox/#align-content-property" />
+        <link rel="help" href="http://www.w3.org/TR/css3-flexbox/#flex-containers" />
+        <link rel="match" href="reference/align-content-001-ref.html" />
         <meta name="flags" content="">
-        <meta name="assert" content="This test checks that a multi-line flex container with 'align-content: center' centers lines in the flex container." />
+        <meta name="assert" content="This test checks that an element with 'display' property set to 'flex' establishes a new block-level flex container." />
         <style type="text/css">
             #flexbox
             {
-                background: linear-gradient(to bottom, green 0, green 25px, red 25px, red 75px, green 75px, green 100px);
-                align-content: center;
+                background-color: red;
                 display: flex;
-                flex-flow: wrap;
                 height: 100px;
                 width: 300px;
             }
             div div
             {
                 background-color: green;
-                height: 26px;
                 width: 150px;
             }
         </style>
@@ -27,8 +25,6 @@
     <body>
         <p>Test passes if there is no red visible on the page.</p>
         <div id="flexbox">
-            <div></div>
-            <div></div>
             <div></div>
             <div></div>
         </div>

--- a/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/flex-001.htm
+++ b/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/flex-001.htm
@@ -1,43 +1,28 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD//XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>CSS Test: The 'flex' shorthand adjusting the 'flex-shrink' sub-property</title>
+        <title>CSS Test: The 'flex' shorthand adjusting the 'flex-grow' sub-property</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/css3-flexbox/#flex-property" />
+        <link rel="match" href="reference/justify-content-001-ref.html" />
         <meta name="flags" content="">
-        <meta name="assert" content="This test checks that the flex shrink factor is multiplied by the flex base size when distributing negative space."/>
+        <meta name="assert" content="This test checks that the flex grow factor determines the distribution of positive free space."/>
         <style type="text/css">
-            div
-            {
-                height: 50px;
-            }
             #flexbox
             {
                 background-color: red;
                 display: flex;
                 width: 300px;
             }
-            #flexItem1
-            {
-                flex: 0 2 auto;
-                width: 300px;
-            }
-            #flexItem2
-            {
-                width: 200px;
-            }
-            #flexItem1, #ref1
-            {
-                background-color: blue;
-            }
-            #flexItem2, #ref2
+            div div
             {
                 background-color: orange;
+                flex: 1 0 auto;
+                height: 100px;
             }
-            #ref1, #ref2
+            #flexItem1
             {
-                display: inline-block;
-                width: 150px;
+                background-color: blue;
             }
         </style>
     </head>
@@ -45,8 +30,7 @@
         <p>Test passes if there is a single blue rectangle on the left, a single orange rectangle directly to its right, and there is no red visible on the page.</p>
         <div id="flexbox">
             <div id="flexItem1"></div>
-            <div id="flexItem2"></div>
+            <div></div>
         </div>
-        <div id="ref1"></div><div id="ref2"></div>
     </body>
 </html>

--- a/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/flex-002.htm
+++ b/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/flex-002.htm
@@ -1,11 +1,12 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD//XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>CSS Test: Comparing two different elements using different values for the 'flex-grow' sub-property on the 'flex' shorthand</title>
+        <title>CSS Test: The 'flex' shorthand adjusting the 'flex-shrink' sub-property</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/css3-flexbox/#flex-property" />
+        <link rel="match" href="reference/justify-content-001-ref.html" />
         <meta name="flags" content="">
-        <meta name="assert" content="This test checks that the flex items with a different flex grow factor have different flexibilities."/>
+        <meta name="assert" content="This test checks that the flex shrink factor is multiplied by the flex base size when distributing negative space."/>
         <style type="text/css">
             div
             {
@@ -19,13 +20,12 @@
             }
             #flexItem1
             {
-                flex: 1 0 auto;
-                width: 100px;
+                flex: 0 2 auto;
+                width: 300px;
             }
             #flexItem2
             {
-                flex: 2 0 auto;
-                width: 50px;
+                width: 200px;
             }
             #flexItem1, #ref1
             {

--- a/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/flex-003.htm
+++ b/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/flex-003.htm
@@ -1,27 +1,45 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD//XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>CSS Test: The 'flex' shorthand adjusting the 'flex-grow' sub-property</title>
+        <title>CSS Test: Comparing two different elements using different values for the 'flex-grow' sub-property on the 'flex' shorthand</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/css3-flexbox/#flex-property" />
+        <link rel="match" href="reference/justify-content-001-ref.html" />
         <meta name="flags" content="">
-        <meta name="assert" content="This test checks that the flex grow factor determines the distribution of positive free space."/>
+        <meta name="assert" content="This test checks that the flex items with a different flex grow factor have different flexibilities."/>
         <style type="text/css">
+            div
+            {
+                height: 50px;
+            }
             #flexbox
             {
                 background-color: red;
                 display: flex;
                 width: 300px;
             }
-            div div
-            {
-                background-color: orange;
-                flex: 1 0 auto;
-                height: 100px;
-            }
             #flexItem1
             {
+                flex: 1 0 auto;
+                width: 100px;
+            }
+            #flexItem2
+            {
+                flex: 2 0 auto;
+                width: 50px;
+            }
+            #flexItem1, #ref1
+            {
                 background-color: blue;
+            }
+            #flexItem2, #ref2
+            {
+                background-color: orange;
+            }
+            #ref1, #ref2
+            {
+                display: inline-block;
+                width: 150px;
             }
         </style>
     </head>
@@ -29,7 +47,8 @@
         <p>Test passes if there is a single blue rectangle on the left, a single orange rectangle directly to its right, and there is no red visible on the page.</p>
         <div id="flexbox">
             <div id="flexItem1"></div>
-            <div></div>
+            <div id="flexItem2"></div>
         </div>
+        <div id="ref1"></div><div id="ref2"></div>
     </body>
 </html>

--- a/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/flex-004.htm
+++ b/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/flex-004.htm
@@ -4,6 +4,7 @@
         <title>CSS Test: Comparing two different elements using different values for the 'flex-shrink' sub-property on the 'flex' shorthand</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/css3-flexbox/#flex-property" />
+        <link rel="match" href="reference/justify-content-001-ref.html" />
         <meta name="flags" content="">
         <meta name="assert" content="This test checks that the flex items with a different flex shrink factor have different flexibilities."/>
         <style type="text/css">

--- a/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/justify-content-001.htm
+++ b/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/justify-content-001.htm
@@ -1,31 +1,36 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD//XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>CSS Test: A flex container with the 'justify-content' property set to 'flex-end'</title>
+        <title>CSS Test: A flex container with 'justify-content' property set to 'center'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/css3-flexbox/#justify-content" />
+        <link rel="match" href="reference/justify-content-001-ref.html" />
         <meta name="flags" content="image">
-        <meta name="assert" content="This test checks that the flex container with 'justify-content: flex-end' packs flex items toward the end of the main axis of each line." />
+        <meta name="assert" content="This test checks that the flex container with 'justify-content: center' centers flex items in the main axis of each line." />
         <style type="text/css">
             #flexbox
             {
-                background: linear-gradient(to right, blue 0, blue 150px, red 150px, red 300px);
+                background: linear-gradient(to right, blue 0, blue 75px, red 75px, red 225px, orange 225px, orange 300px);
                 display: flex;
-                justify-content: flex-end;
+                justify-content: center;
                 height: 100px;
                 width: 300px;
             }
             div div
             {
                 background-color: orange;
-                width: 75px;
+                width: 76px;
+            }
+            .blue
+            {
+                background-color: blue;
             }
         </style>
     </head>
     <body>
         <p>Test passes if there is a single blue rectangle on the left, a single orange rectangle directly to its right, and there is no red visible on the page.</p>
         <div id="flexbox">
-            <div></div>
+            <div class="blue"></div>
             <div></div>
         </div>
     </body>

--- a/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/justify-content-002.htm
+++ b/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/justify-content-002.htm
@@ -4,6 +4,7 @@
         <title>CSS Test: A flex container with the 'justify-content' property set to 'flex-start'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/css3-flexbox/#justify-content" />
+        <link rel="match" href="reference/justify-content-001-ref.html" />
         <meta name="flags" content="image">
         <meta name="assert" content="This test checks that the flex container with 'justify-content: flex-start' packs flex items toward the start of the main axis of each line." />
         <style type="text/css">

--- a/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/justify-content-003.htm
+++ b/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/justify-content-003.htm
@@ -1,35 +1,32 @@
 ﻿<!DOCTYPE html PUBLIC "-//W3C//DTD//XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>CSS Test: A flex container with 'justify-content' property set to 'center'</title>
+        <title>CSS Test: A flex container with the 'justify-content' property set to 'flex-end'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/css3-flexbox/#justify-content" />
+        <link rel="match" href="reference/justify-content-001-ref.html" />
         <meta name="flags" content="image">
-        <meta name="assert" content="This test checks that the flex container with 'justify-content: center' centers flex items in the main axis of each line." />
+        <meta name="assert" content="This test checks that the flex container with 'justify-content: flex-end' packs flex items toward the end of the main axis of each line." />
         <style type="text/css">
             #flexbox
             {
-                background: linear-gradient(to right, blue 0, blue 75px, red 75px, red 225px, orange 225px, orange 300px);
+                background: linear-gradient(to right, blue 0, blue 150px, red 150px, red 300px);
                 display: flex;
-                justify-content: center;
+                justify-content: flex-end;
                 height: 100px;
                 width: 300px;
             }
             div div
             {
                 background-color: orange;
-                width: 76px;
-            }
-            .blue
-            {
-                background-color: blue;
+                width: 75px;
             }
         </style>
     </head>
     <body>
         <p>Test passes if there is a single blue rectangle on the left, a single orange rectangle directly to its right, and there is no red visible on the page.</p>
         <div id="flexbox">
-            <div class="blue"></div>
+            <div></div>
             <div></div>
         </div>
     </body>

--- a/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/justify-content-004.htm
+++ b/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/justify-content-004.htm
@@ -4,6 +4,7 @@
         <title>CSS Test: A flex container with the 'justify-content' property set to 'space-between'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/css3-flexbox/#justify-content" />
+        <link rel="match" href="reference/justify-content-001-ref.html" />
         <meta name="flags" content="image">
         <meta name="assert" content="This test checks that the flex container with 'justify-content: space-between' evenly distributes flex items in the main axis of each line." />
         <style type="text/css">

--- a/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/justify-content-005.htm
+++ b/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/justify-content-005.htm
@@ -4,6 +4,7 @@
         <title>CSS Test: A flex container with the 'justify-content' property set to 'space-around'</title>
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/css3-flexbox/#justify-content" />
+        <link rel="match" href="reference/justify-content-001-ref.html" />
         <meta name="flags" content="image">
         <meta name="assert" content="This test checks that the flex container with 'justify-content: space-around' evenly distributes flex items in the main axis of each line, with half-size spaces on either end." />
         <style type="text/css">

--- a/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/align-content-001-ref.html
+++ b/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/align-content-001-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<style>
+  div {
+    background: green;
+    height: 100px;
+    width: 300px;
+  }
+</style>
+<body>
+  <p>Test passes if there is no red visible on the page.</p>
+  <div></div>
+</body>

--- a/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/justify-content-001-ref.html
+++ b/webapi/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/justify-content-001-ref.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<style>
+  #blue {
+    background: blue;
+    height: 100px;
+    width: 150px;
+  }
+  #orange {
+    background: orange;
+    height: 100px;
+    left: 150px;
+    position: relative;
+    top: -100px;
+    width: 150px;
+  }
+</style>
+<body>
+  <p>Test passes if there is a single blue rectangle on the left, a single orange rectangle directly to its right, and there is no red visible on the page.</p>
+  <div id="blue"></div>
+  <div id="orange"></div>
+</body>

--- a/webapi/tct-flexiblebox-css3-tests/tests.full.xml
+++ b/webapi/tct-flexiblebox-css3-tests/tests.full.xml
@@ -423,42 +423,7 @@
           </spec>
         </specs>
       </testcase>
-     <testcase purpose="This test checks that a multi-line flex container with 'align-content: center' centers lines in the flex container" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="align-content-001">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-001-manual.htm</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="align-content" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This test checks that a multi-line flex container with 'align-content: flex-start' packs lines toward the start of the flex container" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="align-content-002">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-002-manual.htm</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="align-content" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This test checks that a multi-line flex container with 'align-content: flex-end' packs lines toward the end of the flex container" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="align-content-003">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-003-manual.htm</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="align-content" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
+    
       <testcase purpose="This test checks that a multi-line flex container with 'align-content: space-between' distributes lines evenly in the flex container" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="align-content-004">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-004-manual.htm</test_script_entry>
@@ -471,66 +436,6 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="This test checks that a multi-line flex container with 'align-content: space-around' distributes lines evenly in the flex container with half-size spaces on either end" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="align-content-005">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-005-manual.htm</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="align-content" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This test checks that a multi-line flex container with 'align-content: stretch' stretches lines to take up the remaining space" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="align-content-006">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-006-manual.htm</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="align-content" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This test checks that the flex container with 'align-items: center' centers each flex item's margin box in the cross-axis of its line" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="align-items-001">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-items-001-manual.htm</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="align-items" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This test checks that the flex container with 'align-items: flex-start' places each flex item's margin box flush with the cross-start edge of line" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="align-items-002">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-items-002-manual.htm</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="align-items" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This test checks that the flex container with 'align-items: flex-end' places each flex item's margin box flush with the cross-end edge of line" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="align-items-003">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-items-003-manual.htm</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="align-items" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
       <testcase purpose="This test checks that the flex container with 'align-items: baseline' places each flex item's margin box so that their baselines align" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="align-items-004">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-items-004-manual.htm</test_script_entry>
@@ -538,138 +443,6 @@
         <specs>
           <spec>
             <spec_assertion element_type="property" element_name="align-items" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This test checks that the flex container with 'align-items: stretch' places each flex item's margin box so that its cross size is the same as the cross size of the line" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="align-items-005">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-items-005-manual.htm</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="align-items" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This test checks that an element with 'display' property set to 'flex' establishes a new block-level flex container" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="display-flex-001">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/display-flex-001-manual.htm</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="display" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This test checks that the flex grow factor determines the distribution of positive free space" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="flex-001">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/flex-001-manual.htm</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="flex" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This test checks that the flex shrink factor is multiplied by the flex base size when distributing negative space" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="flex-002">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/flex-002-manual.htm</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="flex" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This test checks that the flex items with a different flex grow factor have different flexibilities" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="flex-003">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/flex-003-manual.htm</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="flex" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This test checks that the flex items with a different flex shrink factor have different flexibilities" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="flex-004">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/flex-004-manual.htm</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="flex" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This test checks that the flex container with 'justify-content: center' centers flex items in the main axis of each line" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="justify-content-001">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/justify-content-001-manual.htm</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="justify-content" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This test checks that the flex container with 'justify-content: flex-start' packs flex items toward the start of the main axis of each line" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="justify-content-002">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/justify-content-002-manual.htm</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="justify-content" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This test checks that the flex container with 'justify-content: flex-end' packs flex items toward the end of the main axis of each line" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="justify-content-003">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/justify-content-003-manual.htm</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="justify-content" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This test checks that the flex container with 'justify-content: space-between' evenly distributes flex items in the main axis of each line" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="justify-content-004">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/justify-content-004-manual.htm</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="justify-content" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="This test checks that the flex container with 'justify-content: space-around' evenly distributes flex items in the main axis of each line with half-size spaces on either end" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="justify-content-005">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/justify-content-005-manual.htm</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="property" element_name="justify-content" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
             <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
             <spec_statement/>
           </spec>
@@ -694,6 +467,255 @@
         <specs>
           <spec>
             <spec_assertion element_type="property" element_name="order" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+    </set>
+    <set name="reftest" type="ref">
+      <testcase purpose="This test checks that an element with 'display' property set to 'flex' establishes a new block-level flex container" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="display-flex-001">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/display-flex-001.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/align-content-001-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="display" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This test checks that the flex grow factor determines the distribution of positive free space" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="flex-001">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/flex-001.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/justify-content-001-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="flex" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This test checks that the flex shrink factor is multiplied by the flex base size when distributing negative space" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="flex-002">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/flex-002.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/justify-content-001-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="flex" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This test checks that the flex items with a different flex grow factor have different flexibilities" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="flex-003">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/flex-003.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/justify-content-001-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="flex" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This test checks that the flex items with a different flex shrink factor have different flexibilities" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="flex-004">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/flex-004.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/justify-content-001-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="flex" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This test checks that the flex container with 'justify-content: center' centers flex items in the main axis of each line" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="justify-content-001">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/justify-content-001.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/justify-content-001-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="justify-content" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This test checks that the flex container with 'justify-content: flex-start' packs flex items toward the start of the main axis of each line" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="justify-content-002">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/justify-content-002.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/justify-content-001-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="justify-content" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This test checks that the flex container with 'justify-content: flex-end' packs flex items toward the end of the main axis of each line" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="justify-content-003">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/justify-content-003.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/justify-content-001-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="justify-content" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This test checks that the flex container with 'justify-content: space-between' evenly distributes flex items in the main axis of each line" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="justify-content-004">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/justify-content-004.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/justify-content-001-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="justify-content" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This test checks that the flex container with 'justify-content: space-around' evenly distributes flex items in the main axis of each line with half-size spaces on either end" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="justify-content-005">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/justify-content-005.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/justify-content-001-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="justify-content" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This test checks that a multi-line flex container with 'align-content: center' centers lines in the flex container" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="align-content-001">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-001.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/align-content-001-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="align-content" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This test checks that a multi-line flex container with 'align-content: flex-start' packs lines toward the start of the flex container" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="align-content-002">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-002.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/align-content-001-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="align-content" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This test checks that a multi-line flex container with 'align-content: flex-end' packs lines toward the end of the flex container" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="align-content-003">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-003.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/align-content-001-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="align-content" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This test checks that a multi-line flex container with 'align-content: space-around' distributes lines evenly in the flex container with half-size spaces on either end" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="align-content-005">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-005.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/align-content-001-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="align-content" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This test checks that a multi-line flex container with 'align-content: stretch' stretches lines to take up the remaining space" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="align-content-006">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-006.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/align-content-001-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="align-content" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This test checks that the flex container with 'align-items: center' centers each flex item's margin box in the cross-axis of its line" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="align-items-001">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-items-001.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/align-content-001-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="align-items" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This test checks that the flex container with 'align-items: flex-start' places each flex item's margin box flush with the cross-start edge of line" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="align-items-002">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-items-002.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/align-content-001-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="align-items" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This test checks that the flex container with 'align-items: flex-end' places each flex item's margin box flush with the cross-end edge of line" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="align-items-003">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-items-003.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/align-content-001-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="align-items" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="This test checks that the flex container with 'align-items: stretch' places each flex item's margin box so that its cross size is the same as the cross size of the line" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" priority="P2" id="align-items-005">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-items-005.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/align-content-001-ref.html</refer_test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="align-items" interface="CSS" specification="CSS Flexible Box Layout Module (Partial)" section="DOM, Forms and Styles" category="W3C API Specifications"/>
             <spec_url>http://www.w3.org/TR/css3-flexbox/</spec_url>
             <spec_statement/>
           </spec>

--- a/webapi/tct-flexiblebox-css3-tests/tests.xml
+++ b/webapi/tct-flexiblebox-css3-tests/tests.xml
@@ -1,153 +1,153 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="./testcase.xsl"?>
 <test_definition>
-  <suite name="tct-flexiblebox-css3-tests" category="W3C/HTML5 APIs" launcher="xwalk">
+  <suite category="W3C/HTML5 APIs" launcher="xwalk" name="tct-flexiblebox-css3-tests">
     <set name="FlexibleBox" type="js">
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="auto" id="CSS3FlexBox_flex-direction" purpose="Check if the 'flex-direction' property exists">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/CSS3FlexBox_flex-direction.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="auto" id="CSS3FlexBox_flex-flow" purpose="Check if the 'flex-flow' property exists">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/CSS3FlexBox_flex-flow.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="auto" id="CSS3FlexBox_flex-wrap" purpose="Check if the 'flex-wrap' property exists">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/CSS3FlexBox_flex-wrap.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="auto" id="CSS3FlexBox_flex" purpose="Check if the 'flex' property exists">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/CSS3FlexBox_flex.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="auto" id="CSS3FlexBox_align-content" purpose="Check if the 'align-content' property exists">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/CSS3FlexBox_align-content.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="auto" id="CSS3FlexBox_align-items" purpose="Check if the 'align-items' property exists">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/CSS3FlexBox_align-items.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="auto" id="CSS3FlexBox_align-self" purpose="Check if the 'align-self' property exists">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/CSS3FlexBox_align-self.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="auto" id="CSS3FlexBox_flex-basis" purpose="Check if the 'flex-basis' property exists">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/CSS3FlexBox_flex-basis.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="auto" id="CSS3FlexBox_flex-grow" purpose="Check if the 'flex-grow' property exists">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/CSS3FlexBox_flex-grow.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="auto" id="CSS3FlexBox_flex-shrink" purpose="Check if the 'flex-shrink' property exists">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/CSS3FlexBox_flex-shrink.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="auto" id="CSS3FlexBox_justify-content" purpose="Check if the 'justify-content' property exists">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/CSS3FlexBox_justify-content.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="auto" id="CSS3FlexBox_min-height" purpose="Check if the 'min-height' property exists">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/CSS3FlexBox_min-height.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="auto" id="CSS3FlexBox_min-width" purpose="Check if the 'min-width' property exists">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/CSS3FlexBox_min-width.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="auto" id="CSS3FlexBox_order" purpose="Check if the 'order' property exists">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/CSS3FlexBox_order.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="css-flexbox-row" purpose="Test checks that when writing mode is vertical and flex-flow: row, the flex container is vertical">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/css-flexbox-row.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="css-flexbox-row-reverse" purpose="Test checks that when writing mode is vertical and flex-flow: row-reverse, the flex container is vertical">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/css-flexbox-row-reverse.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="css-flexbox-row-reverse-wrap" purpose="Test checks that when writing mode is vertical and flex-flow: row-reverse wrap, the flex container is vertical">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/css-flexbox-row-reverse-wrap.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="css-flexbox-row-reverse-wrap-reverse" purpose="Test checks that when writing mode is vertical and flex-flow: row-reverse wrap-reverse, the flex container is vertical">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/css-flexbox-row-reverse-wrap-reverse.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="css-flexbox-row-wrap" purpose="Test checks that when writing mode is vertical and flex-flow: row wrap, the flex container is vertical">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/css-flexbox-row-wrap.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="css-flexbox-row-wrap-reverse" purpose="Test checks that when writing mode is vertical and flex-flow: row wrap-reverse, the flex container is vertical">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/css-flexbox-row-wrap-reverse.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="flexbox-flex-direction-column" purpose="Test checks that flex container's main axis has the same orientation as the block axis of the current writing mode, when flex-direction = column. This assumes writing-direction = horizontal-tb', and direction = 'ltr'.">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/flexbox-flex-direction-column.htm</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="flexbox-flex-direction-column-reverse" purpose="Test checks that flex container's main axis has the same orientation as the block axis of the current writing mode, and main-start and main-end are swapped, when flex-direction = column-reverse. This assumes writing-direction = horizontal-tb', and direction = 'ltr'.">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/flexbox-flex-direction-column-reverse.htm</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="flexbox-flex-direction-default" purpose="Test checks that flex container's main axis has the same orientation as the inline axis of the current writing mode by default. This assumes writing-direction = horizontal-tb', and direction = 'ltr'.">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/flexbox-flex-direction-default.htm</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="flexbox-flex-direction-row" purpose="Test checks that flex container's main axis has the same orientation as the inline axis of the current writing mode, when flex-direction = row. This assumes writing-direction = horizontal-tb', and direction = 'ltr'.">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/flexbox-flex-direction-row.htm</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="flexbox-flex-direction-row-reverse" purpose="Test checks that flex container's main axis has the opposite orientation as the inline axis of the current writing mode, when flex-direction = row-reverse. This assumes writing-direction = horizontal-tb', and direction = 'ltr'.">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/flexbox-flex-direction-row-reverse.htm</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="flexbox-flex-wrap-default" purpose="Test checks that flex elements default to flex-wrap: nowrap if flex-wrap is not set. With wrapping disabled, the .green flex item should extend outside the bounds of its container, as it is set to flex:none.">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/flexbox-flex-wrap-default.htm</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="flexbox-flex-wrap-nowrap" purpose="Test checks that flex elements set to flex-wrap: nowrap will not wrap their flex items. With wrapping disabled, the .green flex item should extend outside the bounds of its container, as it is set to flex:none.">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/flexbox-flex-wrap-nowrap.htm</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="flexbox-flex-wrap-wrap" purpose="Test checks that flex elements wrap left-to-right within their flex container when flex-wrap = 'wrap', matching the writing direction. This assumes writing-direction = horizontal-tb', and direction = 'ltr'.">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/flexbox-flex-wrap-wrap.htm</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="flexbox-flex-wrap-wrap-reverse" purpose="Test checks that flex elements wrap left-to-right and bottom-to-top within their flex container when flex-wrap = 'wrap-reverse'. This assumes writing-direction = horizontal-tb', and direction = 'ltr'.">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/flexbox-flex-wrap-wrap-reverse.htm</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="multi-line-wrap-reverse-column-reverse" purpose="This test check that a flex container reverse-wraps blocks multiline in column-reverse direction.">
         <description>
           <steps>
@@ -158,7 +158,7 @@
           </steps>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/multi-line-wrap-reverse-column-reverse.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="multi-line-wrap-reverse-row-reverse" purpose="This test check that a flex container reverse-wraps blocks multiline in row-reverse direction.">
         <description>
           <steps>
@@ -169,7 +169,7 @@
           </steps>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/multi-line-wrap-reverse-row-reverse.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="multi-line-wrap-with-column-reverse" purpose="This test check that a flex container wraps blocks multiline in column-reverse direction.">
         <description>
           <steps>
@@ -180,7 +180,7 @@
           </steps>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/multi-line-wrap-with-column-reverse.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="multi-line-wrap-with-row-reverse" purpose="This test check that a flex container wraps blocks multiline in row-reverse direction.">
         <description>
           <steps>
@@ -191,122 +191,143 @@
           </steps>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/multi-line-wrap-with-row-reverse.html</test_script_entry>
         </description>
-        </testcase>
-      <testcase execution_type="manual" id="align-content-001" purpose="This test checks that a multi-line flex container with 'align-content: center' centers lines in the flex container">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-001-manual.htm</test_script_entry>
-        </description>
-        </testcase>
-      <testcase execution_type="manual" id="align-content-002" purpose="This test checks that a multi-line flex container with 'align-content: flex-start' packs lines toward the start of the flex container">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-002-manual.htm</test_script_entry>
-        </description>
-        </testcase>
-      <testcase execution_type="manual" id="align-content-003" purpose="This test checks that a multi-line flex container with 'align-content: flex-end' packs lines toward the end of the flex container">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-003-manual.htm</test_script_entry>
-        </description>
-        </testcase>
-      <testcase execution_type="manual" id="align-content-004" purpose="This test checks that a multi-line flex container with 'align-content: space-between' distributes lines evenly in the flex container">
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="align-content-004" purpose="This test checks that a multi-line flex container with 'align-content: space-between' distributes lines evenly in the flex container">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-004-manual.htm</test_script_entry>
         </description>
-        </testcase>
-      <testcase execution_type="manual" id="align-content-005" purpose="This test checks that a multi-line flex container with 'align-content: space-around' distributes lines evenly in the flex container with half-size spaces on either end">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-005-manual.htm</test_script_entry>
-        </description>
-        </testcase>
-      <testcase execution_type="manual" id="align-content-006" purpose="This test checks that a multi-line flex container with 'align-content: stretch' stretches lines to take up the remaining space">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-006-manual.htm</test_script_entry>
-        </description>
-        </testcase>
-      <testcase execution_type="manual" id="align-items-001" purpose="This test checks that the flex container with 'align-items: center' centers each flex item's margin box in the cross-axis of its line">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-items-001-manual.htm</test_script_entry>
-        </description>
-        </testcase>
-      <testcase execution_type="manual" id="align-items-002" purpose="This test checks that the flex container with 'align-items: flex-start' places each flex item's margin box flush with the cross-start edge of line">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-items-002-manual.htm</test_script_entry>
-        </description>
-        </testcase>
-      <testcase execution_type="manual" id="align-items-003" purpose="This test checks that the flex container with 'align-items: flex-end' places each flex item's margin box flush with the cross-end edge of line">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-items-003-manual.htm</test_script_entry>
-        </description>
-        </testcase>
-      <testcase execution_type="manual" id="align-items-004" purpose="This test checks that the flex container with 'align-items: baseline' places each flex item's margin box so that their baselines align">
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="align-items-004" purpose="This test checks that the flex container with 'align-items: baseline' places each flex item's margin box so that their baselines align">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-items-004-manual.htm</test_script_entry>
         </description>
-        </testcase>
-      <testcase execution_type="manual" id="align-items-005" purpose="This test checks that the flex container with 'align-items: stretch' places each flex item's margin box so that its cross size is the same as the cross size of the line">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-items-005-manual.htm</test_script_entry>
-        </description>
-        </testcase>
-      <testcase execution_type="manual" id="display-flex-001" purpose="This test checks that an element with 'display' property set to 'flex' establishes a new block-level flex container">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/display-flex-001-manual.htm</test_script_entry>
-        </description>
-        </testcase>
-      <testcase execution_type="manual" id="flex-001" purpose="This test checks that the flex grow factor determines the distribution of positive free space">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/flex-001-manual.htm</test_script_entry>
-        </description>
-        </testcase>
-      <testcase execution_type="manual" id="flex-002" purpose="This test checks that the flex shrink factor is multiplied by the flex base size when distributing negative space">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/flex-002-manual.htm</test_script_entry>
-        </description>
-        </testcase>
-      <testcase execution_type="manual" id="flex-003" purpose="This test checks that the flex items with a different flex grow factor have different flexibilities">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/flex-003-manual.htm</test_script_entry>
-        </description>
-        </testcase>
-      <testcase execution_type="manual" id="flex-004" purpose="This test checks that the flex items with a different flex shrink factor have different flexibilities">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/flex-004-manual.htm</test_script_entry>
-        </description>
-        </testcase>
-      <testcase execution_type="manual" id="justify-content-001" purpose="This test checks that the flex container with 'justify-content: center' centers flex items in the main axis of each line">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/justify-content-001-manual.htm</test_script_entry>
-        </description>
-        </testcase>
-      <testcase execution_type="manual" id="justify-content-002" purpose="This test checks that the flex container with 'justify-content: flex-start' packs flex items toward the start of the main axis of each line">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/justify-content-002-manual.htm</test_script_entry>
-        </description>
-        </testcase>
-      <testcase execution_type="manual" id="justify-content-003" purpose="This test checks that the flex container with 'justify-content: flex-end' packs flex items toward the end of the main axis of each line">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/justify-content-003-manual.htm</test_script_entry>
-        </description>
-        </testcase>
-      <testcase execution_type="manual" id="justify-content-004" purpose="This test checks that the flex container with 'justify-content: space-between' evenly distributes flex items in the main axis of each line">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/justify-content-004-manual.htm</test_script_entry>
-        </description>
-        </testcase>
-      <testcase execution_type="manual" id="justify-content-005" purpose="This test checks that the flex container with 'justify-content: space-around' evenly distributes flex items in the main axis of each line with half-size spaces on either end">
-        <description>
-          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/justify-content-005-manual.htm</test_script_entry>
-        </description>
-        </testcase>
-      <testcase execution_type="manual" id="order-with-column-reverse" purpose="This test check that a flex container layouts out its content starting with the lowest numbered ordinal group and going up with column-reverse direction">
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="order-with-column-reverse" purpose="This test check that a flex container layouts out its content starting with the lowest numbered ordinal group and going up with column-reverse direction">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/order-with-column-reverse.html</test_script_entry>
         </description>
-        </testcase>
-      <testcase execution_type="manual" id="order-with-row-reverse" purpose="This test check that a flex container layouts out its content starting with the lowest numbered ordinal group and going up with row-reverse direction">
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="order-with-row-reverse" purpose="This test check that a flex container layouts out its content starting with the lowest numbered ordinal group and going up with row-reverse direction">
         <description>
           <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/order-with-row-reverse.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
+    </set>
+    <set name="reftest" type="ref">
+      <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="display-flex-001" purpose="This test checks that an element with 'display' property set to 'flex' establishes a new block-level flex container">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/display-flex-001.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/align-content-001-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="flex-001" purpose="This test checks that the flex grow factor determines the distribution of positive free space">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/flex-001.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/justify-content-001-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="flex-002" purpose="This test checks that the flex shrink factor is multiplied by the flex base size when distributing negative space">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/flex-002.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/justify-content-001-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="flex-003" purpose="This test checks that the flex items with a different flex grow factor have different flexibilities">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/flex-003.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/justify-content-001-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="flex-004" purpose="This test checks that the flex items with a different flex shrink factor have different flexibilities">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/flex-004.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/justify-content-001-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="justify-content-001" purpose="This test checks that the flex container with 'justify-content: center' centers flex items in the main axis of each line">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/justify-content-001.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/justify-content-001-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="justify-content-002" purpose="This test checks that the flex container with 'justify-content: flex-start' packs flex items toward the start of the main axis of each line">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/justify-content-002.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/justify-content-001-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="justify-content-003" purpose="This test checks that the flex container with 'justify-content: flex-end' packs flex items toward the end of the main axis of each line">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/justify-content-003.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/justify-content-001-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="justify-content-004" purpose="This test checks that the flex container with 'justify-content: space-between' evenly distributes flex items in the main axis of each line">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/justify-content-004.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/justify-content-001-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="justify-content-005" purpose="This test checks that the flex container with 'justify-content: space-around' evenly distributes flex items in the main axis of each line with half-size spaces on either end">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/justify-content-005.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/justify-content-001-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="align-content-001" purpose="This test checks that a multi-line flex container with 'align-content: center' centers lines in the flex container">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-001.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/align-content-001-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="align-content-002" purpose="This test checks that a multi-line flex container with 'align-content: flex-start' packs lines toward the start of the flex container">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-002.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/align-content-001-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="align-content-003" purpose="This test checks that a multi-line flex container with 'align-content: flex-end' packs lines toward the end of the flex container">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-003.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/align-content-001-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="align-content-005" purpose="This test checks that a multi-line flex container with 'align-content: space-around' distributes lines evenly in the flex container with half-size spaces on either end">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-005.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/align-content-001-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="align-content-006" purpose="This test checks that a multi-line flex container with 'align-content: stretch' stretches lines to take up the remaining space">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-content-006.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/align-content-001-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="align-items-001" purpose="This test checks that the flex container with 'align-items: center' centers each flex item's margin box in the cross-axis of its line">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-items-001.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/align-content-001-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="align-items-002" purpose="This test checks that the flex container with 'align-items: flex-start' places each flex item's margin box flush with the cross-start edge of line">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-items-002.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/align-content-001-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="align-items-003" purpose="This test checks that the flex container with 'align-items: flex-end' places each flex item's margin box flush with the cross-end edge of line">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-items-003.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/align-content-001-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/CSS Flexible Box Layout Module (Partial)" execution_type="manual" id="align-items-005" purpose="This test checks that the flex container with 'align-items: stretch' places each flex item's margin box so that its cross size is the same as the cross size of the line">
+        <description>
+          <test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/align-items-005.htm</test_script_entry>
+          <refer_test_script_entry>/opt/tct-flexiblebox-css3-tests/flexiblebox/csswg/reference/align-content-001-ref.html</refer_test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>


### PR DESCRIPTION
- Add 2 reference files for 19 tests
- Still keep the 19 ref tests as manual because test tool haven't support ref type

Impacted tests(approved): new 0, update 19, delete 0
Unit test platform: [Tizen IVI]
Unit test result summary: pass 19, fail 0, block 0
