### PR TITLE
[webapi][XWALK-2450] Fix bug for contactsmanager

### DIFF
--- a/webapi/webapi-contactsmanager-sysapps-tests/contactsmanager/ContactsChangeEvent_added.html
+++ b/webapi/webapi-contactsmanager-sysapps-tests/contactsmanager/ContactsChangeEvent_added.html
@@ -42,7 +42,7 @@ Authors:
 
 var t = async_test("Check if the implementation of ContactsChangeEvent added attribute is valid", { timeout: 2000});
 t.step(function () {
-  contacts.clear().then(function () {/* Do Nothing */}, function () {/* Do Nothing */});
+  contacts.clear();
   var contactName = new ContactName({
     givenNames: ['John'],
     familyNames: ['Doe']
@@ -57,12 +57,14 @@ t.step(function () {
     phoneNumbers: [mobilePhone]
   });
   contacts.addEventListener("contactschange", function (e) {
-    t.step(function () {
-      assert_not_equals(e.added[0], null, "The ContactsChangeEvent.added[0]");
-    });
-    t.done();
+    if (e.added[0]) {
+      t.step(function () {
+        assert_not_equals(e.added[0], null, "The ContactsChangeEvent.added[0]");
+      });
+      t.done();
+    }
   });
-  contacts.save(contact).then(function () {/* Do Nothing */}, function () {/* Do Nothing */});
+  contacts.save(contact);
 });
 
  </script>

--- a/webapi/webapi-contactsmanager-sysapps-tests/contactsmanager/ContactsChangeEvent_added_attribute.html
+++ b/webapi/webapi-contactsmanager-sysapps-tests/contactsmanager/ContactsChangeEvent_added_attribute.html
@@ -43,7 +43,7 @@ var t = async_test("Check if the readonly attribute ContactsChangeEvent.added ex
 
 t.step(function () {
   assert_true(!!contacts, "The Navigator support contacts");
-  contacts.clear().then(function () {/* Do Nothing */}, function () {/* Do Nothing */});
+  contacts.clear();
 
   var contactName = new ContactName({
     givenNames: ['John'],
@@ -59,15 +59,17 @@ t.step(function () {
     phoneNumbers: [mobilePhone]
   });
   contacts.addEventListener("contactschange", function (e) {
-    t.step(function () {
-      assert_true("added" in e, "The ContactsChangeEvent.added exists");
-      assert_equals(typeof e.added, "object", "The type of ContactsChangeEvent.added");
-      var value = e.added;
-      e.added = null;
-      assert_equals(e.added, value, "The ContactsChangeEvent.added");
-    });
-    t.done();
+    if (e.added[0]) {
+      t.step(function () {
+        assert_true("added" in e, "The ContactsChangeEvent.added exists");
+        assert_equals(typeof e.added, "object", "The type of ContactsChangeEvent.added");
+        var value = e.added;
+        e.added = null;
+        assert_equals(e.added, value, "The ContactsChangeEvent.added");
+      });
+      t.done();
+    }
   });
-  contacts.save(contact).then(function () {/* Do Nothing */}, function () {/* Do Nothing */});
+  contacts.save(contact);
 });
  </script>

--- a/webapi/webapi-contactsmanager-sysapps-tests/contactsmanager/ContactsChangeEvent_modified.html
+++ b/webapi/webapi-contactsmanager-sysapps-tests/contactsmanager/ContactsChangeEvent_modified.html
@@ -40,10 +40,11 @@ Authors:
 <div id="log"></div>
 <script>
 var t = async_test("Check if the implementation of ContactsChangeEvent modified attribute is valid", {timeout: 2000});
+var id;
 
 t.step(function () {
   assert_true(!!contacts, "The Navigator support contacts");
-  contacts.clear().then(function () {/* Do Nothing */}, function () {/* Do Nothing */});
+  contacts.clear();
 
   var contactName = new ContactName({
     givenNames: ['John'],
@@ -58,15 +59,21 @@ t.step(function () {
     name: contactName,
     phoneNumbers: [mobilePhone]
   });
-  contacts.save(contact).then(function () {/* Do Nothing */}, function () {/* Do Nothing */});
-  contacts.addEventListener("contactschange", function (e) {
-    t.step(function () {
-     assert_not_equals(e.modified[0], null, "The ContactsChangeEvent.modified[0]");
-     assert_equals(e.modified[0], contact.id, "The ContactsChangeEvent.modified[0]");
+  contacts.save(contact).then(function () {
+    contacts.find().then(function (cons) {
+      cons[0].name.familyNames[0] = "kobe";
+      id = cons[0].id;
+      contacts.save(cons[0]);
     });
-    t.done();
   });
-  contact.name.familyNames[0] = "kobe";
-  contacts.save(contact).then(function () {/* Do Nothing */}, function () {/* Do Nothing */});
+  contacts.addEventListener("contactschange", function (e) {
+    if (e.modified[0]) {
+      t.step(function () {
+       assert_not_equals(e.modified[0], null, "The ContactsChangeEvent.modified[0]");
+       assert_equals(e.modified[0], id, "The ContactsChangeEvent.modified[0]");
+      });
+      t.done();
+    }
+  });
 });
 </script>

--- a/webapi/webapi-contactsmanager-sysapps-tests/contactsmanager/ContactsChangeEvent_modified_attribute.html
+++ b/webapi/webapi-contactsmanager-sysapps-tests/contactsmanager/ContactsChangeEvent_modified_attribute.html
@@ -40,10 +40,11 @@ Authors:
 <div id="log"></div>
 <script>
 var t = async_test("Check if the readonly attribute ContactsChangeEvent.modified exists and typeof object", {timeout: 2000});
+var id;
 
 t.step(function () {
   assert_true(!!contacts, "The Navigator support contacts");
-  contacts.clear().then(function () {/* Do Nothing */}, function () {/* Do Nothing */});
+  contacts.clear();
 
   var contactName = new ContactName({
     givenNames: ['John'],
@@ -58,18 +59,24 @@ t.step(function () {
     name: contactName,
     phoneNumbers: [mobilePhone]
   });
-  contacts.save(contact).then(function () {/* Do Nothing */}, function () {/* Do Nothing */});
-  contacts.addEventListener("contactschange", function (e) {
-    t.step(function () {
-      assert_true("modified" in e, "The ContactsChangeEvent.modified exists");
-      assert_equals(typeof e.modified, "object", "The type of ContactsChangeEvent.modified");
-      var value = e.modified;
-      e.modified = null;
-      assert_equals(e.modified, value, "The ContactsChangeEvent.modified");
+  contacts.save(contact).then(function () {
+    contacts.find().then(function (cons) {
+      cons[0].name.familyNames[0] = "kobe";
+      id = cons[0].id;
+      contacts.save(cons[0]);
     });
-    t.done();
   });
-  contact.name.familyNames[0] = "kobe";
-  contacts.save(contact).then(function () {/* Do Nothing */}, function () {/* Do Nothing */});
+  contacts.addEventListener("contactschange", function (e) {
+    if (e.modified[0]) {
+      t.step(function () {
+        assert_true("modified" in e, "The ContactsChangeEvent.modified exists");
+        assert_equals(typeof e.modified, "object", "The type of ContactsChangeEvent.modified");
+        var value = e.modified;
+        e.modified = null;
+        assert_equals(e.modified, value, "The ContactsChangeEvent.modified");
+      });
+      t.done();
+    }
+  });
 });
 </script>


### PR DESCRIPTION
- Fix case bug for contactsmanager
- Failure analysis: The Contact.id attribute of type should be string by spec, but get number on crosswalk-9.37.194.0

Impacted tests(approved): new 0, update 4, delete 0
Unit test platform: [Android]
Unit test result summary: pass 3, fail 1, block 0
