### PR TITLE
[webapi][XWALK-2313]  Adding set landscape-primary orientation after 100ms for screenorientation

### DIFF
--- a/webapi/tct-screenorientation-w3c-tests/screenorientation/window_onorientationchange_basic.html
+++ b/webapi/tct-screenorientation-w3c-tests/screenorientation/window_onorientationchange_basic.html
@@ -39,7 +39,7 @@ Authors:
 <script src="../resources/testharnessreport.js"></script>
 <div id="log"></div>
 <script>
-var t = async_test("Test checks that window.onorientationchange is invoked when orientation changes", { timeout: 2000});
+var t = async_test("Test checks that window.onorientationchange is invoked when orientation changes", { timeout: 1000});
 
 t.step(function () {
   screen.unlockOrientation();
@@ -51,10 +51,7 @@ window.onorientationchange = t.step_func(function(e) {
 });
 
 setTimeout(function () {
-  t.step(function () {
-    assert_unreached("unexpected timeout callback");
-  });
-  t.done();
-}, 1000)
+  screen.lockOrientation("landscape-primary");
+}, 100)
 </script>
 


### PR DESCRIPTION
- When lock orientation to "portrait-primary", if can't fire event, after 100 ms, lock orientation to "landscape-primary"
- Failure reason: We test on IVI, onorientationchange event can't invoked.

Impacted TCs num(approved): New 0, Update 1, Delete 0
Unit test Platform: Tizen IVI
Tizen test result summary: Pass 0, Fail 1, Blocked 0
