### PR TITLE
Update 44 TCs for MediaRenderer

### DIFF
--- a/webapi/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html
+++ b/webapi/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html
@@ -67,17 +67,14 @@ navigator.mediaRenderer.onrendererfound = function (event) {
     test(function () {
       assert_true(name in event.renderer.controller, name + " attribute in MediaController");
       switch(type) {
+      case "object":
       case "boolean":
       case "number":
+      case "function":
         if(read == "readonly") {
           assert_readonly(event.renderer.controller, name, "expect attribute " + name + " cannot be changed but");
         }
-      case "function":
         assert_equals(typeof event.renderer.controller[name], type, name + " attribute of type");      
-        break;
-      case "object":
-        assert_equals(Object.prototype.toString.call(event.renderer.controller[name]), "[object Object]", name + " attribute of type");
-        assert_readonly(event.renderer.controller, name, "expect attribute " + name + " cannot be changed but");
         break;
       default:
         break;

--- a/webapi/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html
+++ b/webapi/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html
@@ -56,21 +56,8 @@ navigator.mediaRenderer.onrendererfound = function (eve) {
 
       test(function () {
         assert_true(name in event, name + " attribute in MediaControllerStatusEvent");
-        switch(type) {
-        case "boolean":
-        case "number":
-          if(read == "readonly") {
-            assert_readonly(event, name, "expect attribute " + name + " cannot be changed but");
-          }
-          assert_equals(typeof event[name], type, name + " attribute of type");      
-          break;
-        case "object":
-          assert_equals(Object.prototype.toString.call(event[name]), "[object Object]", name + " attribute of type");
-          assert_readonly(event, name, "expect attribute " + name + " cannot be changed but");
-          break;
-        default:
-          break;
-        }
+        assert_readonly(event, name, "expect attribute " + name + " cannot be changed but");
+        assert_equals(typeof event[name], type, name + " attribute of type");
       }, "Check if " + read + " MediaControllerStatusEvent." + name + " exists and type of " + type);
     });
     done();

--- a/webapi/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html
+++ b/webapi/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html
@@ -56,7 +56,7 @@ navigator.mediaRenderer.onrendererfound = function (event) {
     ["string", "iconURL", "readonly"],
     ["string", "deviceType", "readonly"],
     ["string", "protocolInfo", "readonly"],
-    ["object", "controller", "readonly"],
+    ["mediaController", "controller", "readonly"],
     ["function", "openURI", ""],
     ["function", "prefetchURI", ""],
     ["function", "cancel", ""]
@@ -69,15 +69,15 @@ navigator.mediaRenderer.onrendererfound = function (event) {
       assert_true(name in event.renderer, name + " attribute in MediaRenderer");
       switch(type) {
       case "string":
+      case "function":
         if(read == "readonly") {
           assert_readonly(event.renderer, name, "expect attribute " + name + " cannot be changed but");
         }
-      case "function":
         assert_equals(typeof event.renderer[name], type, name + " attribute of type");      
         break;
-      case "object":
-        assert_equals(Object.prototype.toString.call(event.renderer[name]), "[object Object]", name + " attribute of type");
-        assert_readonly(event.renderer, name, "expect attribute " + name + " cannot be changed but");
+      case "mediaController":
+        assert_equals(Object.prototype.toString.call(event.renderer.controller[name]), "[object MediaController]", name + " attribute of type");
+        assert_readonly(event.renderer.controller, name, "expect attribute " + name + " cannot be changed but");
         break;
       default:
         break;

--- a/webapi/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererEvent_renderer.html
+++ b/webapi/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererEvent_renderer.html
@@ -40,11 +40,11 @@ Authors:
 <script>
 
 var t = async_test("Check if the readonly attribute renderer of MediaRendererEvent exists and type of object");
-setup({timeout: 20000});
+setup({timeout: 30000});
 
 navigator.mediaRenderer.onrendererfound = t.step_func(function (event) {
   assert_true("renderer" in event, "renderer attribute in MediaRendererEvent");
-  assert_equals(Object.prototype.toString.call(event.renderer), "[object Object]", "renderer attribute of type");
+  assert_equals(typeof (event.renderer), "object", "renderer attribute of type");
   assert_readonly(event, "renderer", "expect attribute renderer cannot be changed but");
   t.done();
 });

--- a/webapi/webapi-mediarenderer-xwalk-tests/tests.full.xml
+++ b/webapi/webapi-mediarenderer-xwalk-tests/tests.full.xml
@@ -231,7 +231,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if readonly MediaRenderer.controller exists and type of object" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaRenderer_controller">
+      <testcase purpose="Check if readonly MediaRenderer.controller exists and type of mediaController" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaRenderer_controller">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
         </description>

--- a/webapi/webapi-mediarenderer-xwalk-tests/tests.xml
+++ b/webapi/webapi-mediarenderer-xwalk-tests/tests.xml
@@ -98,7 +98,7 @@
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_controller" purpose="Check if readonly MediaRenderer.controller exists and type of object" onload_delay="30">
+      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_controller" purpose="Check if readonly MediaRenderer.controller exists and type of mediaController" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
         </description>


### PR DESCRIPTION
- Update 44 TCs for MediaRenderer
- Failure analysis: The statuschanged event and rendererlost event cannot be fired

Impacted tests(approved): new 0, update 44, delete 0
Unit test platform: [Tizen IVI]
Unit test result summary: pass 37, fail 1, block 6
