### PR TITLE
[webapi][xwalk-2561] Update codes based on Chromium implement

### DIFF
--- a/webapi/tct-video-html5-tests/tests.full.xml
+++ b/webapi/tct-video-html5-tests/tests.full.xml
@@ -1097,7 +1097,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if the video.canPlayType supports video/mp4 of codecs's parameter(avc1.42E01E, mp4a.40.8)" type="compliance" status="approved" component="WebAPI/Media/HTML5 The video element (Partial)" execution_type="auto" priority="P2" id="video_canPlayType_codecs_mp4-avc-mp4a">
+      <testcase purpose="Check if the video.canPlayType supports video/mp4 of codecs's parameter(avc1.42E01E, mp4a.40.2)" type="compliance" status="approved" component="WebAPI/Media/HTML5 The video element (Partial)" execution_type="auto" priority="P2" id="video_canPlayType_codecs_mp4-avc-mp4a">
         <description>
           <test_script_entry>/opt/tct-video-html5-tests/video/video_canPlayType_codecs.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
@@ -1121,7 +1121,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if the video.canPlayType supports video/mp4 of codecs's parameter(avc1.42E01E, mp4v.20.8)" type="compliance" status="approved" component="WebAPI/Media/HTML5 The video element (Partial)" execution_type="auto" priority="P2" id="video_canPlayType_codecs_mp4-avc-mp4v">
+      <testcase purpose="Check if the video.canPlayType supports video/mp4 of codecs's parameter(avc1.42E01E, mp4a.40)" type="compliance" status="approved" component="WebAPI/Media/HTML5 The video element (Partial)" execution_type="auto" priority="P2" id="video_canPlayType_codecs_mp4-avc-mp4v">
         <description>
           <test_script_entry>/opt/tct-video-html5-tests/video/video_canPlayType_codecs.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
         </description>

--- a/webapi/tct-video-html5-tests/tests.xml
+++ b/webapi/tct-video-html5-tests/tests.xml
@@ -460,7 +460,7 @@
           <test_script_entry test_script_expected_result="0">/opt/tct-video-html5-tests/video/w3c/event_loadedmetadata.html</test_script_entry>
         </description>
         </testcase>
-      <testcase component="WebAPI/Media/HTML5 The video element (Partial)" execution_type="auto" id="video_canPlayType_codecs_mp4-avc-mp4a" purpose="Check if the video.canPlayType supports video/mp4 of codecs's parameter(avc1.42E01E, mp4a.40.8)">
+      <testcase component="WebAPI/Media/HTML5 The video element (Partial)" execution_type="auto" id="video_canPlayType_codecs_mp4-avc-mp4a" purpose="Check if the video.canPlayType supports video/mp4 of codecs's parameter(avc1.42E01E, mp4a.40.2)">
         <description>
           <test_script_entry>/opt/tct-video-html5-tests/video/video_canPlayType_codecs.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
@@ -470,7 +470,7 @@
           <test_script_entry>/opt/tct-video-html5-tests/video/video_canPlayType_codecs.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
         </testcase>
-      <testcase component="WebAPI/Media/HTML5 The video element (Partial)" execution_type="auto" id="video_canPlayType_codecs_mp4-avc-mp4v" purpose="Check if the video.canPlayType supports video/mp4 of codecs's parameter(avc1.42E01E, mp4v.20.8)">
+      <testcase component="WebAPI/Media/HTML5 The video element (Partial)" execution_type="auto" id="video_canPlayType_codecs_mp4-avc-mp4v" purpose="Check if the video.canPlayType supports video/mp4 of codecs's parameter(avc1.42E01E, mp4v.40)">
         <description>
           <test_script_entry>/opt/tct-video-html5-tests/video/video_canPlayType_codecs.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
         </description>

--- a/webapi/tct-video-html5-tests/video/video_canPlayType_codecs.html
+++ b/webapi/tct-video-html5-tests/video/video_canPlayType_codecs.html
@@ -48,16 +48,16 @@ Authors:
     <script>
         var v = document.getElementById("m");
         test(function() {
-            assert_true(v.canPlayType('video/mp4; codecs="avc1.42E01E, mp4a.40.8"') !== "", "MPEG-4 supported (codecs='avc1.42E01E, mp4a.40.8')");
-        }, "Check if the video.canPlayType supports video/mp4 of codecs's parameter(avc1.42E01E, mp4a.40.8)");
+            assert_true(v.canPlayType('video/mp4; codecs="avc1.42E01E, mp4a.40.2"') !== "", "MPEG-4 supported (codecs='avc1.42E01E, mp4a.40.2')");
+        }, "Check if the video.canPlayType supports video/mp4 of codecs's parameter(avc1.42E01E, mp4a.40.2)");
 
         test(function() {
             assert_true(v.canPlayType('video/mp4; codecs="avc1.42E01E"') !== "", 'H.264 supported (codecs="avc1.42E01E")');
         }, "Check if the video.canPlayType supports video/mp4 of codecs's parameter(avc1.42E01E)");
 
         test(function() {
-            assert_true(v.canPlayType('video/mp4; codecs="avc1.42E01E, mp4v.20.8"') !== "", "MPEG-4 supported (codecs='avc1.42E01E, mp4v.20.8')");
-        }, "Check if the video.canPlayType supports video/mp4 of codecs's parameter(avc1.42E01E, mp4v.20.8)");
+            assert_true(v.canPlayType('video/mp4; codecs="avc1.42E01E, mp4a.40"') !== "", "MPEG-4 supported (codecs='avc1.42E01E, mp4a.40')");
+        }, "Check if the video.canPlayType supports video/mp4 of codecs's parameter(avc1.42E01E, mp4a.40)");
     </script>
   </body>
 </html>


### PR DESCRIPTION
- mp4a.40.8/mp4v.20.8 is also not supported in chromium 38, need use mp4a.40.2/mp4a.40 instead.
- Verified on Crosswalk 9.38.204.0

Impacted tests(approved): new 0, update 2, delete 0
Unit test platform: [Tizen IVI][Android]
Unit test result summary: pass 2, fail 0, block 0
