### PR TITLE
[webapi]Update 36 nfc TCs

### DIFF
--- a/webapi/webapi-nfc-w3c-tests/nfc/NDEFMessageEvent_message_attribute.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NDEFMessageEvent_message_attribute.html
@@ -38,19 +38,40 @@ Authors:
 <script type="text/javascript" src="support/unitcommon.js"></script>
 <script type="text/javascript" src="support/nfc_common.js"></script>
 </head>
-
 <body>
+<p>Test step:</p>
+<p>Use other NFC enabled device tap to share some data(such as contacts or coupons) to the NFC Manager.</p>
 <div id="log"></div>
 <script>
 //==== TEST: NDEFMessageEvent_message_attribute
 //==== PRIORITY P1
 //==== LABEL Check if NDEFMessageEvent have message attribute with proper type and is readonly
 //==== SPEC_URL http://www.w3.org/TR/nfc/
-test(function () {
-    assert_true("message" in NDEFMessageEvent, "message attribute exists");
-    assert_equals(typeof NDEFMessageEvent.message, "object", "message attribute of type");
-    check_readonly(NDEFMessageEvent, "message", NDEFMessageEvent.message, "object", "null");
-}, document.title);
+setup({timeout: 100000});
+
+async_test(function (t) {
+    onError = t.step_func(function (error) {
+        assert_unreached("startPoll() error callback was invoked: " + error.name + " msg: " + error.message);
+        t.done();
+    });
+
+    onSuccess = function () {
+       //After NFC manager start polling, then peer device can be detected.
+    }
+
+    navigator.nfc.onpeerfound = function (e) {
+        e.peer.onmessageread = function (messageEvent) {
+            t.step(function () {
+                assert_true("message" in messageEvent, "message attribute exists");
+                assert_equals(typeof messageEvent.message, "object", "message attribute of type");
+                check_readonly(messageEvent, "message", messageEvent.message, "object", "null");
+            });
+            t.done();
+        }   
+    }
+
+    navigator.nfc.startPoll().then(onSuccess, onError);         
+}, document.title, {timeout: 100000});
 </script>
 </body>
 </html>

--- a/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordMedia_mimeType_attribute.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordMedia_mimeType_attribute.html
@@ -53,7 +53,7 @@ test(function () {
     record = new NDEFRecordMedia("text/plain", payloads);
     assert_own_property(record, "mimeType", "NDEFRecordMedia own mimeType property");
     assert_equals(typeof record.mimeType, "string", "mimeType attribute of type");
-    check_readonly(record, "mimeType", "text/plain", "string", "image/jpeg");
+    check_readonly(record, "mimeType", record.mimeType, "string", "image/jpeg");
 }, document.title);
 </script>
 </body>

--- a/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_action_attribute.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_action_attribute.html
@@ -47,15 +47,16 @@ Authors:
 //==== LABEL Check if attribute action of NDEFRecordSmartPoster exists, has type DOMString and is readonly
 //==== SPEC_URL http://www.w3.org/TR/nfc/
 test(function () {
-    var record, recordText1, recordText2, recordText3;
+    var record, recordText1, recordText2, title = [];
     recordText1 = new NDEFRecordText("Hello!", "en-GB");
     recordText2 = new NDEFRecordText("Everybody!", "en-US");
-    var title = [recordText1, reocrdText2];
+    title[0] = recordText1;
+    title[1] = recordText2;
     record = new NDEFRecordSmartPoster("http://www.w3.org/TR/nfc/", title, "do");
-    assert_own_property(record, "action", "NDEFRecordSmartPoster does not own action property");
+    assert_own_property(record, "action", "NDEFRecordSmartPoster has action property");
 
     assert_equals(typeof record.action, "string", "action attribute of type");
-    assert_equals(record.action, "do", "NDEFRecordSmartPoster.action value");
+    assert_equals(record.action, "do", "NDEFRecordSmartPoster.action init value");
 
     check_readonly(record, "action", record.action, "string", "save");
 }, document.title);

--- a/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_constructor_uri.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_constructor_uri.html
@@ -51,17 +51,17 @@ test(function () {
     record = new NDEFRecordSmartPoster("http://www.w3.org/TR/nfc/");
     assert_true(record instanceof NDEFRecordSmartPoster,
         "constructed record is instance of NDEFRecordSmartPoster");
-    assert_true("uri" in record, "NDEFRecordSmartPoster has uri property");
-    assert_true("titles" in record, "NDEFRecordSmartPoster has titles property");
-    assert_true("action" in record, "NDEFRecordSmartPoster has action property");
-    assert_true("icons" in record, "NDEFRecordSmartPoster has icons property");
-    assert_true("targetSize" in record, "NDEFRecordSmartPoster has targetSize property");
-    assert_true("targetMIME" in record, "NDEFRecordSmartPoster has targetMIME property");
-    assert_true("recordType" in record, "NDEFRecordSmartPoster has recordType property");
-    assert_true("tnf" in record, "NDEFRecordSmartPoster has tnf property");
-    assert_true("type" in record, "NDEFRecordSmartPoster has type property");
-    assert_true("id" in record, "NDEFRecordSmartPoster has id property");
-    assert_true("getPayload" in record, "NDEFRecordSmartPoster has getPayload method");
+    assert_true("uri" in record, "NDEFRecordSmartPoster.uri exists");
+    assert_true("titles" in record, "NDEFRecordSmartPoster.titles exists");
+    assert_true("action" in record, "NDEFRecordSmartPoster.action exists");
+    assert_true("icons" in record, "NDEFRecordSmartPoster.icons exists");
+    assert_true("targetSize" in record, "NDEFRecordSmartPoster.targetSize exists");
+    assert_true("targetMIME" in record, "NDEFRecordSmartPoster.targetMIME exists");
+    assert_true("recordType" in record, "NDEFRecordSmartPoster.recordType exists");
+    assert_true("tnf" in record, "NDEFRecordSmartPoster.tnf exists");
+    assert_true("type" in record, "NDEFRecordSmartPoster.type exists");
+    assert_true("id" in record, "NDEFRecordSmartPoster.id exists");
+    assert_true("getPayload" in record, "NDEFRecordSmartPoster.getPayload() method exists");
 }, document.title);
 </script>
 </body>

--- a/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_constructor_uri_titles.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_constructor_uri_titles.html
@@ -47,23 +47,24 @@ Authors:
 //==== LABEL Check NDEFRecordSmartPoster constructor works with DOMString uri, NDEFRecordText［］titles parameters
 //==== SPEC_URL http://www.w3.org/TR/nfc/
 test(function () {
-    var record, recordText1, recordText2;
+    var record, recordText1, recordText2, title = [];
     recordText1 = new NDEFRecordText("Hello!", "en-GB");
     recordText2 = new NDEFRecordText("Everybody!", "en-US");
-    var title = [recordText1, reocrdText2];
+    title[0] = recordText1;
+    title[1] = recordText2;
     record = new NDEFRecordSmartPoster("http://www.w3.org/TR/nfc/", title);
     assert_true(record instanceof NDEFRecordSmartPoster,
         "constructed record is instance of NDEFRecordSmartPoster");
-    assert_own_property(record, "uri", "NDEFRecordSmartPoster does not own uri property");
-    assert_own_property(record, "titles", "NDEFRecordSmartPoster does not own titles property");
-    assert_own_property(record, "action", "NDEFRecordSmartPoster does not own action property");
-    assert_own_property(record, "icons", "NDEFRecordSmartPoster does not own icons property");
-    assert_own_property(record, "targetSize", "NDEFRecordSmartPoster does not own targetSize property");
-    assert_own_property(record, "targetMIME", "NDEFRecordSmartPoster does not own targetMIME property");
-    assert_own_property(record, "recordType", "NDEFRecordSmartPoster does not own recordType property");
-    assert_own_property(record, "tnf", "NDEFRecordSmartPoster does not own tnf property");
-    assert_own_property(record, "type", "NDEFRecordSmartPoster does not own type property");
-    assert_own_property(record, "id", "NDEFRecordSmartPoster does not own id property");
+    assert_true("uri" in record, "NDEFRecordSmartPoster.uri exists");
+    assert_true("titles" in record, "NDEFRecordSmartPoster.titles exists");
+    assert_true("action" in record, "NDEFRecordSmartPoster.action exists");
+    assert_true("icons" in record, "NDEFRecordSmartPoster.icons exists");
+    assert_true("targetSize" in record, "NDEFRecordSmartPoster.targetSize exists");
+    assert_true("targetMIME" in record, "NDEFRecordSmartPoster.targetMIME exists");
+    assert_true("recordType" in record, "NDEFRecordSmartPoster.recordType exists");
+    assert_true("tnf" in record, "NDEFRecordSmartPoster.tnf exists");
+    assert_true("type" in record, "NDEFRecordSmartPoster.type exists");
+    assert_true("id" in record, "NDEFRecordSmartPoster.id exists");
     assert_true("getPayload" in record, "NDEFRecordSmartPoster.getPayload() method exists");
 }, document.title);
 </script>

--- a/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_constructor_uri_titles_action.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_constructor_uri_titles_action.html
@@ -47,24 +47,24 @@ Authors:
 //==== LABEL Check NDEFRecordSmartPoster constructor works with DOMString uri, NDEFRecordText［］titles, DOMString action parameters
 //==== SPEC_URL http://www.w3.org/TR/nfc/
 test(function () {
-    var record, recordText1, recordText2;
+    var record, recordText1, recordText2, title = [];
     recordText1 = new NDEFRecordText("Hello!", "en-GB");
     recordText2 = new NDEFRecordText("Everybody!", "en-US");
-    var title = [recordText1, reocrdText2];
+    title[0] = recordText1;
+    title[1] = recordText2;
     record = new NDEFRecordSmartPoster("http://www.w3.org/TR/nfc/", title, "do");
     assert_true(record instanceof NDEFRecordSmartPoster,
         "constructed record is instance of NDEFRecordSmartPoster");
-    assert_own_property(record, "uri", "NDEFRecordSmartPoster does not own uri property");
-    assert_own_property(record, "titles", "NDEFRecordSmartPoster does not own titles property");
-    assert_own_property(record, "action", "NDEFRecordSmartPoster does not own action property");
-    assert_equals(record.action, "do", "NDEFRecordSmartPoster.action value");
-    assert_own_property(record, "icons", "NDEFRecordSmartPoster does not own icons property");
-    assert_own_property(record, "targetSize", "NDEFRecordSmartPoster does not own targetSize property");
-    assert_own_property(record, "targetMIME", "NDEFRecordSmartPoster does not own targetMIME property");
-    assert_own_property(record, "recordType", "NDEFRecordSmartPoster does not own recordType property");
-    assert_own_property(record, "tnf", "NDEFRecordSmartPoster does not own tnf property");
-    assert_own_property(record, "type", "NDEFRecordSmartPoster does not own type property");
-    assert_own_property(record, "id", "NDEFRecordSmartPoster does not own id property");
+    assert_true("uri" in record, "NDEFRecordSmartPoster.uri exists");
+    assert_true("titles" in record, "NDEFRecordSmartPoster.titles exists");
+    assert_true("action" in record, "NDEFRecordSmartPoster.action exists");
+    assert_true("icons" in record, "NDEFRecordSmartPoster.icons exists");
+    assert_true("targetSize" in record, "NDEFRecordSmartPoster.targetSize exists");
+    assert_true("targetMIME" in record, "NDEFRecordSmartPoster.targetMIME exists");
+    assert_true("recordType" in record, "NDEFRecordSmartPoster.recordType exists");
+    assert_true("tnf" in record, "NDEFRecordSmartPoster.tnf exists");
+    assert_true("type" in record, "NDEFRecordSmartPoster.type exists");
+    assert_true("id" in record, "NDEFRecordSmartPoster.id exists");
     assert_true("getPayload" in record, "NDEFRecordSmartPoster.getPayload() method exists");
 }, document.title);
 </script>

