### PR TITLE
[Crosswalk-9][webapi][XWALK-2593] Fix bug for webrtc

### DIFF
--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection.html
@@ -65,19 +65,10 @@ Authors:
       });
 
       t.step(function () {
-        assert_throws("SyntaxError",
-          function () {
-            var initializer = {candidate:"nano nano"};
-            var candidate = new RTCIceCandidate(initializer);
-            pc1.addIceCandidate(candidate, t.step_func(function (ev) {
-              t.done();
-            }), function (error) {
-              t.step(function () {
-                assert_unreached("Error message: {" + error.message + "}");
-              });
-              t.done();
-            });
-          },"the candidate parameter is malformed throw a exception");
+        assert_throws("TypeMismatchError", function () {
+          pc1.addIceCandidate("", function () {}, function () {});
+        },"the candidate parameter is malformed throw a exception");
+        t.done();
       });
 
       t1.step(function () {


### PR DESCRIPTION
- Fix bug for webrtc
- `addIceCandidate("", function () {}, function () {})` should throw `TypeError`

Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: [Tizen IVI]
Unit test result summary: pass 1, fail 0, block 0
