### PR TITLE
[webapi] Update 3 TCs and add 28 TCs for MediaRenderer

### DIFF
--- a/webapi/webapi-mediarenderer-xwalk-tests/README
+++ b/webapi/webapi-mediarenderer-xwalk-tests/README
@@ -5,7 +5,7 @@ This test suite is for testing Media Renderer Interface (Partial) specification:
 
 ## Pre-conditions
 
-* Set up dlna server follow the steps:
+* Set up dlna media server follow the steps:
 1. Modify rygel.conf on IVI device.
 $ cp /etc/rygel.conf /home/app/.config/
 

--- a/webapi/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html
+++ b/webapi/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html
@@ -43,7 +43,7 @@ setup({timeout: 30000}, {explicit_done: true});
 
 navigator.mediaRenderer.onrendererfound = function (event) {
   [
-    ["object", "playbackStatus", "readonly"],
+    ["string", "playbackStatus", "readonly"],
     ["boolean", "muted", "readonly"],
     ["number", "volume", "readonly"],
     ["number", "track", "readonly"],
@@ -67,7 +67,7 @@ navigator.mediaRenderer.onrendererfound = function (event) {
     test(function () {
       assert_true(name in event.renderer.controller, name + " attribute in MediaController");
       switch(type) {
-      case "object":
+      case "string":
       case "boolean":
       case "number":
       case "function":
@@ -80,6 +80,18 @@ navigator.mediaRenderer.onrendererfound = function (event) {
         break;
       }
     }, "Check if " + read + " MediaController." + name + " exists and type of " + type);
+
+    switch(type) {
+    case "string":
+    case "boolean":
+    case "number":
+      test(function () {
+        assert_not_equals(event.renderer.controller[name], null, name + " attribute of MediaController");
+      }, "Check if MediaController." + name + " is valid");
+      break;
+    default:
+      break;
+    }
   });
   done();
 };

--- a/webapi/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html
+++ b/webapi/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html
@@ -44,7 +44,7 @@ setup({timeout: 30000}, {explicit_done: true});
 navigator.mediaRenderer.onrendererfound = function (eve) {
   eve.renderer.controller.onstatuschanged = function (event) {
     [
-      ["object", "playbackStatus", "readonly"],
+      ["string", "playbackStatus", "readonly"],
       ["boolean", "muted", "readonly"],
       ["number", "volume", "readonly"],
       ["number", "track", "readonly"],
@@ -59,6 +59,10 @@ navigator.mediaRenderer.onrendererfound = function (eve) {
         assert_readonly(event, name, "expect attribute " + name + " cannot be changed but");
         assert_equals(typeof event[name], type, name + " attribute of type");
       }, "Check if " + read + " MediaControllerStatusEvent." + name + " exists and type of " + type);
+
+      test(function () {
+        assert_not_equals(event[name], null, name + " attribute of MediaControllerStatusEvent");
+      }, "Check if MediaControllerStatusEvent." + name + " is valid");
     });
     done();
   };

--- a/webapi/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html
+++ b/webapi/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html
@@ -76,13 +76,24 @@ navigator.mediaRenderer.onrendererfound = function (event) {
         assert_equals(typeof event.renderer[name], type, name + " attribute of type");      
         break;
       case "mediaController":
-        assert_equals(Object.prototype.toString.call(event.renderer.controller[name]), "[object MediaController]", name + " attribute of type");
-        assert_readonly(event.renderer.controller, name, "expect attribute " + name + " cannot be changed but");
+        assert_equals(Object.prototype.toString.call(event.renderer[name]), "[object MediaController]", name + " attribute of type");
+        assert_readonly(event.renderer, name, "expect attribute " + name + " cannot be changed but");
         break;
       default:
         break;
       }
     }, "Check if " + read + " MediaRenderer." + name + " exists and type of " + type);
+
+    switch(type) {
+    case "string":
+    case "mediaController":
+      test(function () {
+        assert_not_equals(event.renderer[name], null, name + " attribute of MediaRenderer");
+      }, "Check if MediaRenderer." + name + " is valid");
+      break;
+    default:
+      break;
+    }
   });
   done();
 };

--- a/webapi/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererEvent_renderer.html
+++ b/webapi/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererEvent_renderer.html
@@ -39,15 +39,20 @@ Authors:
 <div id="log"></div>
 <script>
 
-var t = async_test("Check if the readonly attribute renderer of MediaRendererEvent exists and type of object");
-setup({timeout: 30000});
+setup({timeout: 30000}, {explicit_done: true});
 
