### PR TITLE
[webapi][bluetooth] change isConnected attribute check in BluetoothDevic...

### DIFF
--- a/webapi/tct-bluetooth-tizen-tests/bluetooth/BluetoothDevice.html
+++ b/webapi/tct-bluetooth-tizen-tests/bluetooth/BluetoothDevice.html
@@ -137,7 +137,7 @@ t.step(function () {
 
         //isConnected AE AT ARO
         test(function () {
-            check_readonly(device, "isConnected", true, "boolean", false);
+            check_readonly(device, "isConnected", device.isConnected, "boolean", !device.isConnected);
         } , "BluetoothDevice_isConnected_attribute");
 
         //isTrusted AE AT ARO


### PR DESCRIPTION
...e.html

This test case aims to verify that 'isConnected' attribute is readonly.
But the test considers that after bonding a remove device, this device
is also connected. Actually this is not obviously the case, and sometime
the device is paired but not connected, and the test is failed because of this.

I suggest that change the expected device connected 'true' value to the
real connected value and just check if it is a readonly attribute.
