### PR TITLE
[usecase-cordova][xwalk-2872] Fix the text overflow in Info button

### DIFF
--- a/usecase/cordova-usecase-tests/js/tests.js
+++ b/usecase/cordova-usecase-tests/js/tests.js
@@ -122,4 +122,5 @@ $(document).bind('pagecreate', function () {
   var maxHeight = $(window).height() - 100 + "px";
   $("#popup_info").css("max-height", maxHeight);
   $("#popup_info").css("margin-bottom", "30px");
+  $("#popup_info").css("overflow-y", "auto");
 });


### PR DESCRIPTION
- Add 'overflow-y' to show scroll when the text of Info popup is too long
- Fail reason: XWALK-2648

Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: [Android]
Unit test result summary: pass 0, fail 1, block 0
