### PR TITLE
[usecase-cordova][XWALK-2330] Add usecase for Cordova Screenshot plugin

### DIFF
--- a/usecase/cordova-usecase-tests/tests.xml
+++ b/usecase/cordova-usecase-tests/tests.xml
@@ -21,6 +21,8 @@
       </testcase>
       <testcase component="usecase" execution_type="manual" id="PageVisibility" purpose="Page Visibility Test">
       </testcase>
+      <testcase component="usecase" execution_type="manual" id="Screenshot" purpose="Screenshot Test">
+      </testcase>
     </set>
   </suite>
 </test_definition>

--- a/usecase/cordova-usecase-tests/tests/Screenshot/REAMDE.md
+++ b/usecase/cordova-usecase-tests/tests/Screenshot/REAMDE.md
@@ -1,0 +1,11 @@
+## Usecase Design
+
+This sample demonstrates Cordova screenshot plugin capture screenshot functionalities, include:
+
+* Capture screenshot
+* Save screenshot
+
+This usecase covers following method:
+
+* Navigator interface: screenshot attribute
+* Screenshot interface: save() method

--- a/usecase/cordova-usecase-tests/tests/Screenshot/index.html
+++ b/usecase/cordova-usecase-tests/tests/Screenshot/index.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2014 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Li, Hao <haox.li@intel.com>
+
+-->
+<meta charset="utf-8" />
+<link rel="author" title="Intel" href="http://www.intel.com">
+<meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, width=device-width">
+<link rel="stylesheet" type="text/css" href="../../css/jquery.mobile.css" />
+<link rel="stylesheet" type="text/css" href="../../css/main.css" />
+<script src="../../js/thirdparty/jquery.js"></script>
+<script src="../../js/thirdparty/jquery.mobile.js"></script>
+<script src="../../js/tests.js"></script>
+<script src="../../cordova.js"></script>
+<script src="js/support.js"></script>
+<body onload="init();">
+  <div data-role="page" id="main">
+    <div data-role="header">
+      <h1 id="main_page_title"></h1>
+    </div>
+    <div data-role="content">
+      <button onclick="getScreenshot()">Get Screenshot</button>
+      <div class="d">
+        <div id="log">N/A</div>
+      </div>
+    </div>
+    <div data-role="footer" data-position="fixed">
+    </div>
+    <div data-role="popup" id="popup_info">
+      <font class="fontSize">
+        <p>Purpose:</p>
+        <p>Verifies that Cordova screenshot plugin can capture screenshot successfully</p>
+        <p>Expected Result:</p>
+        <ol>
+          <li>Get screenshot and the screenshot display correctly</li>
+        </ol>
+      </font>
+    </div>
+  </div>
+</body>

--- a/usecase/cordova-usecase-tests/tests/Screenshot/js/support.js
+++ b/usecase/cordova-usecase-tests/tests/Screenshot/js/support.js
@@ -1,0 +1,65 @@
+/*
+Copyright (c) 2014 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Li, Hao <haox.li@intel.com>
+
+*/
+
+var deviceReady = false;
+
+/**
+* Function called when page has finished loading.
+*/
+function init() {
+  document.addEventListener("deviceready", function() {
+    deviceReady = true;
+    console.log("Device="+device.platform+" "+device.version);
+  }, false);
+  window.setTimeout(function() {
+    if (!deviceReady) {
+      alert("Error: Apache Cordova did not initialize. Demo will not run correctly.");
+    }
+  },1000);
+}
+
+function getScreenshot() {
+  try {
+    navigator.screenshot.save(function(error, res){
+      if(error){
+        $("#log").html("<p>" + error + "</p>");
+      }else{
+        //screenshot files are stored in /sdcard/Pictures for android
+        var filepath = res.filePath.replace("/storage/emulated/0", "/sdcard");
+        $("#log").html("<p>Screenshot image: <br/>" + filepath + "</p>");
+        $("#log").append("<img width='300px' height='500px' src='" + filepath + "'>");
+      }
+    },'jpg',50);
+  } catch (e) {
+    $("#log").html("<p>" + e + "</p>");
+  }
+}
+


### PR DESCRIPTION
- Use Cordova Screenshot plugin to capture screenshot of xwalkView
- Fail reason: [XWALK-2233](https://crosswalk-project.org/jira/browse/XWALK-2233)

Impacted tests(approved): new 1, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 0, fail 1, block 0
