### PR TITLE
[webapi][XWALK-2363] Fix issue by using regexp to verify nativeAPIVersion of SystemInfo

### DIFF
--- a/webapi/tct-systeminfo-tizen-tests/systeminfo/SystemInfoDeviceCapability_nativeApiVersion_attribute.html
+++ b/webapi/tct-systeminfo-tizen-tests/systeminfo/SystemInfoDeviceCapability_nativeApiVersion_attribute.html
@@ -41,8 +41,8 @@ test(function () {
     check_readonly(deviceCapabilities, "nativeApiVersion",
         deviceCapabilities.nativeApiVersion, "string", null);
     assert_true(deviceCapabilities.nativeApiVersion !== "", "null check");
-    assert_equals(deviceCapabilities.nativeApiVersion, "2.2",
-        "nativeApiVersion is not 2.2");
+    //The version of the native API in the [Major].[Minor] format(e.g. 1.0, 2.1)
+    assert_regexp_match(deviceCapabilities.nativeApiVersion, /^[0-9]+\.[0-9]+$/);
 }, document.title);
 
 </script>


### PR DESCRIPTION
- Because IVI platform version may be change, but TC set default nativeAPIVersion 2.2, so update version verfy by regexp.

Impacted TCs num(approved): New 0, Update 1, Delete 0
Unit test Platform: Tizen IVI
Tizen test result summary: Pass 1, Fail 0, Blocked 0
