### PR TITLE
[webapi] Update lockOrientation-basic.html converted from Blink Layout Test

### DIFF
--- a/webapi/tct-screenorientation-w3c-tests/screenorientation/blink/COPYING
+++ b/webapi/tct-screenorientation-w3c-tests/screenorientation/blink/COPYING
@@ -1,6 +1,0 @@
-This test suite comes from
-https://github.com/crosswalk-project/blink-crosswalk/blob/master/LayoutTests/screen_orientation/
-from the blink integration, and then follow testharness redefine
-
-Use of this source code is governed by a BSD-style license:
-http://src.chromium.org/viewvc/chrome/trunk/src/LICENSE

--- a/webapi/tct-screenorientation-w3c-tests/screenorientation/blink/lockOrientation-basic.html
+++ b/webapi/tct-screenorientation-w3c-tests/screenorientation/blink/lockOrientation-basic.html
@@ -1,24 +1,29 @@
+<!DOCTYPE html>
 <!--
 Test convert from Blink:
 https://github.com/crosswalk-project/blink-crosswalk/blob/master/LayoutTests/screen_orientation/lockOrientation-basic.html
+
+Use of this source code is governed by a BSD-style license:
+https://chromium.googlesource.com/chromium/blink/+/master/LICENSE
 -->
 
-
-<!DOCTYPE html>
 <meta charset="utf-8">
 <title>Screen Test: lockOrientation-basic</title>
-<link rel="author" title="Intel" href="http://www.intel.com">
-<link rel="help" href="http://www.w3.org/TR/2012/WD-screen-orientation-20120522/#extensions-to-the-screen-interface" />
+<link rel="help" href="https://w3c.github.io/screen-orientation/#screenorientation-interface">
 <script src="../../resources/testharness.js"></script>
 <script src="../../resources/testharnessreport.js"></script>
+
 <div id="log"></div>
 <script>
-var t = async_test("Basic screen.lockOrientation() / screen.unlockOrientation() testing", { timeout: 2000});
-
+var t = async_test("Basic screen.lockOrientation() and screen.unlockOrientation() testing", {timeout: 2000});
 var orientation_num = 0;
+
 t.step(function () {
   screen.unlockOrientation();
-  [ "any", "landscape", "portrait", "portrait-primary", "portrait-secondary", "landscape-primary", "landscape-secondary", "0",  "90", "180", "270" ].forEach(function(orientation) {
+  [
+    "any", "landscape", "portrait", "portrait-primary", "portrait-secondary",
+    "landscape-primary", "landscape-secondary", "0",  "90", "180", "270"
+  ].forEach(function(orientation) {
     orientation_num++;
     screen.lockOrientation(orientation).then(t.step_func(function(e) {
       if(orientation_num == 11) {


### PR DESCRIPTION
- Integrate license info into the test file after <!DOCTYPE html>
- Update the spec link to reflect latest Blink implementation
- Remove the author Intel as we are not the original author
- TODO: update the test logic after Crosswalk rebases to Chromium 38
  https://chromium.googlesource.com/chromium/blink/+/master/LayoutTests/screen_orientation/lockOrientation-basic.html
