### PR TITLE
[embedding][XWALK-2763] Add test cases for EmbeddingApi

### DIFF
--- a/embeddingapi/webapi-embeddingapi-xwalk-tests/embeddingapi/src/org/xwalk/embedding/base/OnReceivedSslHelper.java
+++ b/embeddingapi/webapi-embeddingapi-xwalk-tests/embeddingapi/src/org/xwalk/embedding/base/OnReceivedSslHelper.java
@@ -1,0 +1,17 @@
+package org.xwalk.embedding.base;
+
+import org.chromium.content.browser.test.util.CallbackHelper;
+
+public class OnReceivedSslHelper extends CallbackHelper {
+    private boolean mCalled = false;
+
+    public boolean getCalled() {
+        assert getCallCount() > 0;
+        return mCalled;
+    }
+
+    public void notifyCalled(boolean called) {
+        mCalled = called;
+        notifyCalled();
+    }
+}

--- a/embeddingapi/webapi-embeddingapi-xwalk-tests/embeddingapi/src/org/xwalk/embedding/base/TestHelperBridge.java
+++ b/embeddingapi/webapi-embeddingapi-xwalk-tests/embeddingapi/src/org/xwalk/embedding/base/TestHelperBridge.java
@@ -6,6 +6,7 @@ package org.xwalk.embedding.base;
 
 import org.chromium.content.browser.test.util.TestCallbackHelperContainer.OnPageFinishedHelper;
 import org.chromium.content.browser.test.util.TestCallbackHelperContainer.OnPageStartedHelper;
+import org.chromium.content.browser.test.util.TestCallbackHelperContainer.OnReceivedErrorHelper;
 
 public class TestHelperBridge {
 
@@ -20,6 +21,8 @@ public class TestHelperBridge {
     private final OnCreateWindowRequestedHelper mOnCreateWindowRequestedHelper;
     private final OnIconAvailableHelper mOnIconAvailableHelper;
     private final OnReceivedIconHelper mOnReceivedIconHelper;
+    private final OnReceivedErrorHelper mOnReceivedErrorHelper;
+    private final OnReceivedSslHelper mOnReceivedSslHelper;
 
     TestHelperBridge() {
         mOnPageStartedHelper = new OnPageStartedHelper();
@@ -32,6 +35,8 @@ public class TestHelperBridge {
         mOnCreateWindowRequestedHelper = new OnCreateWindowRequestedHelper();
         mOnIconAvailableHelper = new OnIconAvailableHelper();
         mOnReceivedIconHelper = new OnReceivedIconHelper();
+        mOnReceivedErrorHelper = new OnReceivedErrorHelper();
+        mOnReceivedSslHelper = new OnReceivedSslHelper();
     }
 
     public OnPageFinishedHelper getOnPageFinishedHelper() {
@@ -109,5 +114,21 @@ public class TestHelperBridge {
 
     public void onReceivedIcon() {
         mOnReceivedIconHelper.notifyCalled(true);
+    }
+
+    public OnReceivedErrorHelper getOnReceivedErrorHelper() {
+        return mOnReceivedErrorHelper;
+    }
+
+    public void onReceivedLoadError(int errorCode, String description, String failingUrl) {
+        mOnReceivedErrorHelper.notifyCalled(errorCode, description, failingUrl);
+    }
+
+    public OnReceivedSslHelper getOnReceivedSslHelper() {
+        return mOnReceivedSslHelper;
+    }
+
+    public void onReceivedSsl() {
+        mOnReceivedSslHelper.notifyCalled(true);
     }
 }

--- a/embeddingapi/webapi-embeddingapi-xwalk-tests/embeddingapi/src/org/xwalk/embedding/test/XWalkResourceClientTest.java
+++ b/embeddingapi/webapi-embeddingapi-xwalk-tests/embeddingapi/src/org/xwalk/embedding/test/XWalkResourceClientTest.java
@@ -5,6 +5,7 @@
 package org.xwalk.embedding.test;
 
 import org.xwalk.core.XWalkResourceClient;
+import org.xwalk.embedding.base.OnReceivedSslHelper;
 import org.xwalk.embedding.base.XWalkViewTestBase;
 
 import android.test.suitebuilder.annotation.SmallTest;
@@ -119,6 +120,21 @@ public class XWalkResourceClientTest extends XWalkViewTestBase {
                 }
             });
 
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
+    @SmallTest
+    public void testOnReceivedSslError() {
+        try {
+            String url = "https://webmail.archermind.com/";
+            OnReceivedSslHelper mOnReceivedSslHelper = mTestHelperBridge.getOnReceivedSslHelper();
+            int count = mOnReceivedSslHelper.getCallCount();
+            loadUrlAsync(url);
+            mOnReceivedSslHelper.waitForCallback(count);
+            assertTrue(mOnReceivedSslHelper.getCalled());
         } catch (Exception e) {
             assertTrue(false);
             e.printStackTrace();

--- a/embeddingapi/webapi-embeddingapi-xwalk-tests/embeddingapi/src/org/xwalk/embedding/test/XWalkViewTest.java
+++ b/embeddingapi/webapi-embeddingapi-xwalk-tests/embeddingapi/src/org/xwalk/embedding/test/XWalkViewTest.java
@@ -11,6 +11,7 @@ import java.util.concurrent.Callable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.xwalk.core.XWalkPreferences;
 import org.xwalk.core.XWalkResourceClient;
 import org.xwalk.core.XWalkUIClient;
 import org.xwalk.embedding.MainActivity;
@@ -418,6 +419,49 @@ public class XWalkViewTest extends XWalkViewTestBase {
                 }
             });
             assertTrue(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testGetRemoteDebuggingUrl_enable() {
+        try {
+            String url = "file:///android_asset/index.html";
+            loadUrlSync(url);
+            getInstrumentation().runOnMainSync(new Runnable() {
+                @Override
+                public void run() {
+                    XWalkPreferences.setValue(XWalkPreferences.REMOTE_DEBUGGING, true);
+                }
+            });
+            String path = getRemoteDebuggingUrlOnUiThread();
+            if(path != null && path.contains("devtools/page"))
+            {
+                assertTrue(true);
+            } else {
+                assertTrue(false);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testGetRemoteDebuggingUrl_disbale() {
+        try {
+            String url = "file:///android_asset/index.html";
+            loadUrlSync(url);
+            getInstrumentation().runOnMainSync(new Runnable() {
+                @Override
+                public void run() {
+                    XWalkPreferences.setValue(XWalkPreferences.REMOTE_DEBUGGING, false);
+                }
+            });
+            String path = getRemoteDebuggingUrlOnUiThread();
+            assertEquals("", path);
         } catch (Exception e) {
             e.printStackTrace();
             assertTrue(false);


### PR DESCRIPTION
- Add 2 cases for XWalkView.getRemoteDebuggingUrl
- Add 1 case for XWalkResourceClient.onReceivedSslError
- Failure analysis: the remoteDebuggingUrl returned is null

Impacted tests(approved): new 3, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 2, fail 1, block 0
