### PR TITLE
[xwalkdriver] Update activity name for crosswalk android package rule changed

### DIFF
--- a/webdriver/webdriver-w3c-tests/base_test.py
+++ b/webdriver/webdriver-w3c-tests/base_test.py
@@ -29,7 +29,7 @@ def create_driver():
     capabilities = {
         'xwalkOptions': {
             'androidPackage': 'org.xwalk.xwalkdrivertest',
-            'androidActivity': '.XwalkDriverTestActivity',
+            'androidActivity': '.XwalkdrivertestActivity',
         }
     }
     return webdriver.Remote('http://localhost:9515', capabilities)


### PR DESCRIPTION
Impacted tests(approved): new 0, update 0, delete 0 
Unit test platform: [Android]
Unit test result summary: pass 53, fail 9, block 52

Fail and Block reason: XWALK-2433, XWALK-2437, XWALK-2443, XWALK-2444