-navigator.mediaRenderer.onrendererfound = t.step_func(function (event) {
-  assert_true("renderer" in event, "renderer attribute in MediaRendererEvent");
-  assert_equals(typeof (event.renderer), "object", "renderer attribute of type");
-  assert_readonly(event, "renderer", "expect attribute renderer cannot be changed but");
-  t.done();
-});
+navigator.mediaRenderer.onrendererfound = function (event) {
+  test(function () {
+    assert_true("renderer" in event, "renderer attribute in MediaRendererEvent");
+    assert_equals(typeof (event.renderer), "object", "renderer attribute of type");
+    assert_readonly(event, "renderer", "expect attribute renderer cannot be changed but");
+  }, "Check if the readonly attribute renderer of MediaRendererEvent exists and type of object");
+
+  test(function () {
+    assert_not_equals(event.renderer, null, "renderer attribute of MediaRendererEvent");
+  }, "Check if MediaRendererEvent.renderer is valid");
+  done();
+};
 
 navigator.mediaRenderer.scanNetwork();
 

--- a/webapi/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererIdEvent_id.html
+++ b/webapi/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererIdEvent_id.html
@@ -39,15 +39,20 @@ Authors:
 <div id="log"></div>
 <script>
 
-var t = async_test("Check if the readonly attribute id of MediaRendererIdEvent exists and type of string");
-setup({timeout: 30000});
+setup({timeout: 30000}, {explicit_done: true});
 