--- a/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_constructor_uri_titles_action_icons.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_constructor_uri_titles_action_icons.html
@@ -47,27 +47,26 @@ Authors:
 //==== LABEL Check NDEFRecordSmartPoster constructor works with DOMString uri, NDEFRecordText［］titles, DOMString action, NDEFRecordMedia［］icons parameters
 //==== SPEC_URL http://www.w3.org/TR/nfc/
 test(function () {
-    var record, recordText1, recordText2, recordMedia,
+    var record, recordText1, recordText2, recordMedia, title = [],
         payloads = [72, 101, 108, 108, 111, 9, 87, 111, 114, 108, 100, 33, 13, 10];
     recordText1 = new NDEFRecordText("Hello!", "en-GB");
     recordText2 = new NDEFRecordText("Everybody!", "en-US");
-    var title = [recordText1, reocrdText2];
+    title[0] = recordText1;
+    title[1] = recordText2;
     recordMedia = new NDEFRecordMedia("text/plain", payloads);
     record = new NDEFRecordSmartPoster("http://www.w3.org/TR/nfc/", title, "do", [recordMedia]);
     assert_true(record instanceof NDEFRecordSmartPoster,
         "constructed record is instance of NDEFRecordSmartPoster");
-    assert_own_property(record, "uri", "NDEFRecordSmartPoster does not own uri property");
-    assert_equals("record.uri", "string", "NDEFRecordSmartPoster.uri attribute of type");
-    assert_own_property(record, "titles", "NDEFRecordSmartPoster does not own titles property");
-    assert_own_property(record, "action", "NDEFRecordSmartPoster does not own action property");
-    assert_equals(record.action, "do", "NDEFRecordSmartPoster.action value");
-    assert_own_property(record, "icons", "NDEFRecordSmartPoster does not own icons property");
-    assert_own_property(record, "targetSize", "NDEFRecordSmartPoster does not own targetSize property");
-    assert_own_property(record, "targetMIME", "NDEFRecordSmartPoster does not own targetMIME property");
-    assert_own_property(record, "recordType", "NDEFRecordSmartPoster does not own recordType property");
-    assert_own_property(record, "tnf", "NDEFRecordSmartPoster does not own tnf property");
-    assert_own_property(record, "type", "NDEFRecordSmartPoster does not own type property");
-    assert_own_property(record, "id", "NDEFRecordSmartPoster does not own id property");
+    assert_true("uri" in record, "NDEFRecordSmartPoste.uri exists");
+    assert_true("titles" in record, "NDEFRecordSmartPoster.titles exists");
+    assert_true("action" in record, "NDEFRecordSmartPoster.action exists");
+    assert_true("icons" in record, "NDEFRecordSmartPoster.icons exists");
+    assert_true("targetSize" in record, "NDEFRecordSmartPoster.targetSize exists");
+    assert_true("targetMIME" in record, "NDEFRecordSmartPoster.targetMIME exists");
+    assert_true("recordType" in record, "NDEFRecordSmartPoster.recordType exists");
+    assert_true("tnf" in record, "NDEFRecordSmartPoster.tnf exists");
+    assert_true("type" in record, "NDEFRecordSmartPoster.type exists");
+    assert_true("id" in record, "NDEFRecordSmartPoster.id exists");
     assert_true("getPayload" in record, "NDEFRecordSmartPoster.getPayload() method exists");
 }, document.title);
 </script>

--- a/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_constructor_uri_titles_action_icons_targetSize.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_constructor_uri_titles_action_icons_targetSize.html
@@ -47,26 +47,26 @@ Authors:
 //==== LABEL Check NDEFRecordSmartPoster constructor works with DOMString uri, NDEFRecordText［］titles, DOMString action, NDEFRecordMedia［］icons, unsigned long targetSize parameters
 //==== SPEC_URL http://www.w3.org/TR/nfc/
 test(function () {
-    var record, recordText1, recordText2, recordMedia,
+    var record, recordText1, recordText2, recordMedia, title = [],
         payloads = [72, 101, 108, 108, 111, 9, 87, 111, 114, 108, 100, 33, 13, 10];
     recordText1 = new NDEFRecordText("Hello!", "en-GB");
     recordText2 = new NDEFRecordText("Everybody!", "en-US");
-    var title = [recordText1, reocrdText2];
+    title[0] = recordText1;
+    title[1] = recordText2;
     recordMedia = new NDEFRecordMedia("text/plain", payloads);
     record = new NDEFRecordSmartPoster("http://www.w3.org/TR/nfc/", title, "do", [recordMedia], 100);
     assert_true(record instanceof NDEFRecordSmartPoster,
         "constructed record is instance of NDEFRecordSmartPoster");
-    assert_own_property(record, "uri", "NDEFRecordSmartPoster does not own uri property");
-    assert_own_property(record, "titles", "NDEFRecordSmartPoster does not own titles property");
-    assert_own_property(record, "action", "NDEFRecordSmartPoster does not own action property");
-    assert_equals(record.action, "do", "NDEFRecordSmartPoster.action value");
-    assert_own_property(record, "icons", "NDEFRecordSmartPoster does not own icons property");
-    assert_own_property(record, "targetSize", "NDEFRecordSmartPoster does not own targetSize property");
-    assert_own_property(record, "targetMIME", "NDEFRecordSmartPoster does not own targetMIME property");
-    assert_own_property(record, "recordType", "NDEFRecordSmartPoster does not own recordType property");
-    assert_own_property(record, "tnf", "NDEFRecordSmartPoster does not own tnf property");
-    assert_own_property(record, "type", "NDEFRecordSmartPoster does not own type property");
-    assert_own_property(record, "id", "NDEFRecordSmartPoster does not own id property");
+    assert_true("uri" in record, "NDEFRecordSmartPoster.uri exists");
+    assert_true("titles" in record, "NDEFRecordSmartPoster.titles exists");
+    assert_true("action" in record, "NDEFRecordSmartPoster.action exists");
+    assert_true("icons" in record, "NDEFRecordSmartPoster.icons exists");
+    assert_true("targetSize" in record, "NDEFRecordSmartPoster.targetSize exists");
+    assert_true("targetMIME" in record, "NDEFRecordSmartPoster.targetMIME exists");
+    assert_true("recordType" in record, "NDEFRecordSmartPoster.recordType exists");
+    assert_true("tnf" in record, "NDEFRecordSmartPoster.tnf exists");
+    assert_true("type" in record, "NDEFRecordSmartPoster.type exists");
+    assert_true("id" in record, "NDEFRecordSmartPoster.id exists");
     assert_true("getPayload" in record, "NDEFRecordSmartPoster.getPayload() method exists");
 }, document.title);
 </script>

--- a/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_constructor_uri_titles_action_icons_targetSize_targetMIME.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_constructor_uri_titles_action_icons_targetSize_targetMIME.html
@@ -47,27 +47,27 @@ Authors:
 //==== LABEL Check NDEFRecordSmartPoster constructor works with DOMString uri, NDEFRecordText［］titles, DOMString action, NDEFRecordMedia［］icons, unsigned long targetSize, DOMString targetMIME parameters
 //==== SPEC_URL http://www.w3.org/TR/nfc/
 test(function () {
-    var record, recordText1, recordText2, recordMedia,
+    var record, recordText1, recordText2, recordMedia, title = [],
         payloads = [72, 101, 108, 108, 111, 9, 87, 111, 114, 108, 100, 33, 13, 10];
     recordText1 = new NDEFRecordText("Hello!", "en-GB");
     recordText2 = new NDEFRecordText("Everybody!", "en-US");
-    var title = [recordText1, reocrdText2];
+    title[0] = recordText1;
+    title[1] = recordText2;
     recordMedia = new NDEFRecordMedia("text/plain", payloads);
     record = new NDEFRecordSmartPoster("http://www.w3.org/TR/nfc/", title, "do", [recordMedia], 100, "text/plain");
     assert_true(record instanceof NDEFRecordSmartPoster,
         "constructed record is instance of NDEFRecordSmartPoster");
-    assert_own_property(record, "uri", "NDEFRecordSmartPoster does not own uri property");
-    assert_own_property(record, "titles", "NDEFRecordSmartPoster does not own titles property");
-    assert_own_property(record, "action", "NDEFRecordSmartPoster does not own action property");
-    assert_equals(record.action, "do", "NDEFRecordSmartPoster.action value");
-    assert_own_property(record, "icons", "NDEFRecordSmartPoster does not own icons property");
-    assert_own_property(record, "targetSize", "NDEFRecordSmartPoster does not own targetSize property");
-    assert_own_property(record, "targetMIME", "NDEFRecordSmartPoster does not own targetMIME property");
-    assert_own_property(record, "recordType", "NDEFRecordSmartPoster does not own recordType property");
-    assert_own_property(record, "tnf", "NDEFRecordSmartPoster does not own tnf property");
-    assert_own_property(record, "type", "NDEFRecordSmartPoster does not own type property");
-    assert_own_property(record, "id", "NDEFRecordSmartPoster does not own id property");
-    assert_ture("getPayload" in record, "NDEFRecordSmartPoster.getPayload() method exists");
+    assert_true("uri" in record, "NDEFRecordSmartPoster.uri exists");
+    assert_true("titles" in record, "NDEFRecordSmartPoster.titles exists");
+    assert_true("action" in record, "NDEFRecordSmartPoste.action exists");
+    assert_true("icons" in record, "NDEFRecordSmartPoster.icons exists");
+    assert_true("targetSize" in record, "NDEFRecordSmartPoster.targetSize exists");
+    assert_true("targetMIME" in record, "NDEFRecordSmartPoster.targetMIME exists");
+    assert_true("recordType" in record, "NDEFRecordSmartPoster.recordType exists");
+    assert_true("tnf" in record, "NDEFRecordSmartPoster.tnf exists");
+    assert_true("type" in record, "NDEFRecordSmartPoster.type exists");
+    assert_true("getPayload" in record, "NDEFRecordSmartPoster.getPayload() method exists");
+    assert_true("id" in record, "NDEFRecordSmartPoster.id exists");
 }, document.title);
 </script>
 </body>

