### PR TITLE
[embedding][XWALK-2684] Add test cases for loading xhtml file

### DIFF
--- a/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/test/LoadTest.java
+++ b/embeddingapi/webapi-embeddingapi-xwalk-tests/src/org/xwalk/embedding/test/LoadTest.java
@@ -9,12 +9,13 @@ import org.xwalk.core.XWalkNavigationHistory;
 import org.xwalk.core.XWalkView;
 import org.xwalk.embedding.base.XWalkViewTestBase;
 
+import android.os.SystemClock;
 import android.test.suitebuilder.annotation.SmallTest;
 
 public class LoadTest extends XWalkViewTestBase {
 
     @SmallTest
-    public void testLoadUrl()
+    public void testLoad_html_content()
     {
         try {
             String filename = "index.html";
@@ -22,6 +23,51 @@ public class LoadTest extends XWalkViewTestBase {
             String content = getFileContent(filename);
             loadUrlSync(filename, content);
             assertEquals(expectedLocalTitle, getTitleOnUiThread());
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testLoad_xhtml_content()
+    {
+        try {
+            String filename = "index.xhtml";
+            String expectedLocalTitle = "Crosswalk Sample Application";
+            String content = getFileContent(filename);
+            loadUrlSync(filename, content);
+            assertEquals(expectedLocalTitle, getTitleOnUiThread());
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testLoad_html_url()
+    {
+        try {
+            String url = "file:///android_asset/index.html";
+            loadUrlSync(url);
+            String title = "Crosswalk Sample Application";
+            assertEquals(title, getTitleOnUiThread());
+            assertEquals(url, getUrlOnUiThread());
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testLoad_xhtml_url() {
+        try {
+            String url = "file:///android_asset/index.xhtml";
+            mXWalkView.load(url, null);
+            SystemClock.sleep(2000);
+            String title = "Crosswalk Sample Application";
+            assertEquals(title, getTitleOnUiThread());
+            assertEquals(url, getUrlOnUiThread());
         } catch (Exception e) {
             e.printStackTrace();
             assertTrue(false);


### PR DESCRIPTION
- Failure analysis: EmbeddingAPI can't support loading url of local xhtml file.

Impacted tests(approved): new 3, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 2, fail 1, block 0