-navigator.mediaRenderer.onrendererlost = t.step_func(function (event) {
-  assert_true("id" in event, "id attribute in MediaRendererIdEvent");
-  assert_equals(typeof event.id, "string", "id attribute of type");
-  assert_readonly(event, "id", "expect attribute id cannot be changed but");
-  t.done();
-});
+navigator.mediaRenderer.onrendererlost = function (event) {
+  test(function () {
+    assert_true("id" in event, "id attribute in MediaRendererIdEvent");
+    assert_equals(typeof event.id, "string", "id attribute of type");
+    assert_readonly(event, "id", "expect attribute id cannot be changed but");
+  }, "Check if the readonly attribute id of MediaRendererIdEvent exists and type of string");
+
+  test(function () {
+    assert_not_equals(event.id, null, "id attribute of MediaRendererIdEvent");
+  }, "Check if MediaRendererIdEvent.id is valid");
+  done();
+};
 
 navigator.mediaRenderer.onrendererfound = function (eve) {
   eve.renderer.controller.pause();

--- a/webapi/webapi-mediarenderer-xwalk-tests/mediarenderer/Navigator_mediaRenderer.html
+++ b/webapi/webapi-mediarenderer-xwalk-tests/mediarenderer/Navigator_mediaRenderer.html
@@ -45,4 +45,8 @@ test(function () {
   assert_readonly(navigator, "mediaRenderer", "expect attribute mediaRenderer cannot be changed but");
 }, "Check if readonly Navigator.mediaRenderer exists and type of object");
 
+test(function () {
+  assert_not_equals(navigator.mediaRenderer, null, "mediaRenderer attribute of Navigator");
+}, "Check if Navigator.mediaRenderer is valid");
+
 </script>

--- a/webapi/webapi-mediarenderer-xwalk-tests/tests.full.xml
+++ b/webapi/webapi-mediarenderer-xwalk-tests/tests.full.xml
@@ -1,531 +1,867 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="./testcase.xsl"?>
 <test_definition>
-  <suite name="webapi-mediarenderer-xwalk-tests" launcher="xwalk" extension="crosswalk" category="Media Renderer API">
+  <suite name="webapi-mediarenderer-xwalk-tests" launcher="xwalk" extension="crosswalk" category="DLNA">
     <set name="mediarenderer" type="js">
-      <testcase purpose="Check if readonly Navigator.mediaRenderer exists and type of object" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="Navigator_mediaRenderer">
+      <testcase purpose="Check if readonly Navigator.mediaRenderer exists and type of object" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="Navigator_mediaRenderer">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/Navigator_mediaRenderer.html</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/Navigator_mediaRenderer.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="interface" element_name="MediaRendererManager" interface="Navigator" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="interface" element_name="MediaRendererManager" interface="Navigator" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#extensions-to-navigator-object</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if MediaRendererManager.scanNetwork exists and type of function" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaRendererManager_scanNetwork">
+      <testcase purpose="Check if Navigator.mediaRenderer is valid" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="Navigator_mediaRenderer_basic">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/Navigator_mediaRenderer.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="interface" element_name="MediaRendererManager" interface="Navigator" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
+            <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#extensions-to-navigator-object</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if MediaRendererManager.scanNetwork exists and type of function" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRendererManager_scanNetwork">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererManager.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="scanNetwork" interface="MediaRendererManager" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="scanNetwork" interface="MediaRendererManager" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderermanager-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if MediaRendererManager.onrendererfound exists and type of event" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaRendererManager_onrendererfound">
+      <testcase purpose="Check if MediaRendererManager.onrendererfound exists and type of event" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRendererManager_onrendererfound">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererManager.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="onrendererfound" interface="MediaRendererManager" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="onrendererfound" interface="MediaRendererManager" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderermanager-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if MediaRendererManager.onrendererlost exists and type of event" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaRendererManager_onrendererlost">
+      <testcase purpose="Check if MediaRendererManager.onrendererlost exists and type of event" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRendererManager_onrendererlost">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererManager.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="onrendererlost" interface="MediaRendererManager" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="onrendererlost" interface="MediaRendererManager" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderermanager-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if the readonly attribute renderer of MediaRendererEvent exists and type of object" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaRendererEvent_renderer">
+      <testcase purpose="Check if the readonly attribute renderer of MediaRendererEvent exists and type of object" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRendererEvent_renderer">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererEvent_renderer.html</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererEvent_renderer.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="renderer" interface="MediaRendererEvent" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="renderer" interface="MediaRendererEvent" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarendererevent-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if the readonly attribute id of MediaRendererIdEvent exists and type of string" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaRendererIdEvent_id">
+      <testcase purpose="Check if MediaRendererEvent.renderer is valid" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRendererEvent_renderer_basic">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererIdEvent_id.html</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererEvent_renderer.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="id" interface="MediaRendererIdEvent" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="renderer" interface="MediaRendererEvent" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
+            <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarendererevent-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if the readonly attribute id of MediaRendererIdEvent exists and type of string" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRendererIdEvent_id">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererIdEvent_id.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="id" interface="MediaRendererIdEvent" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarendereridevent-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if readonly MediaRenderer.id exists and type of string" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaRenderer_id">
+      <testcase purpose="Check if MediaRendererIdEvent.id is valid" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRendererIdEvent_id_basic">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererIdEvent_id.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="id" interface="MediaRenderer" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="id" interface="MediaRendererIdEvent" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
+            <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarendereridevent-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly MediaRenderer.id exists and type of string" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_id">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="id" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if readonly MediaRenderer.friendlyName exists and type of string" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaRenderer_friendlyName">
+      <testcase purpose="Check if MediaRenderer.id is valid" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_id_basic">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="friendlyName" interface="MediaRenderer" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="id" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if readonly MediaRenderer.manufacturer exists and type of string" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaRenderer_manufacturer">
+      <testcase purpose="Check if readonly MediaRenderer.friendlyName exists and type of string" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_friendlyName">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="manufacturer" interface="MediaRenderer" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="friendlyName" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if readonly MediaRenderer.manufacturerURL exists and type of string" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaRenderer_manufacturerURL">
+      <testcase purpose="Check if MediaRenderer.friendlyName is valid" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_friendlyName_basic">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="manufacturerURL" interface="MediaRenderer" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="friendlyName" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if readonly MediaRenderer.modelDescription exists and type of string" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaRenderer_modelDescription">
+      <testcase purpose="Check if readonly MediaRenderer.manufacturer exists and type of string" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_manufacturer">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="modelDescription" interface="MediaRenderer" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="manufacturer" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if readonly MediaRenderer.modelName exists and type of string" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaRenderer_modelName">
+      <testcase purpose="Check if MediaRenderer.manufacturer is valid" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_manufacturer_basic">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="modelName" interface="MediaRenderer" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="manufacturer" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if readonly MediaRenderer.modelNumber exists and type of string" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaRenderer_modelNumber">
+      <testcase purpose="Check if readonly MediaRenderer.manufacturerURL exists and type of string" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_manufacturerURL">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="modelNumber" interface="MediaRenderer" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="manufacturerURL" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if readonly MediaRenderer.serialNumber exists and type of string" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaRenderer_serialNumber">
+      <testcase purpose="Check if MediaRenderer.manufacturerURL is valid" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_manufacturerURL_basic">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="serialNumber" interface="MediaRenderer" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="manufacturerURL" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if readonly MediaRenderer.UDN exists and type of string" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaRenderer_UDN">
+      <testcase purpose="Check if readonly MediaRenderer.modelDescription exists and type of string" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_modelDescription">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="UDN" interface="MediaRenderer" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="modelDescription" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if readonly MediaRenderer.presentationURL exists and type of string" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaRenderer_presentationURL">
+      <testcase purpose="Check if MediaRenderer.modelDescription is valid" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_modelDescription_basic">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="presentationURL" interface="MediaRenderer" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="modelDescription" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if readonly MediaRenderer.iconURL exists and type of string" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaRenderer_iconURL">
+      <testcase purpose="Check if readonly MediaRenderer.modelName exists and type of string" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_modelName">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="iconURL" interface="MediaRenderer" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="modelName" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if readonly MediaRenderer.deviceType exists and type of string" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaRenderer_deviceType">
+      <testcase purpose="Check if MediaRenderer.modelName is valid" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_modelName_basic">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="deviceType" interface="MediaRenderer" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="modelName" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if readonly MediaRenderer.protocolInfo exists and type of string" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaRenderer_protocolInfo">
+      <testcase purpose="Check if readonly MediaRenderer.modelNumber exists and type of string" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_modelNumber">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="protocolInfo" interface="MediaRenderer" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="modelNumber" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if readonly MediaRenderer.controller exists and type of mediaController" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaRenderer_controller">
+      <testcase purpose="Check if MediaRenderer.modelNumber is valid" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_modelNumber_basic">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="controller" interface="MediaRenderer" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="modelNumber" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if MediaRenderer.openURI exists and type of function" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaRenderer_openURI">
+      <testcase purpose="Check if readonly MediaRenderer.serialNumber exists and type of string" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_serialNumber">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="method" element_name="openURI" interface="MediaRenderer" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="serialNumber" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if MediaRenderer.prefetchURI exists and type of function" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaRenderer_prefetchURI">
+      <testcase purpose="Check if MediaRenderer.serialNumber is valid" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_serialNumber_basic">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=16</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=16</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="method" element_name="prefetchURI" interface="MediaRenderer" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="serialNumber" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if MediaRenderer.cancel exists and type of function" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaRenderer_cancel">
+      <testcase purpose="Check if readonly MediaRenderer.UDN exists and type of string" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_UDN">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="method" element_name="cancel" interface="MediaRenderer" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="UDN" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if readonly MediaController.playbackStatus exists and type of object" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaController_playbackStatus">
+      <testcase purpose="Check if MediaRenderer.UDN is valid" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_UDN_basic">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=18</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="playbackStatus" interface="MediaController" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="UDN" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
+            <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly MediaRenderer.presentationURL exists and type of string" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_presentationURL">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=19</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="presentationURL" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
+            <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if MediaRenderer.presentationURL is valid" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_presentationURL_basic">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=20</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="presentationURL" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
+            <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly MediaRenderer.iconURL exists and type of string" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_iconURL">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=21</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="iconURL" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
+            <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if MediaRenderer.iconURL is valid" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_iconURL_basic">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=22</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="iconURL" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
+            <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly MediaRenderer.deviceType exists and type of string" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_deviceType">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=23</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="deviceType" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
+            <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if MediaRenderer.deviceType is valid" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_deviceType_basic">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=24</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="deviceType" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
+            <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly MediaRenderer.protocolInfo exists and type of string" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_protocolInfo">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=25</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="protocolInfo" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
+            <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if MediaRenderer.protocolInfo is valid" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_protocolInfo_basic">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=26</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="protocolInfo" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
+            <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly MediaRenderer.controller exists and type of mediaController" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_controller">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=27</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="controller" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
+            <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if MediaRenderer.controller is valid" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_controller_basic">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=28</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="controller" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
+            <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if MediaRenderer.openURI exists and type of function" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_openURI">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=29</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="openURI" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
+            <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if MediaRenderer.prefetchURI exists and type of function" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_prefetchURI">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=30</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="prefetchURI" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
+            <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if MediaRenderer.cancel exists and type of function" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaRenderer_cancel">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=31</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="cancel" interface="MediaRenderer" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
+            <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediarenderer-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly MediaController.playbackStatus exists and type of string" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaController_playbackStatus">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="playbackStatus" interface="MediaController" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediacontroller-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if readonly MediaController.muted exists and type of boolean" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaController_muted">
+      <testcase purpose="Check if MediaController.playbackStatus is valid" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaController_playbackStatus_basic">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="muted" interface="MediaController" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="playbackStatus" interface="MediaController" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediacontroller-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if readonly MediaController.volume exists and type of number" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaController_volume">
+      <testcase purpose="Check if readonly MediaController.muted exists and type of boolean" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaController_muted">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="volume" interface="MediaController" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="muted" interface="MediaController" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediacontroller-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if readonly MediaController.track exists and type of number" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaController_track">
+      <testcase purpose="Check if MediaController.muted is valid" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaController_muted_basic">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="track" interface="MediaController" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="muted" interface="MediaController" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediacontroller-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if readonly MediaController.speed exists and type of number" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaController_speed">
+      <testcase purpose="Check if readonly MediaController.volume exists and type of number" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaController_volume">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="speed" interface="MediaController" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="volume" interface="MediaController" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediacontroller-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if readonly MediaController.playSpeeds exists and type of number" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaController_playSpeeds">
+      <testcase purpose="Check if MediaController.volume is valid" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaController_volume_basic">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="playSpeeds" interface="MediaController" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="volume" interface="MediaController" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediacontroller-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if MediaController.play exists and type of function" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaController_play">
+      <testcase purpose="Check if readonly MediaController.track exists and type of number" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaController_track">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="method" element_name="play" interface="MediaController" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="track" interface="MediaController" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediacontroller-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if MediaController.pause exists and type of function" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaController_pause">
+      <testcase purpose="Check if MediaController.track is valid" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaController_track_basic">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="method" element_name="pause" interface="MediaController" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="track" interface="MediaController" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediacontroller-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if MediaController.stop exists and type of function" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaController_stop">
+      <testcase purpose="Check if readonly MediaController.speed exists and type of number" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaController_speed">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="method" element_name="stop" interface="MediaController" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="speed" interface="MediaController" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediacontroller-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if MediaController.next exists and type of function" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaController_next">
+      <testcase purpose="Check if MediaController.speed is valid" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaController_speed_basic">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="method" element_name="next" interface="MediaController" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="speed" interface="MediaController" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediacontroller-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if MediaController.previous exists and type of function" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaController_previous">
+      <testcase purpose="Check if readonly MediaController.playSpeeds exists and type of number" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaController_playSpeeds">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="method" element_name="previous" interface="MediaController" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="playSpeeds" interface="MediaController" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediacontroller-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if MediaController.mute exists and type of function" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaController_mute">
+      <testcase purpose="Check if MediaController.playSpeeds is valid" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaController_playSpeeds_basic">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="method" element_name="mute" interface="MediaController" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="playSpeeds" interface="MediaController" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediacontroller-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if MediaController.setSpeed exists and type of function" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaController_setSpeed">
+      <testcase purpose="Check if MediaController.play exists and type of function" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaController_play">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="method" element_name="setSpeed" interface="MediaController" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="method" element_name="play" interface="MediaController" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediacontroller-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if MediaController.setVolume exists and type of function" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaController_setVolume">
+      <testcase purpose="Check if MediaController.pause exists and type of function" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaController_pause">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="method" element_name="setVolume" interface="MediaController" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="method" element_name="pause" interface="MediaController" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediacontroller-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if MediaController.gotoTrack exists and type of function" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaController_gotoTrack">
+      <testcase purpose="Check if MediaController.stop exists and type of function" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaController_stop">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="method" element_name="gotoTrack" interface="MediaController" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="method" element_name="stop" interface="MediaController" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediacontroller-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if MediaController.onstatuschanged exists and type of event" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaController_onstatuschanged">
+      <testcase purpose="Check if MediaController.next exists and type of function" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaController_next">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=16</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=16</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="event" element_name="onstatuschanged" interface="MediaController" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="method" element_name="next" interface="MediaController" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediacontroller-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if readonly MediaControllerStatusEvent.playbackStatus exists and type of object" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaControllerStatusEvent_playbackStatus">
+      <testcase purpose="Check if MediaController.previous exists and type of function" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaController_previous">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="playbackStatus" interface="MediaControllerStatusEvent" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="method" element_name="previous" interface="MediaController" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
+            <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediacontroller-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if MediaController.mute exists and type of function" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaController_mute">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=18</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="mute" interface="MediaController" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
+            <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediacontroller-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if MediaController.setSpeed exists and type of function" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaController_setSpeed">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=19</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="setSpeed" interface="MediaController" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
+            <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediacontroller-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if MediaController.setVolume exists and type of function" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaController_setVolume">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=20</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="setVolume" interface="MediaController" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
+            <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediacontroller-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if MediaController.gotoTrack exists and type of function" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaController_gotoTrack">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=21</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="gotoTrack" interface="MediaController" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
+            <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediacontroller-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if MediaController.onstatuschanged exists and type of event" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaController_onstatuschanged">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=22</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="event" element_name="onstatuschanged" interface="MediaController" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
+            <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediacontroller-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly MediaControllerStatusEvent.playbackStatus exists and type of string" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaControllerStatusEvent_playbackStatus">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="playbackStatus" interface="MediaControllerStatusEvent" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediaControllerStatusEvent-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if readonly MediaControllerStatusEvent.muted exists and type of boolean" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaControllerStatusEvent_muted">
+      <testcase purpose="Check if MediaControllerStatusEvent.playbackStatus is valid" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaControllerStatusEvent_playbackStatus_basic">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="muted" interface="MediaControllerStatusEvent" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="playbackStatus" interface="MediaControllerStatusEvent" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediaControllerStatusEvent-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if readonly MediaControllerStatusEvent.volume exists and type of number" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaControllerStatusEvent_volume">
+      <testcase purpose="Check if readonly MediaControllerStatusEvent.muted exists and type of boolean" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaControllerStatusEvent_muted">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="volume" interface="MediaControllerStatusEvent" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="muted" interface="MediaControllerStatusEvent" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediaControllerStatusEvent-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if readonly MediaControllerStatusEvent.track exists and type of number" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaControllerStatusEvent_track">
+      <testcase purpose="Check if MediaControllerStatusEvent.muted is valid" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaControllerStatusEvent_muted_basic">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="track" interface="MediaControllerStatusEvent" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="muted" interface="MediaControllerStatusEvent" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediaControllerStatusEvent-interface</spec_url>
             <spec_statement/>
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if readonly MediaControllerStatusEvent.speed exists and type of number" type="compliance" status="approved" component="WebAPI/Media Renderer API/DLNA" execution_type="auto" priority="P1" id="MediaControllerStatusEvent_speed">
+      <testcase purpose="Check if readonly MediaControllerStatusEvent.volume exists and type of number" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaControllerStatusEvent_volume">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
         </description>
         <specs>
           <spec>
-            <spec_assertion element_type="property" element_name="speed" interface="MediaControllerStatusEvent" specification="DLNA" section="W3C API Specifications" category="Media Renderer API"/>
+            <spec_assertion element_type="property" element_name="volume" interface="MediaControllerStatusEvent" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
+            <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediaControllerStatusEvent-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if MediaControllerStatusEvent.volume is valid" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaControllerStatusEvent_volume_basic">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="volume" interface="MediaControllerStatusEvent" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
+            <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediaControllerStatusEvent-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly MediaControllerStatusEvent.track exists and type of number" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaControllerStatusEvent_track">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="track" interface="MediaControllerStatusEvent" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
+            <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediaControllerStatusEvent-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if MediaControllerStatusEvent.track is valid" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaControllerStatusEvent_track_basic">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="track" interface="MediaControllerStatusEvent" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
+            <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediaControllerStatusEvent-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if readonly MediaControllerStatusEvent.speed exists and type of number" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaControllerStatusEvent_speed">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="speed" interface="MediaControllerStatusEvent" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
+            <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediaControllerStatusEvent-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if MediaControllerStatusEvent.speed is valid" type="compliance" status="approved" component="WebAPI/DLNA/MediaRenderer" execution_type="auto" priority="P1" id="MediaControllerStatusEvent_speed_basic">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="property" element_name="speed" interface="MediaControllerStatusEvent" specification="MediaRenderer" section="W3C API Specifications" category="DLNA"/>
             <spec_url>http://01org.github.io/cloud-dleyna/mediarenderer.html#mediaControllerStatusEvent-interface</spec_url>
             <spec_statement/>
           </spec>

--- a/webapi/webapi-mediarenderer-xwalk-tests/tests.xml
+++ b/webapi/webapi-mediarenderer-xwalk-tests/tests.xml
@@ -1,226 +1,366 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="./testcase.xsl"?>
 <test_definition>
-  <suite category="Media Renderer API" extension="crosswalk" launcher="xwalk" name="webapi-mediarenderer-xwalk-tests">
+  <suite category="DLNA" extension="crosswalk" launcher="xwalk" name="webapi-mediarenderer-xwalk-tests">
     <set name="mediarenderer" type="js">
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="Navigator_mediaRenderer" purpose="Check if readonly Navigator.mediaRenderer exists and type of object">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="Navigator_mediaRenderer" purpose="Check if readonly Navigator.mediaRenderer exists and type of object" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/Navigator_mediaRenderer.html</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/Navigator_mediaRenderer.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRendererManager_scanNetwork" purpose="Check if MediaRendererManager.scanNetwork exists and type of function">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="Navigator_mediaRenderer_basic" purpose="Check if Navigator.mediaRenderer is valid" onload_delay="30">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/Navigator_mediaRenderer.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRendererManager_scanNetwork" purpose="Check if MediaRendererManager.scanNetwork exists and type of function" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererManager.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRendererManager_onrendererfound" purpose="Check if MediaRendererManager.onrendererfound exists and type of event">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRendererManager_onrendererfound" purpose="Check if MediaRendererManager.onrendererfound exists and type of event" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererManager.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRendererManager_onrendererlost" purpose="Check if MediaRendererManager.onrendererlost exists and type of event">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRendererManager_onrendererlost" purpose="Check if MediaRendererManager.onrendererlost exists and type of event" onload_delay="30">
         <description>
           <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererManager.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRendererEvent_renderer" purpose="Check if the readonly attribute renderer of MediaRendererEvent exists and type of object" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRendererEvent_renderer" purpose="Check if the readonly attribute renderer of MediaRendererEvent exists and type of object" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererEvent_renderer.html</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererEvent_renderer.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRendererIdEvent_id" purpose="Check if the readonly attribute id of MediaRendererIdEvent exists and type of string" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRendererEvent_renderer_basic" purpose="Check if MediaRendererEvent.renderer is valid" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererIdEvent_id.html</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererEvent_renderer.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_id" purpose="Check if readonly MediaRenderer.id exists and type of string" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRendererIdEvent_id" purpose="Check if the readonly attribute id of MediaRendererIdEvent exists and type of string" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererIdEvent_id.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_friendlyName" purpose="Check if readonly MediaRenderer.friendlyName exists and type of string" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRendererIdEvent_id_basic" purpose="Check if MediaRendererIdEvent.id is valid" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRendererIdEvent_id.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_manufacturer" purpose="Check if readonly MediaRenderer.manufacturer exists and type of string" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_id" purpose="Check if readonly MediaRenderer.id exists and type of string" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_manufacturerURL" purpose="Check if readonly MediaRenderer.manufacturerURL exists and type of string" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_id_basic" purpose="Check if MediaRenderer.id is valid" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_modelDescription" purpose="Check if readonly MediaRenderer.modelDescription exists and type of string" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_friendlyName" purpose="Check if readonly MediaRenderer.friendlyName exists and type of string" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_modelName" purpose="Check if readonly MediaRenderer.modelName exists and type of string" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_friendlyName_basic" purpose="Check if MediaRenderer.friendlyName is valid" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_modelNumber" purpose="Check if readonly MediaRenderer.modelNumber exists and type of string" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_manufacturer" purpose="Check if readonly MediaRenderer.manufacturer exists and type of string" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_serialNumber" purpose="Check if readonly MediaRenderer.serialNumber exists and type of string" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_manufacturer_basic" purpose="Check if MediaRenderer.manufacturer is valid" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_UDN" purpose="Check if readonly MediaRenderer.UDN exists and type of string" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_manufacturerURL" purpose="Check if readonly MediaRenderer.manufacturerURL exists and type of string" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_presentationURL" purpose="Check if readonly MediaRenderer.presentationURL exists and type of string" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_manufacturerURL_basic" purpose="Check if MediaRenderer.manufacturerURL is valid" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_iconURL" purpose="Check if readonly MediaRenderer.iconURL exists and type of string" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_modelDescription" purpose="Check if readonly MediaRenderer.modelDescription exists and type of string" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_deviceType" purpose="Check if readonly MediaRenderer.deviceType exists and type of string" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_modelDescription_basic" purpose="Check if MediaRenderer.modelDescription is valid" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_protocolInfo" purpose="Check if readonly MediaRenderer.protocolInfo exists and type of string" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_modelName" purpose="Check if readonly MediaRenderer.modelName exists and type of string" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_controller" purpose="Check if readonly MediaRenderer.controller exists and type of mediaController" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_modelName_basic" purpose="Check if MediaRenderer.modelName is valid" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_openURI" purpose="Check if MediaRenderer.openURI exists and type of function" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_modelNumber" purpose="Check if readonly MediaRenderer.modelNumber exists and type of string" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_prefetchURI" purpose="Check if MediaRenderer.prefetchURI exists and type of function" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_modelNumber_basic" purpose="Check if MediaRenderer.modelNumber is valid" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=16</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaRenderer_cancel" purpose="Check if MediaRenderer.cancel exists and type of function" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_serialNumber" purpose="Check if readonly MediaRenderer.serialNumber exists and type of string" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_playbackStatus" purpose="Check if readonly MediaController.playbackStatus exists and type of object" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_serialNumber_basic" purpose="Check if MediaRenderer.serialNumber is valid" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=16</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_muted" purpose="Check if readonly MediaController.muted exists and type of boolean" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_UDN" purpose="Check if readonly MediaRenderer.UDN exists and type of string" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_volume" purpose="Check if readonly MediaController.volume exists and type of number" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_UDN_basic" purpose="Check if MediaRenderer.UDN is valid" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=18</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_track" purpose="Check if readonly MediaController.track exists and type of number" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_presentationURL" purpose="Check if readonly MediaRenderer.presentationURL exists and type of string" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=19</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_speed" purpose="Check if readonly MediaController.speed exists and type of number" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_presentationURL_basic" purpose="Check if MediaRenderer.presentationURL is valid" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=20</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_playSpeeds" purpose="Check if readonly MediaController.playSpeeds exists and type of number" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_iconURL" purpose="Check if readonly MediaRenderer.iconURL exists and type of string" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=21</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_play" purpose="Check if MediaController.play exists and type of function" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_iconURL_basic" purpose="Check if MediaRenderer.iconURL is valid" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=22</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_pause" purpose="Check if MediaController.pause exists and type of function" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_deviceType" purpose="Check if readonly MediaRenderer.deviceType exists and type of string" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=23</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_stop" purpose="Check if MediaController.stop exists and type of function" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_deviceType_basic" purpose="Check if MediaRenderer.deviceType is valid" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=24</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_next" purpose="Check if MediaController.next exists and type of function" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_protocolInfo" purpose="Check if readonly MediaRenderer.protocolInfo exists and type of string" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=25</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_previous" purpose="Check if MediaController.previous exists and type of function" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_protocolInfo_basic" purpose="Check if MediaRenderer.protocolInfo is valid" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=26</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_mute" purpose="Check if MediaController.mute exists and type of function" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_controller" purpose="Check if readonly MediaRenderer.controller exists and type of mediaController" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=27</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_setSpeed" purpose="Check if MediaController.setSpeed exists and type of function" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_controller_basic" purpose="Check if MediaRenderer.controller is valid" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=28</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_setVolume" purpose="Check if MediaController.setVolume exists and type of function" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_openURI" purpose="Check if MediaRenderer.openURI exists and type of function" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=29</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_gotoTrack" purpose="Check if MediaController.gotoTrack exists and type of function" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_prefetchURI" purpose="Check if MediaRenderer.prefetchURI exists and type of function" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=30</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaController_onstatuschanged" purpose="Check if MediaController.onstatuschanged exists and type of event" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaRenderer_cancel" purpose="Check if MediaRenderer.cancel exists and type of function" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=16</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaRenderer.html?total_num=31&amp;amp;locator_key=id&amp;amp;value=31</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaControllerStatusEvent_playbackStatus" purpose="Check if readonly MediaControllerStatusEvent.playbackStatus exists and type of object" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaController_playbackStatus" purpose="Check if readonly MediaController.playbackStatus exists and type of string" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaControllerStatusEvent_muted" purpose="Check if readonly MediaControllerStatusEvent.muted exists and type of boolean" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaController_playbackStatus_basic" purpose="Check if MediaController.playbackStatus is valid" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaControllerStatusEvent_volume" purpose="Check if readonly MediaControllerStatusEvent.volume exists and type of number" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaController_muted" purpose="Check if readonly MediaController.muted exists and type of boolean" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaControllerStatusEvent_track" purpose="Check if readonly MediaControllerStatusEvent.track exists and type of number" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaController_muted_basic" purpose="Check if MediaController.muted is valid" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
         </description>
       </testcase>
-      <testcase component="WebAPI/Media Renderer API/DLNA" execution_type="auto" id="MediaControllerStatusEvent_speed" purpose="Check if readonly MediaControllerStatusEvent.speed exists and type of number" onload_delay="30">
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaController_volume" purpose="Check if readonly MediaController.volume exists and type of number" onload_delay="30">
         <description>
-          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=16&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaController_volume_basic" purpose="Check if MediaController.volume is valid" onload_delay="30">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaController_track" purpose="Check if readonly MediaController.track exists and type of number" onload_delay="30">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaController_track_basic" purpose="Check if MediaController.track is valid" onload_delay="30">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaController_speed" purpose="Check if readonly MediaController.speed exists and type of number" onload_delay="30">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaController_speed_basic" purpose="Check if MediaController.speed is valid" onload_delay="30">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaController_playSpeeds" purpose="Check if readonly MediaController.playSpeeds exists and type of number" onload_delay="30">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaController_playSpeeds_basic" purpose="Check if MediaController.playSpeeds is valid" onload_delay="30">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaController_play" purpose="Check if MediaController.play exists and type of function" onload_delay="30">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaController_pause" purpose="Check if MediaController.pause exists and type of function" onload_delay="30">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaController_stop" purpose="Check if MediaController.stop exists and type of function" onload_delay="30">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaController_next" purpose="Check if MediaController.next exists and type of function" onload_delay="30">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=16</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaController_previous" purpose="Check if MediaController.previous exists and type of function" onload_delay="30">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaController_mute" purpose="Check if MediaController.mute exists and type of function" onload_delay="30">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=18</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaController_setSpeed" purpose="Check if MediaController.setSpeed exists and type of function" onload_delay="30">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=19</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaController_setVolume" purpose="Check if MediaController.setVolume exists and type of function" onload_delay="30">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=20</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaController_gotoTrack" purpose="Check if MediaController.gotoTrack exists and type of function" onload_delay="30">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=21</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaController_onstatuschanged" purpose="Check if MediaController.onstatuschanged exists and type of event" onload_delay="30">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaController.html?total_num=22&amp;amp;locator_key=id&amp;amp;value=22</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaControllerStatusEvent_playbackStatus" purpose="Check if readonly MediaControllerStatusEvent.playbackStatus exists and type of string" onload_delay="30">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaControllerStatusEvent_playbackStatus_basic" purpose="Check if MediaControllerStatusEvent.playbackStatus is valid" onload_delay="30">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaControllerStatusEvent_muted" purpose="Check if readonly MediaControllerStatusEvent.muted exists and type of boolean" onload_delay="30">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaControllerStatusEvent_muted_basic" purpose="Check if MediaControllerStatusEvent.muted is valid" onload_delay="30">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaControllerStatusEvent_volume" purpose="Check if readonly MediaControllerStatusEvent.volume exists and type of number" onload_delay="30">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaControllerStatusEvent_volume_basic" purpose="Check if MediaControllerStatusEvent.volume is valid" onload_delay="30">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaControllerStatusEvent_track" purpose="Check if readonly MediaControllerStatusEvent.track exists and type of number" onload_delay="30">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaControllerStatusEvent_track_basic" purpose="Check if MediaControllerStatusEvent.track is valid" onload_delay="30">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaControllerStatusEvent_speed" purpose="Check if readonly MediaControllerStatusEvent.speed exists and type of number" onload_delay="30">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DLNA/MediaRenderer" execution_type="auto" id="MediaControllerStatusEvent_speed_basic" purpose="Check if MediaControllerStatusEvent.speed is valid" onload_delay="30">
+        <description>
+          <test_script_entry>/opt/webapi-mediarenderer-xwalk-tests/mediarenderer/MediaControllerStatusEvent.html?total_num=10&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
         </description>
       </testcase>
     </set>


### PR DESCRIPTION
- Update the playbackStatus attribute of type and add 28 basic TCs
- Failure analysis: The statuschanged event nad rendererlost event cannot be fired

Impacted tests(approved): new 28, update 3, delete 0
Unit test platform: [Tizen IVI]
Unit test result summary: pass 52, fail 8, block 12