--- a/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_icons_attribute.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_icons_attribute.html
@@ -47,22 +47,23 @@ Authors:
 //==== LABEL Check if attribute icons of NDEFRecordSmartPoster exists, has proper type and is readonly
 //==== SPEC_URL http://www.w3.org/TR/nfc/
 test(function () {
-    var record, recordText1, recordText2, recordMedia,
+    var record, recordText1, recordText2, recordMedia, title = [],
         payloads = [72, 101, 108, 108, 111, 9, 87, 111, 114, 108, 100, 33, 13, 10];
     recordText1 = new NDEFRecordText("Hello!", "en-GB");
     recordText2 = new NDEFRecordText("Everybody!", "en-US");
-    var title = [recordText1, reocrdText2];
+    title[0] = recordText1;
+    title[1] = recordText2;
     recordMedia = new NDEFRecordMedia("text/plain", payloads);
     record = new NDEFRecordSmartPoster("http://www.w3.org/TR/nfc/", title, "do", [recordMedia]);
 
-    assert_own_property(record, "icons", "NDEFRecordSmartPoster does not own icons property");
-    assert_equals(record.icons, [recordMedia], "NDEFRecordSmartPoster.icons value")
+    assert_own_property(record, "icons", "NDEFRecordSmartPoster has icons property");
+    assert_array_equals(record.icons, [recordMedia], "NDEFRecordSmartPoster.icons value")
 
     assert_type(record.icons, "array", "NDEFRecordSmartPoster.icons should be array");
-    assert_equals(record.icons[0], "object", "NDEFRecordSmartPoster.icons attribute of type");
+    assert_equals(typeof record.icons[0], "object", "NDEFRecordSmartPoster.icons attribute of type");
 
     record.icons = [];
-    assert_equals(reocrd.icons, [recordMedia], "NDEFRecordSmartPoster.icons attribute is readonly");
+    assert_array_equals(record.icons, [recordMedia], "NDEFRecordSmartPoster.icons attribute is readonly");
 }, document.title);
 </script>
 </body>

