### PR TITLE
[webapi][DeviceCapabilities] Use correct name of Event attribute.

### DIFF
--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemDisplayEvent_DisplayUnit-manual.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemDisplayEvent_DisplayUnit-manual.html
@@ -50,11 +50,11 @@ t.step(function () {
 
   system.addEventListener("displayconnect", function (e) {
     t.step(function () {
-      assert_true("DisplayUnit" in e, "The SystemDisplayEvent.DisplayUnit exists");
-      assert_equals(typeof e.DisplayUnit, "object", "The type of SystemDisplayEvent.DisplayUnit");
-      var value = e.DisplayUnit;
-      e.DisplayUnit = null;
-      assert_equals(e.DisplayUnit, value, "The SystemDisplayEvent.DisplayUnit");
+      assert_true("display" in e, "The SystemDisplayEvent.DisplayUnit exists");
+      assert_equals(typeof e.display, "object", "The type of SystemDisplayEvent.DisplayUnit");
+      var value = e.display;
+      e.display= null;
+      assert_equals(e.display, value, "The SystemDisplayEvent.DisplayUnit");
     });
     t.done();
   });

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemDisplayEvent_DisplayUnit_Connect-manual.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemDisplayEvent_DisplayUnit_Connect-manual.html
@@ -51,8 +51,8 @@ t.step(function () {
   system.addEventListener("displayconnect", function (e) {
     t.step(function () {
       assert_true(e instanceof SystemDisplayEvent, "The SystemDisplayEvent initialized");
-      assert_not_equals(e.DisplayUnit, undefined, "The SystemDisplayEvent.DisplayUnit");
-      assert_not_equals(e.DisplayUnit, null, "The SystemDisplayEvent.DisplayUnit");
+      assert_not_equals(e.display, undefined, "The SystemDisplayEvent.DisplayUnit");
+      assert_not_equals(e.display, null, "The SystemDisplayEvent.DisplayUnit");
     });
     t.done();
   });

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemDisplayEvent_DisplayUnit_Disconnect-manual.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemDisplayEvent_DisplayUnit_Disconnect-manual.html
@@ -51,8 +51,8 @@ t.step(function () {
   system.addEventListener("displaydisconnect", function (e) {
     t.step(function () {
       assert_true(e instanceof SystemDisplayEvent, "The SystemDisplayEvent initailized");
-      assert_not_equals(e.DisplayUnit, undefined, "The SystemDisplayEvent.DisplayUnit");
-      assert_not_equals(e.DisplayUnit, null, "The SystemDisplayEvent.DisplayUnit");
+      assert_not_equals(e.display, undefined, "The SystemDisplayEvent.DisplayUnit");
+      assert_not_equals(e.display, null, "The SystemDisplayEvent.DisplayUnit");
     });
     t.done();
   });

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemStorageEvent_StorageUnit-manual.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemStorageEvent_StorageUnit-manual.html
@@ -50,11 +50,11 @@ t.step(function () {
 
   system.addEventListener("storageattach", function (e) {
     t.step(function () {
-      assert_true("StorageUnit" in e, "The SystemStorageEvent.StorageUnit exists");
-      assert_equals(typeof e.StorageUnit, "object", "The type of SystemStorageEvent.StorageUnit");
-      var value = e.StorageUnit;
-      e.StorageUnit = null;
-      assert_equals(e.StorageUnit, value, "The SystemStorageEvent.StorageUnit");
+      assert_true("storage" in e, "The SystemStorageEvent.StorageUnit exists");
+      assert_equals(typeof e.storage, "object", "The type of SystemStorageEvent.StorageUnit");
+      var value = e.storage;
+      e.storage= null;
+      assert_equals(e.storage, value, "The SystemStorageEvent.StorageUnit");
     });
     t.done();
   });

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemStorageEvent_StorageUnit_Attach-manual.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemStorageEvent_StorageUnit_Attach-manual.html
@@ -51,8 +51,8 @@ t.step(function () {
   system.addEventListener("storageattach", function (e) {
     t.step(function () {
       assert_true(e instanceof SystemStorageEvent, "The SystemStorageEvent initialized");
-      assert_not_equals(e.StorageUnit, undefined, "The SystemStorageEvent.StorageUnit");
-      assert_not_equals(e.StorageUnit, null, "The SystemStorageEvent.StorageUnit");
+      assert_not_equals(e.storage, undefined, "The SystemStorageEvent.StorageUnit");
+      assert_not_equals(e.storage, null, "The SystemStorageEvent.StorageUnit");
     });
     t.done();
   });

--- a/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemStorageEvent_StorageUnit_Detach-manual.html
+++ b/webapi/webapi-devicecapabilities-sysapps-tests/devicecapabilities/SystemStorageEvent_StorageUnit_Detach-manual.html
@@ -51,8 +51,8 @@ t.step(function () {
   system.addEventListener("storagedetach", function (e) {
     t.step(function () {
       assert_true(e instanceof SystemStorageEvent, "The SystemStorageEvent initialized");
-      assert_not_equals(e.StorageUnit, undefined, "The SystemStorageEvent.StorageUnit");
-      assert_not_equals(e.StorageUnit, null, "The SystemStorageEvent.StorageUnit");
+      assert_not_equals(e.storage, undefined, "The SystemStorageEvent.StorageUnit");
+      assert_not_equals(e.storage, null, "The SystemStorageEvent.StorageUnit");
     });
     t.done();
   });


### PR DESCRIPTION
Spec bugs: StorageUnit and DisplayUnit are type name.
The attribute name should be `storage` and `display`.
