### PR TITLE
[webapi] Remove 2 tests due to spec update for rawsockets

### DIFF
--- a/webapi/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_attribute.html
+++ b/webapi/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_attribute.html
@@ -54,21 +54,9 @@ test(function () {
 
 test(function () {
   assert_true(!!namespace, "TCPServerSocket interface support");
-  var socket = new namespace.TCPServerSocket();
-  assert_equals(socket.localAddress, null, "TCPServerSocket.localAddress");
-}, "Check if the value of TCPServerSocket.localAddress is null when not set");
-
-test(function () {
-  assert_true(!!namespace, "TCPServerSocket interface support");
   var socket = new namespace.TCPServerSocket(socketOptions);
   assert_equals(socket.localAddress, socketOptions.localAddress, "TCPServerSocket.localAddress");
 }, "Check if TCPServerSocket.localAddress can be set by the constructor's options argument's valid localAddress member");
-
-test(function () {
-  assert_true(!!namespace, "TCPServerSocket interface support");
-  var socket = new namespace.TCPServerSocket();
-  assert_equals(socket.localPort, null, "TCPServerSocket.localPort");
-}, "Check if the value of TCPServerSocket.localPort is null when not set");
 
 test(function () {
   assert_true(!!namespace, "TCPServerSocket interface support");

--- a/webapi/webapi-rawsockets-sysapps-tests/tests.full.xml
+++ b/webapi/webapi-rawsockets-sysapps-tests/tests.full.xml
@@ -1355,7 +1355,7 @@
     <set name="TCPServerSocket" type="js">
       <testcase purpose="Check if the default value of TCPServerSocket.addressReuse is true" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPServerSocket_addressReuse_default">
         <description>
-          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_attribute.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_attribute.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1367,7 +1367,7 @@
       </testcase>
       <testcase purpose="Check if the value of TCPServerSocket.addressReuse can be set by the options argument in the constructor" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPServerSocket_addressReuse_false">
         <description>
-          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_attribute.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_attribute.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1377,37 +1377,13 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check if the value of TCPServerSocket.localAddress is null when not set" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPServerSocket_localAddress_null">
-        <description>
-          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_attribute.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="attribute" element_name="localAddress" interface="TCPServerSocket" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/2012/sysapps/raw-sockets/#interface-tcpserversocket</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
       <testcase purpose="Check if TCPServerSocket.localAddress can be set by the constructors options arguments valid localAddress member" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPServerSocket_set_valid_localAddress">
         <description>
-          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_attribute.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_attribute.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
         </description>
         <specs>
           <spec>
             <spec_assertion element_type="attribute" element_name="localAddress" interface="TCPServerSocket" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
-            <spec_url>http://www.w3.org/2012/sysapps/raw-sockets/#interface-tcpserversocket</spec_url>
-            <spec_statement/>
-          </spec>
-        </specs>
-      </testcase>
-      <testcase purpose="Check if the value of TCPServerSocket.localPort is null when not set" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPServerSocket_localPort_null">
-        <description>
-          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_attribute.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion element_type="attribute" element_name="localPort" interface="TCPServerSocket" specification="Raw Sockets" section="System-level APIs" category="W3C API Specifications"/>
             <spec_url>http://www.w3.org/2012/sysapps/raw-sockets/#interface-tcpserversocket</spec_url>
             <spec_statement/>
           </spec>
@@ -1415,7 +1391,7 @@
       </testcase>
       <testcase purpose="Check if TCPServerSocket.localPort can be set by the constructors options arguments valid localPort member" type="compliance" status="approved" component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" priority="P1" id="TCPServerSocket_set_valid_localPort">
         <description>
-          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_attribute.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_attribute.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
         </description>
         <specs>
           <spec>

--- a/webapi/webapi-rawsockets-sysapps-tests/tests.xml
+++ b/webapi/webapi-rawsockets-sysapps-tests/tests.xml
@@ -413,32 +413,22 @@
     <set name="TCPServerSocket" type="js">
       <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPServerSocket_addressReuse_default" purpose="Check if the default value of TCPServerSocket.addressReuse is true">
         <description>
-          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_attribute.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_attribute.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
       </testcase>
       <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPServerSocket_addressReuse_false" purpose="Check if the value of TCPServerSocket.addressReuse can be set by the options argument in the constructor">
         <description>
-          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_attribute.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPServerSocket_localAddress_null" purpose="Check if the value of TCPServerSocket.localAddress is null when not set">
-        <description>
-          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_attribute.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_attribute.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
       </testcase>
       <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPServerSocket_set_valid_localAddress" purpose="Check if TCPServerSocket.localAddress can be set by the constructors options arguments valid localAddress member">
         <description>
-          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_attribute.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPServerSocket_localPort_null" purpose="Check if the value of TCPServerSocket.localPort is null when not set">
-        <description>
-          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_attribute.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_attribute.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
         </description>
       </testcase>
       <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPServerSocket_set_valid_localPort" purpose="Check if TCPServerSocket.localPort can be set by the constructors options arguments valid localPort member">
         <description>
-          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_attribute.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+          <test_script_entry>/opt/webapi-rawsockets-sysapps-tests/rawsockets/TCPServerSocket_attribute.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
         </description>
       </testcase>
       <testcase component="WebAPI/System-level APIs/Raw Sockets" execution_type="auto" id="TCPServerSocket_onconnect_with_connect" purpose="Check if set up the onconnect event successful for TCPServerSocket using the type connect">


### PR DESCRIPTION
Spec Link: http://www.w3.org/TR/raw-sockets/
