### PR TITLE
Fix bugs of CSS3 mediaqueries' test cases

### DIFF
--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_Mediaqueries_at_import.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_Mediaqueries_at_import.html
@@ -39,7 +39,6 @@ Authors:
     <link rel="stylesheet" media="screen and (color)" href="color.css" />
     <meta name="flags" content="" />
     <meta name="assert" content="Check that With 'media='screen and (color), projection and (color)'' mode to test the media queries syntax in HTML" />
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
@@ -48,14 +47,9 @@ Authors:
     <div id="media"></div>
     <script>
       test(function () {
-        try {
-          var div = document.querySelector("#media");
-          var color = GetCurrentStyle("color");
-          assert_equals(color, "rgb(255, 102, 0)", "The text color");
-        } catch (err) {
-          assert_unreached(err.name + err.message);
-        }
-      }, document.title);
+        var color = getComputedStyle(document.getElementById("media"))["color"];
+        assert_equals(color, "rgb(255, 102, 0)", "The text color");
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_Mediaqueries_at_media.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_Mediaqueries_at_media.html
@@ -38,7 +38,6 @@ Authors:
     <link rel="help" href="http://www.w3.org/TR/2012/REC-css3-mediaqueries-20120619/#media0" />
     <meta name="flags" content="" />
     <meta name="assert" content="Check that with '@media screen and (color), projection and (color) { … }' mode to test the media queries syntax" />
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
     <style>
@@ -49,17 +48,12 @@ Authors:
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" ></div>
+    <div id="media"></div>
     <script>
       test(function () {
-        try {
-          var div = document.querySelector("#media");
-          var color = GetCurrentStyle("color");
-          assert_equals(color, "rgb(255, 102, 0)", "The text color");
-        } catch (err) {
-          assert_unreached(err.name + err.message);
-        }
-      }, document.title);
+        var color = getComputedStyle(document.getElementById("media"))["color"];
+        assert_equals(color, "rgb(255, 102, 0)", "The text color");
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_Mediaqueries_import-rule.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_Mediaqueries_import-rule.html
@@ -38,7 +38,6 @@ Authors:
     <link rel="help" href="http://www.w3.org/TR/2012/REC-css3-mediaqueries-20120619/#media0" />
     <meta name="flags" content="" />
     <meta name="assert" content="CHeck that with '@import url(example.css) screen and (color), projection and (color);' mode to test the media queries syntax" />
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
     <style>