--- a/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_targetMIME_attribute.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_targetMIME_attribute.html
@@ -47,15 +47,16 @@ Authors:
 //==== LABEL Check if attribute targetMIME of NDEFRecordSmartPoster exists, has proper type and is readonly
 //==== SPEC_URL http://www.w3.org/TR/nfc/
 test(function () {
-    var record, recordText1, recordText2, recordMedia,
+    var record, recordText1, recordText2, recordMedia, title = [],
         payloads = [72, 101, 108, 108, 111, 9, 87, 111, 114, 108, 100, 33, 13, 10];
     recordText1 = new NDEFRecordText("Hello!", "en-GB");
     recordText2 = new NDEFRecordText("Everybody!", "en-US");
-    var title = [recordText1, reocrdText2];
+    title[0] = recordText1;
+    title[1] = recordText2;
     recordMedia = new NDEFRecordMedia("text/plain", payloads);
     record = new NDEFRecordSmartPoster("http://www.w3.org/TR/nfc/", title, "do", [recordMedia], 100, "text/plain");
 
-    assert_own_property(record, "targetMIME", "NDEFRecordSmartPoster does not own targetMIME property");
+    assert_own_property(record, "targetMIME", "NDEFRecordSmartPoster has targetMIME property");
     assert_equals(record.targetMIME, "text/plain", "NDEFRecordSmartPoster.targetMIME value");
 
     assert_equals(typeof record.targetMIME, "string", "NDEFRecordSmartPoster.targetMIME attribute of type");

--- a/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_targetSize_attribute.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_targetSize_attribute.html
@@ -47,17 +47,18 @@ Authors:
 //==== LABEL Check if attribute targetSize of NDEFRecordSmartPoster exists, has proper type and is readonly
 //==== SPEC_URL http://www.w3.org/TR/nfc/
 test(function () {
-    var record, recordText1, recordText2, recordMedia,
+    var record, recordText1, recordText2, recordMedia, title = [],
         payloads = [72, 101, 108, 108, 111, 9, 87, 111, 114, 108, 100, 33, 13, 10];
     recordText1 = new NDEFRecordText("Hello!", "en-GB");
     recordText2 = new NDEFRecordText("Everybody!", "en-US");
-    var title = [recordText1, reocrdText2];
+    title[0] = recordText1;
+    title[1] = recordText2;
     recordMedia = new NDEFRecordMedia("text/plain", payloads);
     record = new NDEFRecordSmartPoster("http://www.w3.org/TR/nfc/", title, "do", [recordMedia], 100);
 
-    assert_own_property(record, "targetSize", "NDEFRecordSmartPoster does not own targetSize property");
+    assert_own_property(record, "targetSize", "NDEFRecordSmartPoster has targetSize property");
 
-    assert_equals(record.targetSize, "number", "NDEFRecordSmartPoster.targetSize attribute of type");
+    assert_equals(typeof record.targetSize, "number", "NDEFRecordSmartPoster.targetSize attribute of type");
 
     check_readonly(record, "targetSize", record.targetSize, "number", 101);
 }, document.title);

--- a/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_titles_attribute.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_titles_attribute.html
@@ -47,14 +47,15 @@ Authors:
 //==== LABEL Check if attribute titles of NDEFRecordSmartPoster exists, has type object and is readonly
 //==== SPEC_URL http://www.w3.org/TR/nfc/
 test(function () {
-    var record, recordText1, recordText2, recordText3;
+    var record, recordText1, recordText2, recordText3, title = [];
     recordText1 = new NDEFRecordText("Hello!", "en-GB");
     recordText2 = new NDEFRecordText("Everybody!", "en-US");
-    var title = [recordText1, reocrdText2];
+    title[0] = recordText1;
+    title[1] = recordText2;
     record = new NDEFRecordSmartPoster("http://www.w3.org/TR/nfc/", title);
-    assert_own_property(record, "titles", "NDEFRecordSmartPoster does not own titles property");
+    assert_own_property(record, "titles", "NDEFRecordSmartPoster has titles property");
     assert_type(record.titles, "array", "NDEFRecordSmartPoster.titles should be array");
-    assert_equals(typeof reocrd.titles[0], "object", "NDEFRecordSmartPoster.titles attribute of type");
+    assert_equals(typeof record.titles[0], "object", "NDEFRecordSmartPoster.titles[0] attribute of type");
     assert_array_equals(record.titles, title, "NDEFRecordSmartPoster.titles array value");
     recordText3 = new NDEFRecordText("Good Job!", "en-US");
     record.titles = [recordText3];

--- a/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_uri_attribute.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_uri_attribute.html
@@ -46,12 +46,11 @@ Authors:
 //==== PRIORITY P1
 //==== LABEL Check if attribute uri of NDEFRecordSmartPoster exists, has type DOMString and is readonly
 //==== SPEC_URL http://www.w3.org/TR/nfc/
-var record;
 test(function () {
-    record = new NDEFRecordSmartPoster("http://www.w3.org/TR/nfc/");
-    assert_own_property(record, "uri", "NDEFRecordSmartPoster does not own uri property.");
-    assert_equals("record.uri", "string", "NDEFRecordSmartPoster.uri attribute of type");
-    check_readonly(record, "uri", "http://www.w3.org/TR/nfc/", "string", "http://www.baidu.com/");
+    var record = new NDEFRecordSmartPoster("http://www.w3.org/TR/nfc/");
+    assert_own_property(record, "uri", "NDEFRecordSmartPoster has uri property.");
+    assert_equals(typeof record.uri, "string", "NDEFRecordSmartPoster.uri attribute of type");
+    check_readonly(record, "uri", record.uri, "string", "http://www.baidu.com/");
 }, document.title);
 </script>
 </body>

--- a/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordText_constructor_text.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordText_constructor_text.html
@@ -47,19 +47,18 @@ Authors:
 //==== PRIORITY P1
 //==== LABEL Check NDEFRecordText constructor works with DOMString text parameter
 //==== SPEC_URL http://www.w3.org/TR/nfc/
-var record;
 test(function () {
-    record = new NDEFRecordText("Hello World!");
+    var record = new NDEFRecordText("Hello World!");
     assert_true(record instanceof NDEFRecordText,
         "constructed record is instance of NDEFRecordText");
-    assert_true("tnf" in record, "NDEFRecordText has tnf property");
-    assert_true("type" in record, "NDEFRecordText has type property");
-    assert_true("id" in record, "NDEFRecordText has id property");
-    assert_true("recordType" in record, "NDEFRecordText has recordType property");
-    assert_true("getPayload" in record, "NDEFRecordText has getPayload method");
-    assert_true("text" in record, "NDEFRecordText has text property");
-    assert_true("languageCode" in record, "NDEFRecordText has languageCode property");
-    assert_true("encoding" in record, "NDEFRecordText has encoding property");
+    assert_true("text" in record, "NDEFRecordText.text exists");
+    assert_true("languageCode" in record, "NDEFRecordText.languageCode exists");
+    assert_true("encoding" in record, "NDEFRecordText.encoding exists");
+    assert_true("tnf" in record, "NDEFRecordText.tnf exists");
+    assert_true("type" in record, "NDEFRecordText.type exists");
+    assert_true("recordType" in record, "NDEFRecordText.recordType exists");
+    assert_true("getPayload" in record, "NDEFRecordText.getPayload() method exists");
+    assert_true("id" in record, "NDEFRecordText.id exists");
 }, document.title);
 </script>
 </body>

--- a/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordText_constructor_text_languageCode.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordText_constructor_text_languageCode.html
@@ -47,19 +47,17 @@ Authors:
 //==== LABEL Check NDEFRecordText constructor works with DOMString text, DOMString languageCode parameters
 //==== SPEC_URL http://www.w3.org/TR/nfc/
 test(function () {
-    var record;
-    record = new NDEFRecordText("Hello World!", "en-GB");
+    var record = new NDEFRecordText("Hello World!", "en-GB");
     assert_true(record instanceof NDEFRecordText,
         "constructed record is instance of NDEFRecordText");
-    assert_own_property(record, "tnf", "NDEFRecordText own tnf property");
-    assert_own_property(record, "type", "NDEFRecordText own type property");
-    assert_own_property(record, "id", "NDEFRecordText own id property");
-    assert_own_property(record, "recordType", "NDEFRecordText own recordType property");
+    assert_true("text" in record, "NDEFRecordText.text exists");
+    assert_true("languageCode" in record, "NDEFRecordText.languageCode exists");
+    assert_true("encoding" in record, "NDEFRecordText.encoding exists");
+    assert_true("tnf" in record, "NDEFRecordText.tnf exists");
+    assert_true("type" in record, "NDEFRecordText.type exists");
+    assert_true("recordType" in record, "NDEFRecordText.recordType exists");
     assert_true("getPayload" in record, "NDEFRecordText.getPayload() method exists");
-    assert_own_property(record, "text", "NDEFRecordText own text property");
-    assert_own_property(record, "languageCode", "NDEFRecordText own languageCode property");
-    assert_equals(record.languageCode, "en-GB", "record.languageCode init value");
-    assert_own_property(record, "encoding", "NDEFRecordText own encoding property");
+    assert_true("id" in record, "NDEFRecordText.id exists");
 }, document.title);
 </script>
 </body>

--- a/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordText_constructor_text_languageCode_encoding.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordText_constructor_text_languageCode_encoding.html
@@ -46,20 +46,17 @@ Authors:
 //==== PRIORITY P1
 //==== LABEL Check NDEFRecordText constructor works with DOMString text, DOMString languageCode, DOMString encoding parameters
 //==== SPEC_URL http://www.w3.org/TR/nfc/
-var record;
 test(function () {
-    record = new NDEFRecordText("Hello World!", "en-GB", "UTF-8");
+    var record = new NDEFRecordText("Hello World!", "en-GB", "UTF-8");
     assert_true(record instanceof NDEFRecordText,
         "constructed record is instance of NDEFRecordText");
-    assert_own_property(record, "tnf", "NDEFRecordText.tnf");
-    assert_own_property(record, "type", "NDEFRecordText.type");
-    assert_own_property(record, "id", "NDEFRecordText.id");
-    assert_true("getPayload" in record, "NDEFRecordText.getPayload()");
-    assert_own_property(record, "text", "NDEFRecordText.text");
-    assert_own_property(record, "languageCode", "NDEFRecordText.languageCode");
-    assert_equals(record.languageCode, "en-GB", "record.languageCode");
-    assert_own_property(record, "encoding", "NDEFRecordText.encoding");
-    assert_equals(record.encoding, "UTF8", "record.encoding");
+    assert_true("text" in record, "NDEFRecordText.text exists");
+    assert_true("languageCode" in record, "NDEFRecordText.languageCode exists");
+    assert_true("encoding" in record, "NDEFRecordText.encoding exists");
+    assert_true("tnf" in record, "NDEFRecordText.tnf exists");
+    assert_true("type" in record, "NDEFRecordText.type exists");
+    assert_true("id" in record, "NDEFRecordText.id exists");
+    assert_true("getPayload" in record, "NDEFRecordText.getPayload() method exists");
 }, document.title);
 </script>
 </body>

--- a/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordText_encoding_attribute.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordText_encoding_attribute.html
@@ -46,11 +46,11 @@ Authors:
 //==== PRIORITY P1
 //==== LABEL Check if attribute encoding of NDEFRecordText exists, has type DOMString and is readonly
 //==== SPEC_URL http://www.w3.org/TR/nfc/
-var record;
 test(function () {
-    record = new NDEFRecordText("Hello World!", "en-GB", "UTF-8");
-    assert_own_property(record, "encoding", "NDEFRecordText own encoding property.");
-    assert_equals("record.encoding", "string", "NDEFRecordText.encoding attribute of type");
+    var record = new NDEFRecordText("Hello World!", "en-GB", "UTF-8");
+    assert_own_property(record, "encoding", "NDEFRecordText has encoding property.");
+    assert_equals(typeof record.encoding, "string", "NDEFRecordText.encoding attribute of type");
+    assert_equals(record.encoding, "UTF-8", "NDEFRecordText.encoding init value");
     check_readonly(record, "encoding", record.encoding, "string", "UTF-16");
 }, document.title);
 </script>

--- a/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordText_languageCode_attribute.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordText_languageCode_attribute.html
@@ -46,11 +46,11 @@ Authors:
 //==== PRIORITY P1
 //==== LABEL Check if attribute languageCode of NDEFRecordText exists, has type DOMString and is readonly
 //==== SPEC_URL http://www.w3.org/TR/nfc/
-var record;
 test(function () {
-    record = new NDEFRecordText("Hello World!", "en-GB");
-    assert_own_property(record, "languageCode", "NDEFRecordText own languageCode property");
-    assert_equals("record.languageCode", "string", "NDEFRecordText.languageCode attribute of type");
+    var record = new NDEFRecordText("Hello World!", "en-GB");
+    assert_own_property(record, "languageCode", "NDEFRecordText has languageCode property");
+    assert_equals(typeof record.languageCode, "string", "NDEFRecordText.languageCode attribute of type");
+    assert_equals(record.languageCode, "en-GB", "NDEFRecordText.languageCode init value");
     check_readonly(record, "languageCode", record.languageCode, "string", "en-US");
 }, document.title);
 </script>

--- a/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordText_text_attribute.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordText_text_attribute.html
@@ -46,12 +46,12 @@ Authors:
 //==== PRIORITY P1
 //==== LABEL Check if attribute text of NDEFRecordText exists, has type DOMString and is readonly
 //==== SPEC_URL http://www.w3.org/TR/nfc/
-var record;
 test(function () {
-    record = new NDEFRecordText("Hello World!", "en-GB");
-    assert_own_property(record, "text", "NDEFRecordText own text property.");
-    assert_equals("record.text", "string", "NDEFRecordText.text attribute of type");
-    check_readonly(record, "text", "Hello World!", "string", "dummy");
+    var record = new NDEFRecordText("Hello World!", "en-GB");
+    assert_own_property(record, "text", "NDEFRecordText has text property.");
+    assert_equals(typeof record.text, "string", "NDEFRecordText.text attribute of type");
+    assert_equals(record.text, "Hello World!", "NDEFRecordText.text init value");
+    check_readonly(record, "text", record.text, "string", "dummy");
 }, document.title);
 </script>
 </body>

--- a/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordURI_constructor.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecordURI_constructor.html
@@ -47,16 +47,15 @@ Authors:
 //==== LABEL Check NDEFRecordURI constructor works
 //==== SPEC_URL http://www.w3.org/TR/nfc/
 test(function () {
-    var record;
-    record = new NDEFRecordURI("http://www.w3.org/TR/nfc/");
+    var record = new NDEFRecordURI("http://www.w3.org/TR/nfc/");
     assert_true(record instanceof NDEFRecordURI,
         "constructed record is instance of NDEFRecordURI");
-    assert_true("tnf" in record, "NDEFRecordURI.tnf exists");
-    assert_true("type" in record, "NDEFRecordURI.type exists");
-    assert_true("id" in record, "NDEFRecordURI.id exists");
-    assert_true("getPayload" in record, "NDEFRecordURI.getPayload() exists");
     assert_true("uri" in record, "NDEFRecordURI.uri exists");
     assert_equals(record.uri, "http://www.w3.org/TR/nfc/", "record.uri init value");
+    assert_true("tnf" in record, "NDEFRecordURI.tnf exists");
+    assert_true("type" in record, "NDEFRecordURI.type exists");
+    assert_true("getPayload" in record, "NDEFRecordURI.getPayload() exists");
+    assert_true("id" in record, "NDEFRecordURI.id exists");
 }, document.title);
 </script>
 </body>

--- a/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecord_constructor_tnf.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecord_constructor_tnf.html
@@ -51,7 +51,6 @@ test(function () {
     assert_true(record instanceof NDEFRecord,
         "constructed record is instance of NDEFRecord");
     assert_true("tnf" in record, "NDEFRecord.tnf exists");
-    asset_equals(record.tnf, 0, "NDEFRecord.tnf value");
     assert_true("type" in record, "NDEFRecord.type exists");
     assert_true("id" in record, "NDEFRecord.id exists");
     assert_true("recordType" in record, "NDEFRecord.recordType exists");

--- a/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecord_constructor_tnf_type.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecord_constructor_tnf_type.html
@@ -48,16 +48,15 @@ Authors:
 //==== SPEC_URL http://www.w3.org/TR/nfc/
 test(function () {
     var record, recordText;
-    recordText = new NDEFRecordText("Hi!", "en-GB");
+    recordText = new NDEFRecordText("Hi!", "en-GB", "UTF-8");
     record = new NDEFRecord(recordText.tnf, recordText.type);
     assert_true(record instanceof NDEFRecord,
         "constructed record is instance of NDEFRecord");
-    assert_own_property(record, "tnf", "NDEFRecord.tnf");
-    asset_equals(record.tnf, recordText.tnf, "NDEFRecord.tnf value");
-    assert_own_property(record, "type", "NDEFRecord.type");
-    asset_equals(record.type, recordText.type, "NDEFRecord.type value");
-    assert_own_property(record, "id", "NDEFRecord.id");
-    assert_true("getPayload" in record, "NDEFRecord.getPayload()");
+    assert_true("tnf" in record, "NDEFRecord.tnf exists");
+    assert_true("type" in record, "NDEFRecord.type exists");
+    assert_true("id" in record, "NDEFRecord.id exists");
+    assert_true("recordType" in record, "NDEFRecord.recordType exists");
+    assert_true("getPayload" in record, "NDEFRecord.getPayload() exists");
 }, document.title);
 </script>
 </body>

--- a/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecord_constructor_tnf_type_payload.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecord_constructor_tnf_type_payload.html
@@ -57,13 +57,11 @@ t.step(function () {
         record = new NDEFRecord(recordText.tnf, recordText.type, payload);
         assert_true(record instanceof NDEFRecord,
         "constructed record is instance of NDEFRecord");
-        assert_own_property(record, "tnf", "NDEFRecord.tnf");
-        asset_equals(record.tnf, recordText.tnf, "NDEFRecord.tnf value");
-        assert_own_property(record, "type", "NDEFRecord.type");
-        asset_equals(record.type, recordText.type, "NDEFRecord.type value");
-        assert_own_property(record, "id", "NDEFRecord.id");
-        asset_equals(record.id, recordText.id, "NDEFRecord.id value");
-        assert_true("getPayload" in record, "NDEFRecord.getPayload()");
+        assert_true("recordType" in record, "NDEFRecord.recordType exists");
+        assert_true("tnf" in record, "NDEFRecord.tnf exists");
+        assert_true("type" in record, "NDEFRecord.type exists");
+        assert_true("id" in record, "NDEFRecord.id exists");
+        assert_true("getPayload" in record, "NDEFRecord.getPayload() method exists");
         t.done();
     });
     recordText = new NDEFRecordText("Hi!", "en-GB");

--- a/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecord_constructor_tnf_type_payload_id.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecord_constructor_tnf_type_payload_id.html
@@ -57,13 +57,11 @@ t.step(function () {
         record = new NDEFRecord(recordText.tnf, recordText.type, payload, recordText.id);
         assert_true(record instanceof NDEFRecord,
         "constructed record is instance of NDEFRecord");
-        assert_own_property(record, "tnf", "NDEFRecord.tnf");
-        asset_equals(record.tnf, recordText.tnf, "NDEFRecord.tnf value");
-        assert_own_property(record, "type", "NDEFRecord.type");
-        asset_equals(record.type, recordText.type, "NDEFRecord.type value");
-        assert_own_property(record, "id", "NDEFRecord.id");
-        asset_equals(record.id, recordText.id, "NDEFRecord.id value");
-        assert_true("getPayload" in record, "NDEFRecord.getPayload()");
+        assert_true("recordType" in record, "NDEFRecord.recordType exists");
+        assert_true("tnf" in record, "NDEFRecord.tnf exists");
+        assert_true("type" in record, "NDEFRecord.type exists");
+        assert_true("id" in record, "NDEFRecord.id exists");
+        assert_true("getPayload" in record, "NDEFRecord.getPayload() method exists");
         t.done();
     });
     recordText = new NDEFRecordText("Hi!", "en-GB");

--- a/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecord_id_attribute.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecord_id_attribute.html
@@ -55,8 +55,8 @@ t.step(function () {
 
     onSuccess = t.step_func(function (payload) {
         record = new NDEFRecord(recordText.tnf, recordText.type, payload, recordText.id);
-        assert_own_property(record, "id", "NDEFRecord.id");
-        asset_equals(typeof record.id, "string", "NDEFRecord.id attribute of type");
+        assert_true("id" in record, "NDEFRecord.id exists");
+        assert_equals(typeof record.id, "string", "NDEFRecord.id attribute of type");
         check_readonly(record, "id", record.id, "string", "dummy");
         t.done();
     });

--- a/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecord_recordType_attribute.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecord_recordType_attribute.html
@@ -55,11 +55,9 @@ t.step(function () {
 
     onSuccess = t.step_func(function (payload) {
         record = new NDEFRecord(recordText.tnf, recordText.type, payload, recordText.id);
-        assert_own_property(record, "recordType", "NDEFRecord.recordType");
-        asset_equals(typeof record.recordType, "number", "NDEFRecord.recordType attribute of type");
-        var oldValue = record.recordType;
-        record.recordType = oldValue + 1;
-        assert_true(record.recordType == oldValue, "NDEFRecord.recordType attribute is readonly");
+        assert_true("recordType" in record, "NDEFRecord.recordType exists");
+        assert_equals(typeof record.recordType, "string", "NDEFRecord.recordType attribute of type");
+        check_readonly(record, "recordType", record.recordType, "string", "dummy");
         t.done();
     });
     recordText = new NDEFRecordText("Hi!", "en-GB");

--- a/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecord_tnf_attribute.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecord_tnf_attribute.html
@@ -46,13 +46,24 @@ Authors:
 //==== PRIORITY P1
 //==== LABEL Check if NDEFRecord have tnf attribute with proper type and is readonly
 //==== SPEC_URL http://www.w3.org/TR/nfc/
-test(function () {
-    var record;
-    record = new NDEFRecord(1);
-    assert_own_property(record, "tnf", "NDEFRecord owen tnf property");
-    asset_equals(typeof record.tnf, "number", "NDEFRecord.tnf attribute of type");
-    check_readonly(record, "tnf", record.tnf, "number", 3);
-}, document.title);
+var t = async_test(document.title, {timeout: 10000}), onSuccess, onError, record, recordText;
+
+t.step(function () {
+    onError = t.step_func(function (error) {
+        assert_unreached("getPayload() error callback was invoked: " + error.name + " msg: " + error.message);
+    });
+
+    onSuccess = t.step_func(function (payload) {
+        record = new NDEFRecord(recordText.tnf, recordText.type, payload, recordText.id);
+        assert_true("tnf" in record, "NDEFRecord.tnf exists");
+        assert_equals(record.tnf, recordText.tnf, "NDEFRecord.tnf init value");
+        assert_equals(typeof record.tnf, "number", "NDEFRecord.tnf attribute of type");
+        check_readonly(record, "tnf", record.tnf, "number", 3);
+        t.done();
+    });
+    recordText = new NDEFRecordText("Hi!", "en-GB");
+    recordText.getPayload().then(onSuccess, onError);
+});
 </script>
 </body>
 </html>

--- a/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecord_type_attribute.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecord_type_attribute.html
@@ -46,14 +46,24 @@ Authors:
 //==== PRIORITY P1
 //==== LABEL Check if NDEFRecord have type attribute with proper type and is readonly
 //==== SPEC_URL http://www.w3.org/TR/nfc/
-test(function () {
-    var record, recordText;
+var t = async_test(document.title, {timeout: 10000}), onSuccess, onError, record, recordText;
+
+t.step(function () {
+    onError = t.step_func(function (error) {
+        assert_unreached("getPayload() error callback was invoked: " + error.name + " msg: " + error.message);
+    });
+
+    onSuccess = t.step_func(function (payload) {
+        record = new NDEFRecord(recordText.tnf, recordText.type, payload, recordText.id);
+        assert_true("type" in record, "NDEFRecord.type exists");
+        assert_equals(record.type, recordText.type, "NDEFRecord.type init value");
+        assert_equals(typeof record.type, "string", "NDEFRecord.type attribute of type");
+        check_readonly(record, "type", record.type, "string", "dummy");
+        t.done();
+    });
     recordText = new NDEFRecordText("Hi!", "en-GB");
-    record = new NDEFRecord(recordText.tnf, recordText.type);
-    assert_own_property(record, "type", "NDEFRecord own type prorerty");
-    asset_equals(typeof record.type, "string", "NDEFRecord.type attribute of type");
-    check_readonly(record, "type", record.type, "string", "dummy");
-}, document.title);
+    recordText.getPayload().then(onSuccess, onError);
+});
 </script>
 </body>
 </html>

--- a/webapi/webapi-nfc-w3c-tests/nfc/NFCPeerEvent_peer_attribute.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NFCPeerEvent_peer_attribute.html
@@ -38,19 +38,40 @@ Authors:
 <script type="text/javascript" src="support/unitcommon.js"></script>
 <script type="text/javascript" src="support/nfc_common.js"></script>
 </head>
-
 <body>
+<p>Test step:</p>
+<p>Tap other NFC enabled device to the NFC Manager.</p>
 <div id="log"></div>
 <script>
 //==== TEST: NFCPeerEvent_peer_attribute
 //==== PRIORITY P1
 //==== LABEL Check if NFCPeerEvent have peer attribute with proper type and is readonly
 //==== SPEC_URL http://www.w3.org/TR/nfc/
-test(function () {
-    assert_true("peer" in NFCPeerEvent, "peer attribute exists");
-    assert_equals(typeof NFCPeerEvent.peer, "object", "peer attribute of type");
-    check_readonly(NFCPeerEvent, "peer", NFCPeerEvent.peer, "object", "null");
-}, document.title);
+setup({timeout: 60000});
+
+async_test(function (t) {
+    onError = t.step_func(function (error) {
+        assert_unreached("startPoll() error callback was invoked: " + error.name + " msg: " + error.message);
+        t.done();
+    });
+
+    onSuccess = function () {
+       //After NFC manager start polling, then peer device can be detected.
+    }
+
+    function peerFound(e) {
+        t.step(function () {
+            assert_true("peer" in e, "peer attribute exists");
+            assert_equals(typeof e.peer, "object", "peer attribute of type");
+            check_readonly(e, "peer", e.peer, "object", "null");
+        });
+        t.done();
+    }
+
+    navigator.nfc.startPoll().then(onSuccess, onError); 
+    navigator.nfc.addEventListener('peerfound', peerFound);    
+}, document.title, {timeout: 60000});
 </script>
+
 </body>
 </html>

--- a/webapi/webapi-nfc-w3c-tests/nfc/NFCPeer_onmessageread_attribute.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NFCPeer_onmessageread_attribute.html
@@ -38,18 +38,38 @@ Authors:
 <script type="text/javascript" src="support/unitcommon.js"></script>
 <script type="text/javascript" src="support/nfc_common.js"></script>
 </head>
-
 <body>
+<p>Test step:</p>
+<p>Tap other NFC enabled device to the NFC Manager.</p>
 <div id="log"></div>
 <script>
 //==== TEST: NFCPeer_onmessageread_attribute
 //==== PRIORITY P1
 //==== LABEL Check if NFCPeer have onmessageread attribute with proper type
 //==== SPEC_URL http://www.w3.org/TR/nfc/
-test(function () {
-    assert_true("onmessageread" in NFCPeerEvent.peer, "onmessageread attribute exists");
-    assert_equals(typeof NFCPeerEvent.peer.onmessageread, "object", "onmessageread attribute of type");
-}, document.title);
+setup({timeout: 60000});
+
+async_test(function (t) {
+    onError = t.step_func(function (error) {
+        assert_unreached("startPoll() error callback was invoked: " + error.name + " msg: " + error.message);
+        t.done();
+    });
+
+    onSuccess = function () {
+       //After NFC manager start polling, then peer device can be detected.
+    }
+
+    function peerFound (e) {
+        t.step(function () {
+            assert_true("onmessageread" in e.peer, "onmessageread attribute exists");
+            assert_equals(typeof e.peer.onmessageread, "object", "onmessageread attribute of type");
+        });
+        t.done();              
+    }
+
+    navigator.nfc.addEventListener('peerfound', peerFound);
+    navigator.nfc.startPoll().then(onSuccess, onError);
+}, document.title, {timeout: 60000}); 
 </script>
 </body>
 </html>

--- a/webapi/webapi-nfc-w3c-tests/nfc/NFCPeer_sendNDEF.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NFCPeer_sendNDEF.html
@@ -38,18 +38,38 @@ Authors:
 <script type="text/javascript" src="support/unitcommon.js"></script>
 <script type="text/javascript" src="support/nfc_common.js"></script>
 </head>
-
 <body>
+<p>Test step:</p>
+<p>Tap other NFC enabled device to the NFC Manager.</p>
 <div id="log"></div>
 <script>
 //==== TEST: NFCPeer_sendNDEF
 //==== PRIORITY P1
 //==== LABEL Check if NFCPeer::sendNDEF() exists
 //==== SPEC_URL http://www.w3.org/TR/nfc/
-test(function () {
-    assert_true("sendNDEF" in NFCPeerEvent.peer, "Check if NFCPeer.sendNDEF() method exists");
-    check_method_exists(NFCPeerEvent.peer, "sendNDEF");
-}, document.title);
+setup({timeout: 60000});
+
+async_test(function (t) {
+    onError = t.step_func(function (error) {
+        assert_unreached("startPoll() error callback was invoked: " + error.name + " msg: " + error.message);
+        t.done();
+    });
+
+    onSuccess = function () {
+       //After NFC manager start polling, then peer device can be detected.
+    }
+
+    function peerFound (e) {
+        t.step(function () {
+            assert_true("sendNDEF" in e.peer, "NFCPeer.sendNDEF() method exists");
+            check_method_exists(e.peer, "sendNDEF");
+        });
+        t.done();                
+    }
+
+    navigator.nfc.addEventListener('peerfound', peerFound);
+    navigator.nfc.startPoll().then(onSuccess, onError);
+}, document.title, {timeout: 60000});
 </script>
 </body>
 </html>

--- a/webapi/webapi-nfc-w3c-tests/nfc/NFCPeer_startHandover.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NFCPeer_startHandover.html
@@ -38,18 +38,38 @@ Authors:
 <script type="text/javascript" src="support/unitcommon.js"></script>
 <script type="text/javascript" src="support/nfc_common.js"></script>
 </head>
-
 <body>
+<p>Test step:</p>
+<p>Tap other NFC enabled device to the NFC Manager.</p>
 <div id="log"></div>
 <script>
 //==== TEST: NFCPeer_startHandover
 //==== PRIORITY P1
 //==== LABEL Check if NFCPeer::startHandover() exists
 //==== SPEC_URL http://www.w3.org/TR/nfc/
-test(function () {
-    assert_true("startHandover" in NFCPeerEvent.peer, "Check if NFCPeer.startHandover() method exists");
-    check_method_exists(NFCPeerEvent.peer, "startHandover");
-}, document.title);
+setup({timeout: 60000});
+
+async_test(function (t) {
+    onError = t.step_func(function (error) {
+        assert_unreached("startPoll() error callback was invoked: " + error.name + " msg: " + error.message);
+        t.done();
+    });
+
+    onSuccess = function () {
+       //After NFC manager start polling, then peer device can be detected.
+    }
+
+    function peerFound (e) {
+        t.step(function () {
+            assert_true("startHandover" in e.peer, "NFCPeer.startHandover() method exists");
+            check_method_exists(e.peer, "startHandover");
+        });
+        t.done();               
+    }
+
+    navigator.nfc.addEventListener('peerfound', peerFound);
+    navigator.nfc.startPoll().then(onSuccess, onError);
+}, document.title, {timeout: 60000});
 </script>
 </body>
 </html>

--- a/webapi/webapi-nfc-w3c-tests/nfc/NFCTagEvent_tag_attribute.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NFCTagEvent_tag_attribute.html
@@ -38,19 +38,40 @@ Authors:
 <script type="text/javascript" src="support/unitcommon.js"></script>
 <script type="text/javascript" src="support/nfc_common.js"></script>
 </head>
-
 <body>
+<p>Test step:</p>
+<p>Tap NFC tag to the NFC Manager.</p>
 <div id="log"></div>
 <script>
 //==== TEST: NFCTagEvent_tag_attribute
 //==== PRIORITY P1
 //==== LABEL Check if NFCTagEvent have tag attribute with proper type and is readonly
 //==== SPEC_URL http://www.w3.org/TR/nfc/
-test(function () {
-    assert_true("tag" in NFCTagEvent, "tag attribute exists");
-    assert_equals(typeof NFCTagEvent.tag, "object", "tag attribute of type");
-    check_readonly(NFCTagEvent, "tag", NFCTagEvent.tag, "object", "null");
-}, document.title);
+setup({timeout: 60000});
+
+async_test(function (t) {
+    
+    onError = t.step_func(function (error) {
+        assert_unreached("startPoll() error callback was invoked: " + error.name + " msg: " + error.message);
+        t.done();
+    });
+
+    onSuccess = function () { 
+       //After NFC manager start polling, then NFC tag can be detected.
+    }
+
+    function tagFound (e) {
+        t.step(function () {
+            assert_true("tag" in e, "tag attribute exists");
+            assert_equals(typeof e.tag, "object", "tag attribute of type");
+            check_readonly(e, "tag", e.tag, "object", "null");
+        });
+        t.done();
+    }
+
+    navigator.nfc.addEventListener('tagfound', tagFound);
+    navigator.nfc.startPoll().then(onSuccess, onError);
+}, document.title, {timeout: 60000});
 </script>
 </body>
 </html>

--- a/webapi/webapi-nfc-w3c-tests/nfc/NFCTag_readNDEF.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NFCTag_readNDEF.html
@@ -38,18 +38,38 @@ Authors:
 <script type="text/javascript" src="support/unitcommon.js"></script>
 <script type="text/javascript" src="support/nfc_common.js"></script>
 </head>
-
 <body>
+<p>Test step:</p>
+<p>Tap NFC tag to the NFC Manager.</p>
 <div id="log"></div>
 <script>
 //==== TEST: NFCTag_readNDEF
 //==== PRIORITY P1
 //==== LABEL Check if NFCTag::readNDEF() exists
 //==== SPEC_URL http://www.w3.org/TR/nfc/
-test(function () {
-    assert_true("readNDEF" in NFCTagEvent.tag, "Check if NFCTag.readNDEF() method exists");
-    check_method_exists(NFCTagEvent.tag, "readNDEF");
-}, document.title);
+setup({timeout: 60000});
+
+async_test(function (t) {
+    onError = t.step_func(function (error) {
+        assert_unreached("startPoll() error callback was invoked: " + error.name + " msg: " + error.message);
+        t.done();
+    });
+
+    onSuccess = function () { 
+       //After NFC manager start polling, then NFC tag can be detected.
+    }
+
+    function tagFound (e) {
+        t.step(function () {
+            assert_true("readNDEF" in e.tag, "NFCTag.readNDEF() method exists");
+            check_method_exists(e.tag, "readNDEF");
+        });
+        t.done();
+    }
+
+    navigator.nfc.addEventListener('tagfound', tagFound);
+    navigator.nfc.startPoll().then(onSuccess, onError);
+}, document.title, {timeout: 60000});
 </script>
 </body>
 </html>

--- a/webapi/webapi-nfc-w3c-tests/nfc/NFCTag_writeNDEF.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NFCTag_writeNDEF.html
@@ -38,18 +38,38 @@ Authors:
 <script type="text/javascript" src="support/unitcommon.js"></script>
 <script type="text/javascript" src="support/nfc_common.js"></script>
 </head>
-
 <body>
+<p>Test step:</p>
+<p>Tap NFC tag to the NFC Manager.</p>
 <div id="log"></div>
 <script>
 //==== TEST: NFCTag_writeNDEF
 //==== PRIORITY P1
 //==== LABEL Check if NFCTag::writeNDEF() exists
 //==== SPEC_URL http://www.w3.org/TR/nfc/
-test(function () {
-    assert_true("writeNDEF" in NFCTagEvent.tag, "Check if NFCTag.writeNDEF() method exists");
-    check_method_exists(NFCTagEvent.tag, "writeNDEF");
-}, document.title);
+setup({timeout: 60000});
+
+async_test(function (t) {
+    onError = t.step_func(function (error) {
+        assert_unreached("startPoll() error callback was invoked: " + error.name + " msg: " + error.message);
+        t.done();
+    });
+
+    onSuccess = function () { 
+       //After NFC manager start polling, then NFC tag can be detected.
+    }
+
+    function tagFound (e) {
+        t.step(function () {
+            assert_true("writeNDEF" in e.tag, "NFCTag.writeNDEF() method exists");
+            check_method_exists(e.tag, "writeNDEF");
+        });
+        t.done();
+    }
+
+    navigator.nfc.addEventListener('tagfound', tagFound);
+    navigator.nfc.startPoll().then(onSuccess, onError);
+}, document.title, {timeout: 60000});
 </script>
 </body>
 </html>

--- a/webapi/webapi-nfc-w3c-tests/tests.full.xml
+++ b/webapi/webapi-nfc-w3c-tests/tests.full.xml
@@ -18,7 +18,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check NDEFMessage constructor works with byte array" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="p1" id="NDEFMessage_constructor_bytes">
+      <testcase purpose="Check NDEFMessage constructor works with byte array" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="p1" id="NDEFMessage_constructor_bytes">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFMessage_constructor_bytes.html</test_script_entry>
         </description>
@@ -42,7 +42,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if NDEFMessageEvent have message attribute with proper type and is readonly" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="p1" id="NDEFMessageEvent_message_attribute">
+      <testcase purpose="Check if NDEFMessageEvent have message attribute with proper type and is readonly" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="manual" priority="p1" id="NDEFMessageEvent_message_attribute">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFMessageEvent_message_attribute.html</test_script_entry>
         </description>
@@ -54,7 +54,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if NDEFMessage::getBytes() exists" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="p1" id="NDEFMessage_getBytes">
+      <testcase purpose="Check if NDEFMessage::getBytes() exists" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="p1" id="NDEFMessage_getBytes">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFMessage_getBytes.html</test_script_entry>
         </description>
@@ -66,7 +66,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if attribute records of NDEFMessage exists, has type Array and is readonly" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFMessage_records_attribute">
+      <testcase purpose="Check if attribute records of NDEFMessage exists, has type Array and is readonly" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFMessage_records_attribute">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFMessage_records_attribute.html</test_script_entry>
         </description>
@@ -90,7 +90,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check NDEFRecord constructor works with byte tnf, DOMString type parameters" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecord_constructor_tnf_type">
+      <testcase purpose="Check NDEFRecord constructor works with byte tnf, DOMString type parameters" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecord_constructor_tnf_type">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecord_constructor_tnf_type.html</test_script_entry>
         </description>
@@ -102,7 +102,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check NDEFRecord constructor works with byte tnf, DOMString type, byte [] payload parameters" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecord_constructor_tnf_type_payload">
+      <testcase purpose="Check NDEFRecord constructor works with byte tnf, DOMString type, byte [] payload parameters" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecord_constructor_tnf_type_payload">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecord_constructor_tnf_type_payload.html</test_script_entry>
         </description>
@@ -114,7 +114,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check NDEFRecord constructor works with byte tnf, DOMString type, byte [] payload, DOMString id parameters" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="p1" id="NDEFRecord_constructor_tnf_type_payload_id">
+      <testcase purpose="Check NDEFRecord constructor works with byte tnf, DOMString type, byte [] payload, DOMString id parameters" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="p1" id="NDEFRecord_constructor_tnf_type_payload_id">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecord_constructor_tnf_type_payload_id.html</test_script_entry>
         </description>
@@ -126,7 +126,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if method NDEFRecord::getPayload() exists" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecord_getPayload">
+      <testcase purpose="Check if method NDEFRecord::getPayload() exists" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecord_getPayload">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecord_getPayload.html</test_script_entry>
         </description>
@@ -138,7 +138,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if NDEFRecord have id attribute with proper id and is readonly" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecord_id_attribute">
+      <testcase purpose="Check if NDEFRecord have id attribute with proper id and is readonly" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecord_id_attribute">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecord_id_attribute.html</test_script_entry>
         </description>
@@ -162,7 +162,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if NDEFRecordMedia have mimeType attribute with proper type and is readonly" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordMedia_mimeType_attribute">
+      <testcase purpose="Check if NDEFRecordMedia have mimeType attribute with proper type and is readonly" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordMedia_mimeType_attribute">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordMedia_mimeType_attribute.html</test_script_entry>
         </description>
@@ -174,7 +174,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if NDEFRecord have recordType attribute with proper type and is readonly" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecord_recordType_attribute">
+      <testcase purpose="Check if NDEFRecord have recordType attribute with proper type and is readonly" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecord_recordType_attribute">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecord_recordType_attribute.html</test_script_entry>
         </description>
@@ -186,7 +186,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if NDEFRecord have tnf attribute with proper type and is readonly" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecord_tnf_attribute">
+      <testcase purpose="Check if NDEFRecord have tnf attribute with proper type and is readonly" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecord_tnf_attribute">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecord_tnf_attribute.html</test_script_entry>
         </description>
@@ -198,7 +198,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if NDEFRecord have type attribute with proper type and is readonly" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecord_type_attribute">
+      <testcase purpose="Check if NDEFRecord have type attribute with proper type and is readonly" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecord_type_attribute">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecord_type_attribute.html</test_script_entry>
         </description>
@@ -210,7 +210,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if attribute action of NDEFRecordSmartPoster exists, has proper type and is readonly" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordSmartPoster_action_attribute">
+      <testcase purpose="Check if attribute action of NDEFRecordSmartPoster exists, has proper type and is readonly" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordSmartPoster_action_attribute">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_action_attribute.html</test_script_entry>
         </description>
@@ -234,7 +234,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check NDEFRecordSmartPoster constructor works with DOMString uri, NDEFRecordText［］titles parameters" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordSmartPoster_constructor_uri_titles">
+      <testcase purpose="Check NDEFRecordSmartPoster constructor works with DOMString uri, NDEFRecordText［］titles parameters" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordSmartPoster_constructor_uri_titles">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_constructor_uri_titles.html</test_script_entry>
         </description>
@@ -246,7 +246,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check NDEFRecordSmartPoster constructor works with DOMString uri, NDEFRecordText［］titles, DOMString action parameters" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordSmartPoster_constructor_uri_titles_action">
+      <testcase purpose="Check NDEFRecordSmartPoster constructor works with DOMString uri, NDEFRecordText［］titles, DOMString action parameters" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordSmartPoster_constructor_uri_titles_action">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_constructor_uri_titles_action.html</test_script_entry>
         </description>
@@ -258,7 +258,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check NDEFRecordSmartPoster constructor works with DOMString uri, NDEFRecordText［］titles, DOMString action, NDEFRecordMedia［］icons parameters" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordSmartPoster_constructor_uri_titles_action_icons">
+      <testcase purpose="Check NDEFRecordSmartPoster constructor works with DOMString uri, NDEFRecordText［］titles, DOMString action, NDEFRecordMedia［］icons parameters" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordSmartPoster_constructor_uri_titles_action_icons">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_constructor_uri_titles_action_icons.html</test_script_entry>
         </description>
@@ -270,7 +270,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check NDEFRecordSmartPoster constructor works with DOMString uri, NDEFRecordText［］titles, DOMString action, NDEFRecordMedia［］icons, unsigned long targetSize parameters" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordSmartPoster_constructor_uri_titles_action_icons_targetSize">
+      <testcase purpose="Check NDEFRecordSmartPoster constructor works with DOMString uri, NDEFRecordText［］titles, DOMString action, NDEFRecordMedia［］icons, unsigned long targetSize parameters" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordSmartPoster_constructor_uri_titles_action_icons_targetSize">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_constructor_uri_titles_action_icons_targetSize.html</test_script_entry>
         </description>
@@ -282,7 +282,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check NDEFRecordSmartPoster constructor works with DOMString uri, NDEFRecordText［］titles, DOMString action, NDEFRecordMedia［］icons, unsigned long targetSize, DOMString targetMIME parameters" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordSmartPoster_constructor_uri_titles_action_icons_targetSize_targetMIME">
+      <testcase purpose="Check NDEFRecordSmartPoster constructor works with DOMString uri, NDEFRecordText［］titles, DOMString action, NDEFRecordMedia［］icons, unsigned long targetSize, DOMString targetMIME parameters" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordSmartPoster_constructor_uri_titles_action_icons_targetSize_targetMIME">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_constructor_uri_titles_action_icons_targetSize_targetMIME.html</test_script_entry>
         </description>
@@ -294,7 +294,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if attribute icons of NDEFRecordSmartPoster exists, has proper type and is readonly" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordSmartPoster_icons_attribute">
+      <testcase purpose="Check if attribute icons of NDEFRecordSmartPoster exists, has proper type and is readonly" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordSmartPoster_icons_attribute">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_icons_attribute.html</test_script_entry>
         </description>
@@ -306,7 +306,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if attribute targetMIME of NDEFRecordSmartPoster exists, has proper type and is readonly" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordSmartPoster_targetMIME_attribute">
+      <testcase purpose="Check if attribute targetMIME of NDEFRecordSmartPoster exists, has proper type and is readonly" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordSmartPoster_targetMIME_attribute">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_targetMIME_attribute.html</test_script_entry>
         </description>
@@ -318,7 +318,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if attribute targetSize of NDEFRecordSmartPoster exists, has proper type and is readonly" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordSmartPoster_targetSize_attribute">
+      <testcase purpose="Check if attribute targetSize of NDEFRecordSmartPoster exists, has proper type and is readonly" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordSmartPoster_targetSize_attribute">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_targetSize_attribute.html</test_script_entry>
         </description>
@@ -330,7 +330,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if attribute titles of NDEFRecordSmartPoster exists, has type object and is readonly" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordSmartPoster_titles_attribute">
+      <testcase purpose="Check if attribute titles of NDEFRecordSmartPoster exists, has type object and is readonly" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordSmartPoster_titles_attribute">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_titles_attribute.html</test_script_entry>
         </description>
@@ -342,7 +342,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if attribute uri of NDEFRecordSmartPoster exists, has type DOMString and is readonly" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordSmartPoster_uri_attribute">
+      <testcase purpose="Check if attribute uri of NDEFRecordSmartPoster exists, has type DOMString and is readonly" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordSmartPoster_uri_attribute">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_uri_attribute.html</test_script_entry>
         </description>
@@ -366,7 +366,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check NDEFRecordText constructor works with DOMString text, DOMString languageCode parameters" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordText_constructor_text_languageCode">
+      <testcase purpose="Check NDEFRecordText constructor works with DOMString text, DOMString languageCode parameters" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordText_constructor_text_languageCode">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordText_constructor_text_languageCode.html</test_script_entry>
         </description>
@@ -378,7 +378,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check NDEFRecordText constructor works with DOMString text, DOMString languageCode, DOMString encoding parameters" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordText_constructor_text_languageCode_encoding">
+      <testcase purpose="Check NDEFRecordText constructor works with DOMString text, DOMString languageCode, DOMString encoding parameters" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordText_constructor_text_languageCode_encoding">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordText_constructor_text_languageCode_encoding.html</test_script_entry>
         </description>
@@ -390,7 +390,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if attribute encoding of NDEFRecordText exists, has type DOMString and is readonly" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordText_encoding_attribute">
+      <testcase purpose="Check if attribute encoding of NDEFRecordText exists, has type DOMString and is readonly" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordText_encoding_attribute">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordText_encoding_attribute.html</test_script_entry>
         </description>
@@ -402,7 +402,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if attribute languageCode of NDEFRecordText exists, has type DOMString and is readonly" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordText_languageCode_attribute">
+      <testcase purpose="Check if attribute languageCode of NDEFRecordText exists, has type DOMString and is readonly" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordText_languageCode_attribute">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordText_languageCode_attribute.html</test_script_entry>
         </description>
@@ -414,7 +414,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if attribute text of NDEFRecordText exists, has type DOMString and is readonly" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordText_text_attribute">
+      <testcase purpose="Check if attribute text of NDEFRecordText exists, has type DOMString and is readonly" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordText_text_attribute">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordText_text_attribute.html</test_script_entry>
         </description>
@@ -438,7 +438,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if NDEFRecordURI have uri attribute with proper type and is readonly" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordURI_uri_attribute">
+      <testcase purpose="Check if NDEFRecordURI have uri attribute with proper type and is readonly" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NDEFRecordURI_uri_attribute">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordURI_uri_attribute.html</test_script_entry>
         </description>
@@ -450,7 +450,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if NFCManager have onpeerfound attribute with proper type" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCManager_onpeerfound_attribute">
+      <testcase purpose="Check if NFCManager have onpeerfound attribute with proper type" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCManager_onpeerfound_attribute">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCManager_onpeerfound_attribute.html</test_script_entry>
         </description>
@@ -462,7 +462,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if NFCManager have onpeerlost attribute with proper type" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCManager_onpeerlost_attribute">
+      <testcase purpose="Check if NFCManager have onpeerlost attribute with proper type" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCManager_onpeerlost_attribute">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCManager_onpeerlost_attribute.html</test_script_entry>
         </description>
@@ -474,7 +474,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if NFCManager have onpollstart attribute with proper type" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCManager_onpollstart_attribute">
+      <testcase purpose="Check if NFCManager have onpollstart attribute with proper type" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCManager_onpollstart_attribute">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCManager_onpollstart_attribute.html</test_script_entry>
         </description>
@@ -486,7 +486,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if NFCManager have onpollstop attribute with proper type" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCManager_onpollstop_attribute">
+      <testcase purpose="Check if NFCManager have onpollstop attribute with proper type" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCManager_onpollstop_attribute">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCManager_onpollstop_attribute.html</test_script_entry>
         </description>
@@ -498,7 +498,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if NFCManager have onpoweroff attribute with proper type" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCManager_onpoweroff_attribute">
+      <testcase purpose="Check if NFCManager have onpoweroff attribute with proper type" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCManager_onpoweroff_attribute">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCManager_onpoweroff_attribute.html</test_script_entry>
         </description>
@@ -510,7 +510,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if NFCManager have onpoweron attribute with proper type" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCManager_onpoweron_attribute">
+      <testcase purpose="Check if NFCManager have onpoweron attribute with proper type" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCManager_onpoweron_attribute">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCManager_onpoweron_attribute.html</test_script_entry>
         </description>
@@ -522,7 +522,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if NFCManager have ontagfound attribute with proper type" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCManager_ontagfound_attribute">
+      <testcase purpose="Check if NFCManager have ontagfound attribute with proper type" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCManager_ontagfound_attribute">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCManager_ontagfound_attribute.html</test_script_entry>
         </description>
@@ -534,7 +534,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if NFCManager have ontaglost attribute with proper type" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCManager_ontaglost_attribute">
+      <testcase purpose="Check if NFCManager have ontaglost attribute with proper type" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCManager_ontaglost_attribute">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCManager_ontaglost_attribute.html</test_script_entry>
         </description>
@@ -546,7 +546,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if NFCManager have polling attribute with proper type" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCManager_polling_attribute">
+      <testcase purpose="Check if NFCManager have polling attribute with proper type" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCManager_polling_attribute">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCManager_polling_attribute.html</test_script_entry>
         </description>
@@ -570,7 +570,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if method NFCManager::powerOff() exists" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCManager_powerOff">
+      <testcase purpose="Check if method NFCManager::powerOff() exists" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCManager_powerOff">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCManager_powerOff.html</test_script_entry>
         </description>
@@ -582,7 +582,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if method NFCManager::powerOn() exists" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCManager_powerOn">
+      <testcase purpose="Check if method NFCManager::powerOn() exists" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCManager_powerOn">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCManager_powerOn.html</test_script_entry>
         </description>
@@ -594,7 +594,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if method NFCManager::startPoll() exists" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCManager_startPoll">
+      <testcase purpose="Check if method NFCManager::startPoll() exists" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCManager_startPoll">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCManager_startPoll.html</test_script_entry>
         </description>
@@ -606,7 +606,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if method NFCManager::stopPoll() exists" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCManager_stopPoll">
+      <testcase purpose="Check if method NFCManager::stopPoll() exists" type="compliance" status="approved" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCManager_stopPoll">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCManager_stopPoll.html</test_script_entry>
         </description>
@@ -618,7 +618,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if NFCPeerEvent have peer attribute with proper type and is readonly" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCPeerEvent_peer_attribute">
+      <testcase purpose="Check if NFCPeerEvent have peer attribute with proper type and is readonly" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="manual" priority="P1" id="NFCPeerEvent_peer_attribute">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCPeerEvent_peer_attribute.html</test_script_entry>
         </description>
@@ -630,7 +630,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if NFCPeer have onmessageread attribute with proper type" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCPeer_onmessageread_attribute">
+      <testcase purpose="Check if NFCPeer have onmessageread attribute with proper type" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="manual" priority="P1" id="NFCPeer_onmessageread_attribute">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCPeer_onmessageread_attribute.html</test_script_entry>
         </description>
@@ -642,7 +642,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if NFCPeer::sendNDEF() exists" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCPeer_sendNDEF">
+      <testcase purpose="Check if NFCPeer::sendNDEF() exists" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="manual" priority="P1" id="NFCPeer_sendNDEF">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCPeer_sendNDEF.html</test_script_entry>
         </description>
@@ -654,7 +654,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if NFCPeer::startHandover() exists" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCPeer_startHandover">
+      <testcase purpose="Check if NFCPeer::startHandover() exists" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="manual" priority="P1" id="NFCPeer_startHandover">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCPeer_startHandover.html</test_script_entry>
         </description>
@@ -666,7 +666,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if NFCTagEvent have tag attribute with proper type and is readonly" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCTagEvent_tag_attribute">
+      <testcase purpose="Check if NFCTagEvent have tag attribute with proper type and is readonly" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="manual" priority="P1" id="NFCTagEvent_tag_attribute">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCTagEvent_tag_attribute.html</test_script_entry>
         </description>
@@ -678,7 +678,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if NFCTag::readNDEF() exists" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCTag_readNDEF">
+      <testcase purpose="Check if NFCTag::readNDEF() exists" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="manual" priority="P1" id="NFCTag_readNDEF">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCTag_readNDEF.html</test_script_entry>
         </description>
@@ -690,7 +690,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if NFCTag::writeNDEF() exists" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="auto" priority="P1" id="NFCTag_writeNDEF">
+      <testcase purpose="Check if NFCTag::writeNDEF() exists" type="compliance" status="designed" component="WebAPI/Communication/NFC" execution_type="manual" priority="P1" id="NFCTag_writeNDEF">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCTag_writeNDEF.html</test_script_entry>
         </description>

--- a/webapi/webapi-nfc-w3c-tests/tests.xml
+++ b/webapi/webapi-nfc-w3c-tests/tests.xml
@@ -11,9 +11,24 @@
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/Navigator_nfc_attribute.html</test_script_entry>
         </description>
       </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFMessage_constructor_bytes" purpose="Check NDEFMessage constructor works with byte array">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFMessage_constructor_bytes.html</test_script_entry>
+        </description>
+      </testcase>
       <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFMessage_constructor_records" purpose="Check NDEFMessage constructor works with NDEF records array">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFMessage_constructor_records.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFMessage_getBytes" purpose="Check if NDEFMessage::getBytes() exists">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFMessage_getBytes.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFMessage_records_attribute" purpose="Check if attribute records of NDEFMessage exists, has type Array and is readonly">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFMessage_records_attribute.html</test_script_entry>
         </description>
       </testcase>
       <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecord_constructor_tnf" purpose="Check NDEFRecord constructor works with byte tnf parameter">
@@ -21,9 +36,59 @@
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecord_constructor_tnf.html</test_script_entry>
         </description>
       </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecord_constructor_tnf_type" purpose="Check NDEFRecord constructor works with byte tnf, DOMString type parameters">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecord_constructor_tnf_type.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecord_constructor_tnf_type_payload" purpose="Check NDEFRecord constructor works with byte tnf, DOMString type, byte [] payload parameters">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecord_constructor_tnf_type_payload.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecord_constructor_tnf_type_payload_id" purpose="Check NDEFRecord constructor works with byte tnf, DOMString type, byte [] payload, DOMString id parameters">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecord_constructor_tnf_type_payload_id.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecord_getPayload" purpose="Check if method NDEFRecord::getPayload() exists">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecord_getPayload.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecord_id_attribute" purpose="Check if NDEFRecord have id attribute with proper id and is readonly">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecord_id_attribute.html</test_script_entry>
+        </description>
+      </testcase>
       <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecordMedia_constructor" purpose="Check if NDEFRecordMedia constructor works">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordMedia_constructor.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecordMedia_mimeType_attribute" purpose="Check if NDEFRecordMedia have mimeType attribute with proper type and is readonly">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordMedia_mimeType_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecord_recordType_attribute" purpose="Check if NDEFRecord have recordType attribute with proper type and is readonly">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecord_recordType_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecord_tnf_attribute" purpose="Check if NDEFRecord have tnf attribute with proper type and is readonly">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecord_tnf_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecord_type_attribute" purpose="Check if NDEFRecord have type attribute with proper type and is readonly">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecord_type_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecordSmartPoster_action_attribute" purpose="Check if attribute action of NDEFRecordSmartPoster exists, has proper type and is readonly">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_action_attribute.html</test_script_entry>
         </description>
       </testcase>
       <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecordSmartPoster_constructor_uri" purpose="Check NDEFRecordSmartPoster constructor works with DOMString uri parameter">
@@ -31,9 +96,84 @@
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_constructor_uri.html</test_script_entry>
         </description>
       </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecordSmartPoster_constructor_uri_titles" purpose="Check NDEFRecordSmartPoster constructor works with DOMString uri, NDEFRecordText［］titles parameters">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_constructor_uri_titles.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecordSmartPoster_constructor_uri_titles_action" purpose="Check NDEFRecordSmartPoster constructor works with DOMString uri, NDEFRecordText［］titles, DOMString action parameters">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_constructor_uri_titles_action.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecordSmartPoster_constructor_uri_titles_action_icons" purpose="Check NDEFRecordSmartPoster constructor works with DOMString uri, NDEFRecordText［］titles, DOMString action, NDEFRecordMedia［］icons parameters">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_constructor_uri_titles_action_icons.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecordSmartPoster_constructor_uri_titles_action_icons_targetSize" purpose="Check NDEFRecordSmartPoster constructor works with DOMString uri, NDEFRecordText［］titles, DOMString action, NDEFRecordMedia［］icons, unsigned long targetSize parameters">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_constructor_uri_titles_action_icons_targetSize.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecordSmartPoster_constructor_uri_titles_action_icons_targetSize_targetMIME" purpose="Check NDEFRecordSmartPoster constructor works with DOMString uri, NDEFRecordText［］titles, DOMString action, NDEFRecordMedia［］icons, unsigned long targetSize, DOMString targetMIME parameters">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_constructor_uri_titles_action_icons_targetSize_targetMIME.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecordSmartPoster_icons_attribute" purpose="Check if attribute icons of NDEFRecordSmartPoster exists, has proper type and is readonly">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_icons_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecordSmartPoster_targetMIME_attribute" purpose="Check if attribute targetMIME of NDEFRecordSmartPoster exists, has proper type and is readonly">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_targetMIME_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecordSmartPoster_targetSize_attribute" purpose="Check if attribute targetSize of NDEFRecordSmartPoster exists, has proper type and is readonly">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_targetSize_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecordSmartPoster_titles_attribute" purpose="Check if attribute titles of NDEFRecordSmartPoster exists, has type object and is readonly">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_titles_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecordSmartPoster_uri_attribute" purpose="Check if attribute uri of NDEFRecordSmartPoster exists, has type DOMString and is readonly">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordSmartPoster_uri_attribute.html</test_script_entry>
+        </description>
+      </testcase>
       <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecordText_constructor_text" purpose="Check NDEFRecordText constructor works with DOMString text parameter">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordText_constructor_text.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecordText_constructor_text_languageCode" purpose="Check NDEFRecordText constructor works with DOMString text, DOMString languageCode parameters">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordText_constructor_text_languageCode.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecordText_constructor_text_languageCode_encoding" purpose="Check NDEFRecordText constructor works with DOMString text, DOMString languageCode, DOMString encoding parameters">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordText_constructor_text_languageCode_encoding.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecordText_encoding_attribute" purpose="Check if attribute encoding of NDEFRecordText exists, has type DOMString and is readonly">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordText_encoding_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecordText_languageCode_attribute" purpose="Check if attribute languageCode of NDEFRecordText exists, has type DOMString and is readonly">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordText_languageCode_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecordText_text_attribute" purpose="Check if attribute text of NDEFRecordText exists, has type DOMString and is readonly">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordText_text_attribute.html</test_script_entry>
         </description>
       </testcase>
       <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecordURI_constructor" purpose="Check NDEFRecordURI constructor works">
@@ -41,9 +181,79 @@
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordURI_constructor.html</test_script_entry>
         </description>
       </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NDEFRecordURI_uri_attribute" purpose="Check if NDEFRecordURI have uri attribute with proper type and is readonly">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NDEFRecordURI_uri_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NFCManager_onpeerfound_attribute" purpose="Check if NFCManager have onpeerfound attribute with proper type">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCManager_onpeerfound_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NFCManager_onpeerlost_attribute" purpose="Check if NFCManager have onpeerlost attribute with proper type">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCManager_onpeerlost_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NFCManager_onpollstart_attribute" purpose="Check if NFCManager have onpollstart attribute with proper type">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCManager_onpollstart_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NFCManager_onpollstop_attribute" purpose="Check if NFCManager have onpollstop attribute with proper type">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCManager_onpollstop_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NFCManager_onpoweroff_attribute" purpose="Check if NFCManager have onpoweroff attribute with proper type">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCManager_onpoweroff_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NFCManager_onpoweron_attribute" purpose="Check if NFCManager have onpoweron attribute with proper type">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCManager_onpoweron_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NFCManager_ontagfound_attribute" purpose="Check if NFCManager have ontagfound attribute with proper type">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCManager_ontagfound_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NFCManager_ontaglost_attribute" purpose="Check if NFCManager have ontaglost attribute with proper type">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCManager_ontaglost_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NFCManager_polling_attribute" purpose="Check if NFCManager have polling attribute with proper type">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCManager_polling_attribute.html</test_script_entry>
+        </description>
+      </testcase>
       <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NFCManager_powered_attribute" purpose="Check if NFCManager have powered attribute with proper type">
         <description>
           <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCManager_powered_attribute.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NFCManager_powerOff" purpose="Check if method NFCManager::powerOff() exists">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCManager_powerOff.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NFCManager_powerOn" purpose="Check if method NFCManager::powerOn() exists">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCManager_powerOn.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NFCManager_startPoll" purpose="Check if method NFCManager::startPoll() exists">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCManager_startPoll.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Communication/NFC" execution_type="auto" id="NFCManager_stopPoll" purpose="Check if method NFCManager::stopPoll() exists">
+        <description>
+          <test_script_entry>/opt/webapi-nfc-w3c-tests/nfc/NFCManager_stopPoll.html</test_script_entry>
         </description>
       </testcase>
     </set>


### PR DESCRIPTION
- Change assert_own_property to assert_true
- Change 42 designed cases to approved
- Redesign several TCs
- Modify test description
- Failure analysis: NDEFRecord.id attribute of type expected "string" but got "object"

Impacted tests(approved): new 0, update 36, delete 0
Unit test platform: [Tizen IVI]
Unit test result summary: pass 49, fail 1, block 0
