### PR TITLE
[usecase-webapi] Reduce the display area to fit the mobile screen for gamepad

### DIFF
--- a/usecase/webapi-usecase-tests/tests/GamePad/res/COPYING
+++ b/usecase/webapi-usecase-tests/tests/GamePad/res/COPYING
@@ -1,6 +1,6 @@
 This test comes from
 https://github.com/InternetExplorer/Gamepad-Sample
-without any modification
+with several CSS styles to be modified
 
 The test is copyright by Microsoft and/or the author listed in the test
 file. The test is dual-licensed under the Apache License:

--- a/usecase/webapi-usecase-tests/tests/GamePad/res/gamepad.css
+++ b/usecase/webapi-usecase-tests/tests/GamePad/res/gamepad.css
@@ -13,18 +13,25 @@
     text-align: center;
 }
 
+#gamepadStateTable td {
+    font-size: 6pt;
+}
+
+#gamepadStateTable {
+    width: 200px;
+}
+
 #gamepadStateTable, #gamepadStateTable th {
     border-collapse: collapse;
+    font-size: 10pt;
 }
 
 #gamepadStateTable th {
-    font-weight: bold;
-    text-align:left;
+    text-align: left;
 }
 
 #gamepadStateTable td, #gamepadStateTable th {
     border: solid 1px #0094FF;
-    padding: 1px 5px 1px 5px;
 }
 
 .AxisVisualizer {
@@ -116,7 +123,7 @@
 }
 
 .bumper {
-    width: 80px;
+    width: 70px;
 }
 
 #gamepadSupportedDiv {

--- a/usecase/webapi-usecase-tests/tests/GamePad/res/index.html
+++ b/usecase/webapi-usecase-tests/tests/GamePad/res/index.html
@@ -6,7 +6,6 @@
     <link rel="stylesheet" type="text/css" href="gamepad.css">
 </head>
 <body onload="Init();">
-    <a href="https://github.com/internetexplorer/Gamepad-Sample"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"></a>
     <div id="gamepadSupportedDiv" style="display:none;">Your browser does not support Gamepad API. Try the <a href="http://go.microsoft.com/fwlink/?LinkId=402361">IE Developer Channel</a>.</div>
 
     <div id="gamepadDisplayDiv">


### PR DESCRIPTION
- Fail Reason:[XWALK-2549]

Impacted TCs num(approved): New 0, Update 1, Delete 0
Unit test Platform: [Android]
Unit test result summary: Pass 0, Fail 1, Blocked 0