@@ -47,17 +46,12 @@ Authors:
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" ></div>
+    <div id="media"></div>
     <script>
       test(function () {
-        try {
-          var div = document.querySelector("#media");
-          var color = GetCurrentStyle("color");
-          assert_equals(color, "rgb(255, 102, 0)", "The text color");
-        } catch (err) {
-          assert_unreached(err.name + err.message);
-        }
-      }, document.title);
+        var color = getComputedStyle(document.getElementById("media"))["color"];
+        assert_equals(color, "rgb(255, 102, 0)", "The text color");
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_aspect-ratio_max_value_1virgule0.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_aspect-ratio_max_value_1virgule0.html
@@ -43,22 +43,17 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >set 'screen; min-aspect-ratio:1/0' on CSS3 Media Queries aspect-ratio attr, this text will not displays in red</div>
+    <div id="media">set 'screen; min-aspect-ratio:1/0' on CSS3 Media Queries aspect-ratio attr, this text will not displays in red</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
-        EqualTest(color, "rgb(0, 0, 0)", "The text color");
-      }catch (err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
+        assert_equals(color, "rgb(0, 0, 0)", "The text color");
+      }, document.title)
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_aspect-ratio_max_value_1virgule1.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_aspect-ratio_max_value_1virgule1.html
@@ -43,26 +43,21 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >set 'screen; max-aspect-ratio:1/1' on CSS3 Media Queries aspect-ratio attr, When the page is visible in the output device and the page width and height ratio less than or equal to 1/1, this text will displays in orange</div>
+    <div id="media">set 'screen; max-aspect-ratio:1/1' on CSS3 Media Queries aspect-ratio attr, When the page is visible in the output device and the page width and height ratio less than or equal to 1/1, this text will displays in orange</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(document.body.scrollWidth/document.body.scrollHeight <= 1) {
-          EqualTest(color, "rgb(255, 0, 0)", "The text color");
+          assert_equals(color, "rgb(255, 0, 0)", "The text color");
         }else {
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch (err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_aspect-ratio_min_59virgule79.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_aspect-ratio_min_59virgule79.html
@@ -42,26 +42,21 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >set 'min-aspect-ratio:59/79' on CSS3 Media Queries aspect-ratio, When the page is visible in the output device and the page width and height ratio more than or equal to 59/79, this text will displays in red</div>
+    <div id="media">set 'min-aspect-ratio:59/79' on CSS3 Media Queries aspect-ratio, When the page is visible in the output device and the page width and height ratio more than or equal to 59/79, this text will displays in red</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(document.body.scrollWidth/document.body.scrollHeight >= 59/79) {
-          EqualTest(color, "rgb(255, 0, 0)", "The text color");
+          assert_equals(color, "rgb(255, 0, 0)", "The text color");
         }else {
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch (err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_aspect-ratio_min_value_0virgule1.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_aspect-ratio_min_value_0virgule1.html
@@ -41,7 +41,6 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
@@ -49,12 +48,10 @@ Authors:
     <div id="log"></div>
     <div id="media">The text should be black.</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        EqualTest(GetCurrentStyle("color"), "rgb(0, 255, 0)", "The text color");
-      }catch (err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
+        assert_equals(color, "rgb(0, 0, 0)", "The text color");
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_aspect-ratio_value_59virgule80.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_aspect-ratio_value_59virgule80.html
@@ -45,24 +45,19 @@ Authors:
     </style>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
-    <script src="MediaQueries.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >Set 'screen; aspect-ratio:59/80' on CSS3 Media Queries, When the page is visible in the output device and the page width and height ratio equal to 59/80, this text will displays in red. Try to adjust your viewport to make the page width between this interval to see the effect</div>
+    <div id="media">Set 'screen; aspect-ratio:59/80' on CSS3 Media Queries, When the page is visible in the output device and the page width and height ratio equal to 59/80, this text will displays in red. Try to adjust your viewport to make the page width between this interval to see the effect</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(document.body.scrollWidth/document.body.scrollHeight == 59/80) {
-          EqualTest(color, "rgb(255, 0, 0)", "The text color");
+          assert_equals(color, "rgb(255, 0, 0)", "The text color");
         }else {
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch (err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_color_max_0.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_color_max_0.html
@@ -43,26 +43,21 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" > set "max-color:0" on the CSS3 Media color attr,when the device is not a color device, the value of color is zero, this text will displays in red</div>
+    <div id="media"> set "max-color:0" on the CSS3 Media color attr,when the device is not a color device, the value of color is zero, this text will displays in red</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(screen.colorDepth <= 0) {
-          EqualTest(color, "rgb(255, 0, 0)", "The text color");
+          assert_equals(color, "rgb(255, 0, 0)", "The text color");
         }else {
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch(err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_color_max_255.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_color_max_255.html
@@ -43,26 +43,21 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >set "max-color:255" on the CSS3 Media color attr, when the number of bits per color component of your  output device is less than or equals to 256, this text will displays in red</div>
+    <div id="media">set "max-color:255" on the CSS3 Media color attr, when the number of bits per color component of your  output device is less than or equals to 256, this text will displays in red</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(screen.colorDepth <= 255) {
-          EqualTest(color, "rgb(255, 0, 0)", "The text color");
+          assert_equals(color, "rgb(255, 0, 0)", "The text color");
         }else {
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch(err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_color_max_neg_1.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_color_max_neg_1.html
@@ -43,7 +43,7 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
+
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
@@ -51,12 +51,10 @@ Authors:
     <div id="log"></div>
     <div id="media">The text should be black.</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        EqualTest(GetCurrentStyle("color"), "rgb(0, 0, 0)", "The text color");
-      }catch(err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      test(function(){
+        var color = getComputedStyle(document.getElementById("media"))["color"];
+        assert_equals(color, "rgb(0, 0, 0)", "The text color");
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_color_min_2.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_color_min_2.html
@@ -43,26 +43,21 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >set "min-color:2" on the CSS3 Media color attr, when the number of bits per color component of the output device is greater than or equals to 2, this text will displays in red</div>
+    <div id="media">set "min-color:2" on the CSS3 Media color attr, when the number of bits per color component of the output device is greater than or equals to 2, this text will displays in red</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(screen.colorDepth >= 2) {
-          EqualTest(color, "rgb(255, 0, 0)", "The text color");
+          assert_equals(color, "rgb(255, 0, 0)", "The text color");
         }else {
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch(err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_color_min_neg_0.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_color_min_neg_0.html
@@ -42,7 +42,6 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
  </head>
@@ -50,12 +49,10 @@ Authors:
     <div id="log"></div>
     <div id="media">The text should be red.</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        EqualTest(GetCurrentStyle("color"), "rgb(255, 0, 0)", "The text color");
-      }catch(err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
+        assert_equals(color, "rgb(255, 0, 0)", "The text color");
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_color_min_neg_1.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_color_min_neg_1.html
@@ -41,7 +41,7 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
+
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
@@ -49,12 +49,10 @@ Authors:
     <div id="log"></div>
     <div id="media">The text should be black.</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        EqualTest(GetCurrentStyle("color"), "rgb(0, 0, 0)", "The text color");
-      }catch(err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
+        assert_equals(color, "rgb(0, 0, 0)", "The text color");
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_device-aspect-ratio_max_value_1281virgule1024.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_device-aspect-ratio_max_value_1281virgule1024.html
@@ -43,26 +43,21 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >Set "screen;max-device-aspect-ratio: 1281/1024" on the CSS3 Media Queries device-aspect-ratio attr, When the output device screen resolution is less than or equal to 1281/1024, this text will displays in red</div>
+    <div id="media">Set "screen;max-device-aspect-ratio: 1281/1024" on the CSS3 Media Queries device-aspect-ratio attr, When the output device screen resolution is less than or equal to 1281/1024, this text will displays in red</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(window.screen.width/window.screen.height <= 1281/1024) {
-          EqualTest(color, "rgb(255, 0, 0)", "The text color");
+          assert_equals(color, "rgb(255, 0, 0)", "The text color");
         }else {
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch(err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_device-aspect-ratio_max_value_1virgule0.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_device-aspect-ratio_max_value_1virgule0.html
@@ -43,22 +43,17 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >Set 'screen;max-device-aspect-ratio: 1/0' on the CSS3 Media Queries device-aspect-ratio attr, this text will not displays in red</div>
+    <div id="media">Set 'screen;max-device-aspect-ratio: 1/0' on the CSS3 Media Queries device-aspect-ratio attr, this text will not displays in red</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
-        EqualTest(color, "rgb(0, 0, 0)", "The text color");
-      }catch(err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
+        assert_equals(color, "rgb(0, 0, 0)", "The text color");
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_device-aspect-ratio_min_1280virgule1024.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_device-aspect-ratio_min_1280virgule1024.html
@@ -43,26 +43,21 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >set 'min-device-aspect-ratio:1280/1024'on CSS3 Media Queries device-aspect-ratio attr, When the output device screen resolution is more than or equal to 1280:1024, this text will displays in red</div>
+    <div id="media">set 'min-device-aspect-ratio:1280/1024'on CSS3 Media Queries device-aspect-ratio attr, When the output device screen resolution is more than or equal to 1280:1024, this text will displays in red</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(window.screen.width/window.screen.height >= 1280/1024) {
-          EqualTest(color, "rgb(255, 0, 0)", "The text color");
+          assert_equals(color, "rgb(255, 0, 0)", "The text color");
         }else {
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch(err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_device-aspect-ratio_min_value_0virgule1.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_device-aspect-ratio_min_value_0virgule1.html
@@ -41,7 +41,6 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
@@ -49,12 +48,10 @@ Authors:
     <div id="log"></div>
     <div id="media">The text should be black.</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        EqualTest(GetCurrentStyle("color"), "rgb(0, 0, 0)", "The text color");
-      }catch(err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
+        assert_equals(color, "rgb(0, 0, 0)", "The text color");
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_device-aspect-ratio_value_1280virgule1024.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_device-aspect-ratio_value_1280virgule1024.html
@@ -43,26 +43,21 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >Set "screen; device-aspect-ratio: 1280/1024;" on CSS3 Media Queries device-aspect-ratio attr, When the output device screen resolution is 1280/1024, the text will become red</div>
+    <div id="media">Set "screen; device-aspect-ratio: 1280/1024;" on CSS3 Media Queries device-aspect-ratio attr, When the output device screen resolution is 1280/1024, the text will become red</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(window.screen.width/window.screen.height == 1280/1024) {
-          EqualTest(color, "rgb(255, 0, 0)", "The text color");
+          assert_equals(color, "rgb(255, 0, 0)", "The text color");
         }else {
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch(err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_device-height_max_vaule_1300px.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_device-height_max_vaule_1300px.html
@@ -43,26 +43,21 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >Set "max-device-height: 1300px" on CSS3 Media Queries device-height attr, when your device is less than or equals to 1300px in height, this text will displays in red</div>
+    <div id="media">Set "max-device-height: 1300px" on CSS3 Media Queries device-height attr, when your device is less than or equals to 1300px in height, this text will displays in red</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(window.screen.height <= 1300) {
-          EqualTest(color, "rgb(255, 0, 0)", "The text color");
+          assert_equals(color, "rgb(255, 0, 0)", "The text color");
         }else {
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch(err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_device-height_max_vaule_neg_1300px.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_device-height_max_vaule_neg_1300px.html
@@ -43,7 +43,6 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
@@ -51,12 +50,10 @@ Authors:
     <div id="log"></div>
     <div id="media">The text should be black.</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        EqualTest(GetCurrentStyle("color"), "rgb(0, 0, 0)", "The text color");
-      }catch(err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
+        assert_equals(color, "rgb(0, 0, 0)", "The text color");
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_device-height_min_neg_0.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_device-height_min_neg_0.html
@@ -43,7 +43,6 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
@@ -51,12 +50,10 @@ Authors:
     <div id="log"></div>
     <div id="media">The text should be red.</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        EqualTest(GetCurrentStyle("color"), "rgb(255, 0, 0)", "The text color");
-      }catch(err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
+        assert_equals(color, "rgb(255, 0, 0)", "The text color");
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_device-height_value_1024px.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_device-height_value_1024px.html
@@ -43,26 +43,21 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >Set "screen;device-height:1024px;" When your output device is 1024px in height the text will displays in red</div>
+    <div id="media">Set "screen;device-height:1024px;" When your output device is 1024px in height the text will displays in red</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(window.screen.height == 1024) {
-          EqualTest(color, "rgb(255, 0, 0)", "The text color");
+          assert_equals(color, "rgb(255, 0, 0)", "The text color");
         }else {
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch(err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_device-height_value_between_900px_and_1200px.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_device-height_value_between_900px_and_1200px.html
@@ -43,26 +43,21 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >Set "screen;max-device-height: 1200px;min-device-height: 900px" on CSS3 Media Queries device-height attr, When your output device is between 900px and 1200px in height the text will displays in red</div>
+    <div id="media">Set "screen;max-device-height: 1200px;min-device-height: 900px" on CSS3 Media Queries device-height attr, When your output device is between 900px and 1200px in height the text will displays in red</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(window.screen.height <= 1200 && window.screen.height >= 900) {
-          EqualTest(color, "rgb(255, 0, 0)", "The text color");
+          assert_equals(color, "rgb(255, 0, 0)", "The text color");
         }else {
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch(err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_device-width_max_positive.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_device-width_max_positive.html
@@ -43,26 +43,21 @@ Authors:
         #media{color:#f60;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body >
     <div id="log"></div>
-    <div id="media" >Set "max-width: 480px;" on CSS3 Media Queries height attr; When the broswer width is less than 960px the text will displays in orange</div>
+    <div id="media">Set "max-width: 480px;" on CSS3 Media Queries height attr; When the broswer width is less than 960px the text will displays in orange</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(window.screen.width <= 960) {
-          EqualTest(color, "rgb(255, 102, 0)", "The text color");
+          assert_equals(color, "rgb(255, 102, 0)", "The text color");
         }else {
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch(err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_device-width_min_neg_0.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_device-width_min_neg_0.html
@@ -43,7 +43,6 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
@@ -51,12 +50,10 @@ Authors:
     <div id="log"></div>
     <div id="media">The text should be red.</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        EqualTest(GetCurrentStyle("color"), "rgb(255, 0, 0)", "The text color");
-      }catch(err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
+        assert_equals(color, "rgb(255, 0, 0)", "The text color");
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_device-width_value_1280px.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_device-width_value_1280px.html
@@ -43,26 +43,21 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >Set "screen;device-width:1280px;" When your output device is 1024px in width the text will displays in red</div>
+    <div id="media">Set "screen;device-width:1280px;" When your output device is 1024px in width the text will displays in red</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(window.screen.width == 1280) {
-          EqualTest(color, "rgb(255, 0, 0)", "The text color");
+          assert_equals(color, "rgb(255, 0, 0)", "The text color");
         }else {
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch(err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_device-width_value_between_900px_and_1200px.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_device-width_value_between_900px_and_1200px.html
@@ -43,26 +43,21 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >Set "screen;max-device-width: 1200px;min-device-width: 900px" on CSS3 Media Queries device-width attr, When your output device is between 900px and 1200px in width the text will displays in red</div>
+    <div id="media">Set "screen;max-device-width: 1200px;min-device-width: 900px" on CSS3 Media Queries device-width attr, When your output device is between 900px and 1200px in width the text will displays in red</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(window.screen.width <= 1200 && window.screen.width >= 900) {
-          EqualTest(color, "rgb(255, 0, 0)", "The text color");
+          assert_equals(color, "rgb(255, 0, 0)", "The text color");
         }else {
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch(err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_height_min_neg_0.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_height_min_neg_0.html
@@ -43,7 +43,6 @@ Authors:
         #media{ color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
@@ -51,12 +50,10 @@ Authors:
     <div id="log"></div>
     <div id="media">The text should be red.</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-          EqualTest(GetCurrentStyle("color"), "rgb(255, 0, 0)", "The text color");
-      }catch (err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
+        assert_equals(color, "rgb(255, 0, 0)", "The text color");
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_height_value_800px.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_height_value_800px.html
@@ -43,26 +43,21 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >Set "height: 800px" on CSS3 Media Queries height attr, When the browser height is 800px the text will displays in red</div>
+    <div id="media">Set "height: 800px" on CSS3 Media Queries height attr, When the browser height is 800px the text will displays in red</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(document.body.scrollHeight == 800) {
-          EqualTest(color, "rgb(255, 0, 0)", "The text color");
+          assert_equals(color, "rgb(255, 0, 0)", "The text color");
         } else{
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch (err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_height_value_between_900px_and_1200px.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_height_value_between_900px_and_1200px.html
@@ -36,33 +36,26 @@ Authors:
     <title>CSS3MediaQueries Test: CSS3MQ_height_value_between_900px_and_1200px</title>
     <link rel="author" title="Intel" href="http://www.intel.com/" />
     <link rel="help" href="http://www.w3.org/TR/2012/REC-css3-mediaqueries-20120619/#height" />
-    <meta name="flags" content="" />
-    <meta name="assert" content="Set 'max-height: 1200px;min-height: 900px' on the Media Queries height attr; When your output device is between 900px and 1200px in height, the text will display in red" />
     <style>
       @media all and (max-height: 1200px) and (min-height: 900px) {
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >Set 'max-height: 1200px;min-height: 900px' on the Media Queries height attr; When your output device is between 900px and 1200px in height, the text will display in red</div>
+    <div id="media">If your output device's height is between 900px and 1200px, the text should be red.</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(document.body.scrollHeight <= 1200 && document.body.scrollHeight >= 900 ) {
-          EqualTest(color, "rgb(255, 0, 0)", "The text color");
+          assert_equals(color, "rgb(255, 0, 0)", "The text color");
         } else{
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch (err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_height_value_max_1300px.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_height_value_max_1300px.html
@@ -39,30 +39,25 @@ Authors:
     <meta name="flags" content="" />
     <meta name="assert" content="Set 'max-height: 1300px' on CSS3 Media Queries width attr; When the browser height is less than or equal to 1300px, the text will displays in red" />
     <style>
-      @media  screen and (max-height: 1300px) {
+      @media screen and (max-height: 1300px) {
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >Set 'max-height: 1300px' on CSS3 Media Queries width attr; When the browser height is less than or equal to 1300px the text will displays in red</div>
+    <div id="media">If the browser height is less than or equal to 1300px, the text should be red.</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(document.body.scrollHeight <= 1300 ) {
-          EqualTest(color, "rgb(255, 0, 0)", "The text color");
+          assert_equals(color, "rgb(255, 0, 0)", "The text color");
         } else{
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch (err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      }, document.title)
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_height_value_max_neg_1300px.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_height_value_max_neg_1300px.html
@@ -43,7 +43,6 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
@@ -51,12 +50,10 @@ Authors:
     <div id="log"></div>
     <div id="media">The text should be black.</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        EqualTest(GetCurrentStyle("color"), "rgb(0, 0, 0)", "The text color");
-      }catch (err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
+        assert_equals(color, "rgb(0, 0, 0)", "The text color");
+      }, document.title)
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_height_value_neg_800px.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_height_value_neg_800px.html
@@ -43,22 +43,17 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >Set "height: -800px" on CSS3 Media Queries height attr, the text will not displays in red</div>
+    <div id="media">The text should be black.</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
-        EqualTest(color, "rgb(0, 0, 0)", "The text color");
-      }catch (err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
+        assert_equals(color, "rgb(0, 0, 0)", "The text color");
+      }, document.title)
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_media_aspect_ratio.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_media_aspect_ratio.html
@@ -37,32 +37,27 @@ Authors:
     <link rel="author" title="Intel" href="http://www.intel.com/" />
     <link rel="help" href="http://www.w3.org/TR/2012/REC-css3-mediaqueries-20120619/#aspect-ratio" />
     <meta name="flags" content="" />
-    <meta name="assert" content="When the page is visible in the output device width and height ratio less than or equal to 20:11, the Bank text is displayed in red" />
+    <meta name="assert" content="When the page is visible in the output device and its width and height ratio less than or equal to 20:11, the text is displayed in red" />
     <style>
       @media screen and (max-aspect-ratio:20/11) {
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
    </head>
    <body>
      <div id="log"></div>
-     <div id="media" >When the page is visible in the output device width and height ratio less than or equal to 20:11, the Bank text is displayed in red</div>
+     <div id="media">When the page is visible in the output device and its width and height ratio less than or equal to 20:11, the text is displayed in red.</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(document.body.scrollWidth/document.body.scrollHeight <= 20/11) {
-          EqualTest(color, "rgb(255, 0, 0)", "The text color");
+          assert_equals(color, "rgb(255, 0, 0)", "The text color");
         } else{
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch (err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_media_color.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_media_color.html
@@ -36,29 +36,22 @@ Authors:
     <title>CSS3MediaQueries Test: CSS3MQ_media_color</title>
     <link rel="author" title="Intel" href="http://www.intel.com/" />
     <link rel="help" href="http://www.w3.org/TR/2012/REC-css3-mediaqueries-20120619/#color" />
-    <meta name="flags" content="" />
-    <meta name="assert" content="When your output device is the color of, the Bank text is displayed in red" />
     <style>
       @media screen and (color) {
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >When your output device is the color of, the Bank text is displayed in red</div>
+    <div id="media">The text should be red.</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
-        EqualTest(color, "rgb(255, 0, 0)", "The text color");
-      }catch(err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
+        assert_equals(color, "rgb(255, 0, 0)", "The text color");
+      }, document.title)
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_media_device_aspect_ratio.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_media_device_aspect_ratio.html
@@ -37,32 +37,27 @@ Authors:
     <link rel="author" title="Intel" href="http://www.intel.com/" />
     <link rel="help" href="http://www.w3.org/TR/2012/REC-css3-mediaqueries-20120619/#device-aspect-ratio" />
     <meta name="flags" content="" />
-    <meta name="assert" content="When the output device screen resolution of 16:10, the Bank text is displayed in red" />
+    <meta name="assert" content="When the output device screen resolution of 16:10, the text is displayed in red" />
     <style>
       @media screen and (device-aspect-ratio:16/10) {
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >When the output device screen resolution of 16:10, the Bank text is displayed in red</div>
+    <div id="media">When the output device screen resolution of 16:10, the text is displayed in red</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(window.screen.width/window.screen.height == 16/10) {
-          EqualTest(color, "rgb(255, 0, 0)", "The text color");
+          assert_equals(color, "rgb(255, 0, 0)", "The text color");
         }else {
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch(err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      }, document.title)
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_media_device_height.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_media_device_height.html
@@ -37,32 +37,27 @@ Authors:
     <link rel="author" title="Intel" href="http://www.intel.com/" />
     <link rel="help" href="http://www.w3.org/TR/2012/REC-css3-mediaqueries-20120619/#device-height" />
     <meta name="flags" content="" />
-    <meta name="assert" content="When your output device resolution is set more than 800px in height, the Bank text is displayed in red" />
+    <meta name="assert" content="When your output device resolution is set more than 800px in height, the text is displayed in red" />
     <style>
       @media screen and (min-device-height:800px) {
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >When your output device resolution is set more than 800px in height, the Bank text is displayed in red</div>
+    <div id="media">When your output device resolution is set more than 800px in height, the text is displayed in red</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(window.screen.height >= 800) {
-          EqualTest(color, "rgb(255, 0, 0)", "The text color");
+          assert_equals(color, "rgb(255, 0, 0)", "The text color");
         }else {
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch(err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      }, document.title)
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_media_device_width.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_media_device_width.html
@@ -37,32 +37,27 @@ Authors:
     <link rel="author" title="Intel" href="http://www.intel.com/" />
     <link rel="help" href="http://www.w3.org/TR/2012/REC-css3-mediaqueries-20120619/#device-width" />
     <meta name="flags" content="" />
-    <meta name="assert" content="When your output device resolution width is set to 1024px, the Bank text is displayed in red" />
+    <meta name="assert" content="When your output device resolution width is set to 1024px, the text is displayed in red" />
     <style>
       @media screen and (device-width:1024px) {
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >When your output device resolution width is set to 1024px, the Bank text is displayed in red</div>
+    <div id="media">When your output device resolution width is set to 1024px, the text is displayed in red</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(window.screen.width == 1024) {
-          EqualTest(color, "rgb(255, 0, 0)", "The text color");
+          assert_equals(color, "rgb(255, 0, 0)", "The text color");
         }else {
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch(err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      }, document.title)
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_media_height.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_media_height.html
@@ -37,32 +37,27 @@ Authors:
     <link rel="author" title="Intel" href="http://www.intel.com/" />
     <link rel="help" href="http://www.w3.org/TR/2012/REC-css3-mediaqueries-20120619/#height" />
     <meta name="flags" content="" />
-    <meta name="assert" content="When the page is visible height is greater than 100px less than 500px, the Bank text is displayed in red." />
+    <meta name="assert" content="When the page is visible height is greater than 100px less than 500px, the text is displayed in red." />
     <style>
       @media all and (min-height:100px) and (max-height:500px) {
         #media{ color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >When the page is visible height is greater than 300px less than 500px, the Bank text is displayed in red. Try to adjust your viewport to make the page height between this interval to see the effect</div>
+    <div id="media">When the page is visible height is greater than 300px less than 500px, the text is displayed in red. Try to adjust your viewport to make the page height between this interval to see the effect</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(document.body.scrollHeight <= 500 && document.body.scrollHeight >= 100) {
-          EqualTest(color, "rgb(255, 0, 0)", "The text color");
+          assert_equals(color, "rgb(255, 0, 0)", "The text color");
         } else{
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch (err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      }, document.title)
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_media_orientation.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_media_orientation.html
@@ -37,32 +37,27 @@ Authors:
     <link rel="author" title="Intel" href="http://www.intel.com/" />
     <link rel="help" href="http://www.w3.org/TR/2012/REC-css3-mediaqueries-20120619/#orientation" />
     <meta name="flags" content="" />
-    <meta name="assert" content="When the page is visible in the output device width greater than height, the Bank text is displayed in red" />
+    <meta name="assert" content="When the page is visible in the output device width greater than height, the text is displayed in red" />
     <style>
       @media screen and (orientation:portrait) {
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >When the page is visible in the output device width greater than height, the Bank text is displayed in red</div>
+    <div id="media">When the page is visible in the output device width greater than height, the text is displayed in red</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(document.body.scrollHeight >= document.body.scrollWidth) {
-          EqualTest(color, "rgb(255, 0, 0)", "The text color");
+          assert_equals(color, "rgb(255, 0, 0)", "The text color");
         }else {
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch(err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      }, document.title)
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_orientation_value_all_landscape.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_orientation_value_all_landscape.html
@@ -43,7 +43,6 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
@@ -51,18 +50,14 @@ Authors:
     <div id="log"></div>
     <div id="media">Test environment:when you get the mobile device horizontally<br/>Pass:the text displays in red <br/> Fail: the text displays in black</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(document.body.scrollHeight < document.body.scrollWidth) {
-          EqualTest(color, "rgb(255, 0, 0)", "The text color");
+          assert_equals(color, "rgb(255, 0, 0)", "The text color");
         }else {
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch(err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      }, document.title)
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_orientation_value_all_portrait.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_orientation_value_all_portrait.html
@@ -43,26 +43,21 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >Test environment:when you get the mobile device placed vertically<br/>Pass:the text displays in red <br/> Fail: the text displays in black</div>
+    <div id="media">Test environment:when you get the mobile device placed vertically<br/>Pass:the text displays in red <br/> Fail: the text displays in black</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(document.body.scrollHeight >= document.body.scrollWidth) {
-          EqualTest(color, "rgb(255, 0, 0)", "The text color");
+          assert_equals(color, "rgb(255, 0, 0)", "The text color");
         }else {
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch(err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      }, document.title)
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_orientation_value_screen_landscape.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_orientation_value_screen_landscape.html
@@ -43,26 +43,22 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
+
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >Test environment:when you get the mobile device horizontally<br/>Pass:the text displays in black <br/> Fail: the text displays in red</div>
+    <div id="media">Test environment:when you get the mobile device horizontally<br/>Pass:the text displays in black <br/> Fail: the text displays in red</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(document.body.scrollHeight < document.body.scrollWidth) {
-          EqualTest(color, "rgb(255, 0, 0)", "The text color");
+          assert_equals(color, "rgb(255, 0, 0)", "The text color");
         }else {
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch(err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      }, document.title)
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_orientation_value_screen_portrait.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_orientation_value_screen_portrait.html
@@ -43,26 +43,21 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >Test environment:when you get the mobile device placed vertically<br/>Pass:the text displays in black <br/> Fail: the text displays in red</div>
+    <div id="media">Test environment:when you get the mobile device placed vertically<br/>Pass:the text displays in black <br/> Fail: the text displays in red</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(document.body.scrollHeight >= document.body.scrollWidth) {
-          EqualTest(color, "rgb(255, 0, 0)", "The text color");
+          assert_equals(color, "rgb(255, 0, 0)", "The text color");
         }else {
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch(err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      }, document.title)
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_width_min-width_positive_max-width_positive.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_width_min-width_positive_max-width_positive.html
@@ -43,26 +43,21 @@ Authors:
         body{ color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >Set '(min-width:400px) and (max-width:700px)' on CSS3 Media Queries width attr, when the output device width is between 400px and 700px, the text will displays in red</div>
+    <div id="media">Set '(min-width:400px) and (max-width:700px)' on CSS3 Media Queries width attr, when the output device width is between 400px and 700px, the text will displays in red</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(document.body.scrollWidth <= 700 && document.body.scrollWidth >= 400 ) {
-          EqualTest(color, "rgb(255, 0, 0)", "The text color");
+          assert_equals(color, "rgb(255, 0, 0)", "The text color");
         } else{
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch (err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_width_min_neg_0.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_width_min_neg_0.html
@@ -43,7 +43,6 @@ Authors:
         #media{ color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
@@ -51,12 +50,10 @@ Authors:
     <div id="log"></div>
     <div id="media">The text should be red.</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        EqualTest(GetCurrentStyle("color"), "rgb(255, 0, 0)", "The text color");
-      }catch (err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
+        assert_equals(color, "rgb(255, 0, 0)", "The text color");
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_width_screen_positive.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_width_screen_positive.html
@@ -43,26 +43,21 @@ Authors:
         body{color:#f60;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >Set "width: 800px" on CSS3 Media Queries width attr, When the broswer width is 800px the text will displays in orange</div>
+    <div id="media">Set "width: 800px" on CSS3 Media Queries width attr, When the broswer width is 800px the text will displays in orange</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(document.body.scrollWidth == 800) {
-          EqualTest(color, "rgb(255, 102, 0)", "The text color");
+          assert_equals(color, "rgb(255, 102, 0)", "The text color");
         } else{
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch (err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_width_value_between_900px_and_1200px.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_width_value_between_900px_and_1200px.html
@@ -43,26 +43,21 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >Set "max-width: 1200px;min-width: 900px" on the Media Queries width attr; When the Orientation of your device screen is portrait the text will display in red</div>
+    <div id="media">Set "max-width: 1200px;min-width: 900px" on the Media Queries width attr; When the Orientation of your device screen is portrait the text will display in red</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(document.body.scrollWidth <= 1200 && document.body.scrollWidth >= 900 ) {
-          EqualTest(color, "rgb(255, 0, 0)", "The text color");
+          assert_equals(color, "rgb(255, 0, 0)", "The text color");
         } else{
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch (err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_width_value_max_1300px.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_width_value_max_1300px.html
@@ -43,26 +43,21 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
   <body>
     <div id="log"></div>
-    <div id="media" >Set "max-width: 1300px;" on CSS3 Media Queries width attr; When the browser width is less than 1300px the text will displays in red</div>
+    <div id="media">Set "max-width: 1300px;" on CSS3 Media Queries width attr; When the browser width is less than 1300px the text will displays in red</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        var div = document.querySelector("#media");
-        var color = GetCurrentStyle("color");
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
         if(document.body.scrollWidth <= 1300 ) {
-          EqualTest(color, "rgb(255, 0, 0)", "The text color");
+          assert_equals(color, "rgb(255, 0, 0)", "The text color");
         } else{
-          EqualTest(color, "rgb(0, 0, 0)", "The text color");
+          assert_equals(color, "rgb(0, 0, 0)", "The text color");
         }
-      }catch (err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_width_value_max_neg_1300px.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_width_value_max_neg_1300px.html
@@ -43,7 +43,6 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
@@ -51,12 +50,10 @@ Authors:
     <div id="log"></div>
     <div id="media">The text should be black.</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        EqualTest(GetCurrentStyle("color"), "rgb(0, 0, 0)", "The text color");
-      }catch (err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
+        assert_equals(color, "rgb(0, 0, 0)", "The text color");
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_width_value_neg_800px.html
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_width_value_neg_800px.html
@@ -43,7 +43,6 @@ Authors:
         #media{color:#f00;}
       }
     </style>
-    <script src="MediaQueries.js"></script>
     <script src="../resources/testharness.js"></script>
     <script src="../resources/testharnessreport.js"></script>
   </head>
@@ -51,12 +50,10 @@ Authors:
     <div id="log"></div>
     <div id="media">The text should be black.</div>
     <script>
-      var t = async_test(document.title, { timeout: 2000 });
-      try {
-        EqualTest(GetCurrentStyle("color"), "rgb(0, 0, 0)", "The text color");
-      }catch (err) {
-        TrueTest(false, "Exception while get " + err.name + err.message);
-      }
+      test(function () {
+        var color = getComputedStyle(document.getElementById("media"))["color"];
+        assert_equals(color, "rgb(0, 0, 0)", "The text color");
+      })
     </script>
   </body>
 </html>

--- a/webapi/tct-mediaqueries-css3-tests/mediaqueries/MediaQueries.js
+++ b/webapi/tct-mediaqueries-css3-tests/mediaqueries/MediaQueries.js
@@ -41,35 +41,35 @@ function GetCurrentStyle(prop) {
 }
 function headProp(s) {
 var div = document.querySelector("#media");
-	if (s in div.style) {
-		return s;
-	}
-	s = s[0].toUpperCase() + s.slice(1);
-	var prefixes = ["ms", "Moz", "moz", "webkit", "O"];
-	for (var i = 0; i < prefixes.length; i++) {
-		if ((prefixes[i] + s) in div.style) {
-			return prefixes[i] + s;
-		}
-	}
-	return s;
+    if (s in div.style) {
+        return s;
+    }
+    s = s[0].toUpperCase() + s.slice(1);
+    var prefixes = ["ms", "Moz", "moz", "webkit", "O"];
+    for (var i = 0; i < prefixes.length; i++) {
+        if ((prefixes[i] + s) in div.style) {
+            return prefixes[i] + s;
+        }
+    }
+    return s;
 }
 //
 function getfilename(path)
 {
-   var indexlast=path.lastIndexOf("/");
-   var indexlast1=path.lastIndexOf("\"");
-   var indexlast2=path.lastIndexOf(")");
-   indexlast1=indexlast1>indexlast2?indexlast1:indexlast2;
-   return path.substring(indexlast+1,indexlast1);
+    var indexlast=path.lastIndexOf("/");
+    var indexlast1=path.lastIndexOf("\"");
+    var indexlast2=path.lastIndexOf(")");
+    indexlast1=indexlast1>indexlast2?indexlast1:indexlast2;
+    return path.substring(indexlast+1,indexlast1);
 }
 //
 
-function EqualTest(color,expected,disc) {
+function assert_equals(color,expected,disc) {
     t.step(function () { assert_equals(color, expected, disc); } );
     t.done();
 }
 
-function TrueTest(expected, disc) {
+function assert_true(expected, disc) {
     t.step(function () { assert_true(expected, disc); } );
     t.done();
 }


### PR DESCRIPTION
A meaningless or invalid value should be treated as default.

Signed-off-by: xiaojunwu xiaojunx.a.wu@intel.com
