### PR TITLE
[cordova][xwalk-2822] Remove --shared option from cordova 3.6.3 packaging

### DIFF
--- a/cordova/cordova-mobilespec-android-tests/mobilespec/CrossWalk_Cordova_Remote_Debug_Pack.html
+++ b/cordova/cordova-mobilespec-android-tests/mobilespec/CrossWalk_Cordova_Remote_Debug_Pack.html
@@ -43,7 +43,7 @@ Authors:
     <ol>
       <li>unzip crosswalk-cordova-version-arm</li>
       <li>Execute 'cd crosswalk-cordova-version-arm'</li>
-      <li>Execute './bin/create remotedebugging com.example.remotedebugging RD -shared'</li>
+      <li>Execute './bin/create remotedebugging com.example.remotedebugging RD'</li>
 	 <li>Execute 'cd remotedebugging'</li>
       <li>Execute './cordova/build -debug'.</li>
     </ol>

--- a/doc/Cordova_Test_Suite_User_Guide.md
+++ b/doc/Cordova_Test_Suite_User_Guide.md
@@ -141,7 +141,7 @@ The Cordova developer tooling is split between general tooling and project level
         $ unzip /path/to/crosswalk-cordova-<version>-<arch>.zip
         ```
 
-    * `$ /path/to/crosswalk-cordova-<version>-<arch>/bin/create testapp com.example.testapp testapp --shared`
+    * `$ /path/to/crosswalk-cordova-<version>-<arch>/bin/create testapp com.example.testapp testapp`
     * `$ cd testapp`
     * Copy web source code (e.g. index.html with some contents) to assets/www
     * `$ . /cordova/build`
@@ -252,7 +252,7 @@ The Cordova Mobile Spec test doesn't need testkit-lite etc., tools to run the te
         $ upzip /path/to/crosswalk-cordova-<version>-<arch>.zip
 
         $ /path/to/crosswalk-cordova-<version>-<arch>/bin/create mobilespec
-        org.apache.mobilespec mobilespec --shared
+        org.apache.mobilespec mobilespec
 
         $ cd mobilespec
 

--- a/usecase/cordova-usecase-tests/tests/CordovaPackage/res/test.py
+++ b/usecase/cordova-usecase-tests/tests/CordovaPackage/res/test.py
@@ -1,6 +1,6 @@
 import os,commands
 
-os.system("./bin/create hello com.example.hello hello --shared");
+os.system("./bin/create hello com.example.hello hello");
 os.chdir("./hello");
 os.system("./cordova/build");
 os.system("./cordova/run");

--- a/usecase/cordova-usecase-tests/tests/CordovaRemoteDebug/index.html
+++ b/usecase/cordova-usecase-tests/tests/CordovaRemoteDebug/index.html
@@ -58,7 +58,7 @@ Authors:
           <div>
             $ unzip crosswalk-cordova-&lt;version&gt;-arm.zip<br/>
             $ cd /localpath/crosswalk-cordova-&lt;version&gt;-arm<br/>
-            $ ./bin/create remotedebugging com.example.remotedebugging RD --shared<br/>
+            $ ./bin/create remotedebugging com.example.remotedebugging RD<br/>
             $ cd remotedebugging<br/>
             $ ./cordova/build --debug<br/>
             $ ./cordova/run  

--- a/usecase/cordova-usecase-tests/tests/WebAppSwitch/index.html
+++ b/usecase/cordova-usecase-tests/tests/WebAppSwitch/index.html
@@ -49,7 +49,7 @@ Authors:
           <div>
             $ unzip crosswalk-cordova-&lt;version&gt;-arm.zip<br/>
             $ cd /localpath/crosswalk-cordova-&lt;version&gt;-arm<br/>
-            $ ./bin/create AppSwitch com.example.appswitch AppSwitch --shared<br/>
+            $ ./bin/create AppSwitch com.example.appswitch AppSwitch<br/>
             $ cd AppSwitch<br/>
             $ ./cordova/build<br/>
             $ ./cordova/run  


### PR DESCRIPTION
- According [XWALK-2794](https://crosswalk-project.org/jira/browse/XWALK-2794) comment, the '--shared' option is not supported by upstream Cordova 3.6.3, remove it from all packaging line in Crosswalk-Cordova 3.6.3.

Impacted tests(approved): new 0, update 4, delete 0
Unit test platform: [Android]
Unit test result summary: pass 4, fail 0, block 0
