### PR TITLE
[webapi][xwalk-2309] Use launch instead of AppControl to throw WebAPIException

### DIFF
--- a/webapi/tct-tizen-tizen-tests/tizen/support/tizen_common.js
+++ b/webapi/tct-tizen-tizen-tests/tizen/support/tizen_common.js
@@ -75,7 +75,11 @@ function getWebAPIException(kind) {
         if (kind === "NotFoundError") {
             tizen.application.getAppInfo("111AppID88.WhichWillNotBeFound");
         } else {
-            tizen.application.findAppControl();
+
+            //tizen.application.findAppControl();
+            // AppControl is not supported in Crosswalk at now.
+            // Use launch() instead to throw WebAPIException
+            tizen.application.launch();
         }
     } catch(error) {
         return error;
@@ -95,11 +99,14 @@ function getWebAPIError(test_obj, callback, kind) {
 
     currentApplication = tizen.application.getCurrentApplication();
     if (kind === "NotFoundError") {
-        tizen.application.launchAppControl(
-            new tizen.ApplicationControl("WRONG_NOT_IMPLEMENTED_OPERATION"),
-            "111AppID88.WhichWillNotBeFound",
-            onSuccess, onError
-        );
+        //tizen.application.launchAppControl(
+        //    new tizen.ApplicationControl("WRONG_NOT_IMPLEMENTED_OPERATION"),
+        //    "111AppID88.WhichWillNotBeFound",
+        //    onSuccess, onError
+        //);
+        // AppControl is not supported in Crosswalk at now.
+        // Use launch() instead to throw WebAPIError
+        tizen.application.launch("111AppID88.WhichWillNotBeFound", onSuccess, onError);
     } else {
         assert_equals(kind, undefined, "Fix the test. Requested kind of error is not available");
         tizen.application.kill(currentApplication.contextId, onSuccess, onError);


### PR DESCRIPTION
- AppControl is not supported in Crosswalk at now. Use launch() instead to throw WebAPIException.
- Fail Reason: Const attributes are not implemented(XWALK-2309); Wrong exception thrown(XWALK-1659); Error message is a empty string, no message info.

Impacted tests(approved): new 0, update 35, delete 0
Unit test platform: [Tizen IVI]
Unit test result summary: pass 6, fail 27, block 0
