### PR TITLE
[webapi] Integrate tests for Vibration API from W3C

### DIFF
--- a/webapi/tct-vibration-w3c-tests/tests.full.xml
+++ b/webapi/tct-vibration-w3c-tests/tests.full.xml
@@ -111,6 +111,138 @@
           </spec>
         </specs>
       </testcase>
+      <testcase purpose="Test checks that vibrate throws a TypeError, when miss pattern argument" type="compliance" status="ready" component="WebAPI/Device/Vibration API" execution_type="auto" priority="P1" id="miss-pattern-argument">
+        <description>
+          <test_script_entry>/opt/tct-vibration-w3c-tests/vibration/w3c/invalid-values.html?total_num=8&amp;locator_key=id&amp;value=1</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="vibrate" interface="Vibration" specification="Vibration API" section="Device" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/vibration/#methods</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Test checks that vibrate take no effect, when set pattern of undefined argument" type="compliance" status="ready" component="WebAPI/Device/Vibration API" execution_type="auto" priority="P1" id="pattern-undefined-argument">
+        <description>
+          <test_script_entry>/opt/tct-vibration-w3c-tests/vibration/w3c/invalid-values.html?total_num=8&amp;locator_key=id&amp;value=2</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="vibrate" interface="Vibration" specification="Vibration API" section="Device" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/vibration/#methods</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Test checks that vibrate take no effect, when set pattern of null argument" type="compliance" status="ready" component="WebAPI/Device/Vibration API" execution_type="auto" priority="P1" id="pattern-null-argument">
+        <description>
+          <test_script_entry>/opt/tct-vibration-w3c-tests/vibration/w3c/invalid-values.html?total_num=8&amp;locator_key=id&amp;value=3</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="vibrate" interface="Vibration" specification="Vibration API" section="Device" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/vibration/#methods</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Test checks that vibrate take no effect, when set pattern of empty string argument" type="compliance" status="ready" component="WebAPI/Device/Vibration API" execution_type="auto" priority="P1" id="pattern-empty-string-argument">
+        <description>
+          <test_script_entry>/opt/tct-vibration-w3c-tests/vibration/w3c/invalid-values.html?total_num=8&amp;locator_key=id&amp;value=4</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="vibrate" interface="Vibration" specification="Vibration API" section="Device" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/vibration/#methods</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Test checks that vibrate take no effect, when set pattern of string argument" type="compliance" status="ready" component="WebAPI/Device/Vibration API" execution_type="auto" priority="P1" id="pattern-string-argument">
+        <description>
+          <test_script_entry>/opt/tct-vibration-w3c-tests/vibration/w3c/invalid-values.html?total_num=8&amp;locator_key=id&amp;value=5</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="vibrate" interface="Vibration" specification="Vibration API" section="Device" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/vibration/#methods</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Test checks that vibrate take no effect, when set pattern of String instance argument" type="compliance" status="ready" component="WebAPI/Device/Vibration API" execution_type="auto" priority="P1" id="pattern-String-instance-argument">
+        <description>
+          <test_script_entry>/opt/tct-vibration-w3c-tests/vibration/w3c/invalid-values.html?total_num=8&amp;locator_key=id&amp;value=6</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="vibrate" interface="Vibration" specification="Vibration API" section="Device" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/vibration/#methods</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Test checks that vibrate take no effect, when set pattern of NaN argument" type="compliance" status="ready" component="WebAPI/Device/Vibration API" execution_type="auto" priority="P1" id="pattern-NaN-argument">
+        <description>
+          <test_script_entry>/opt/tct-vibration-w3c-tests/vibration/w3c/invalid-values.html?total_num=8&amp;locator_key=id&amp;value=7</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="vibrate" interface="Vibration" specification="Vibration API" section="Device" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/vibration/#methods</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Test checks that vibrate take no effect, when set pattern of {} argument" type="compliance" status="ready" component="WebAPI/Device/Vibration API" execution_type="auto" priority="P1" id="pattern-brace-argument">
+        <description>
+          <test_script_entry>/opt/tct-vibration-w3c-tests/vibration/w3c/invalid-values.html?total_num=8&amp;locator_key=id&amp;value=8</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="vibrate" interface="Vibration" specification="Vibration API" section="Device" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/vibration/#methods</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Test checks that cancel ongoing vibrate() when hidden by switching tab/window" type="compliance" status="ready" component="WebAPI/Device/Vibration API" execution_type="manual" priority="P1" id="cancel-when-hidden-manual">
+        <description>
+          <test_script_entry>/opt/tct-vibration-w3c-tests/vibration/w3c/cancel-when-hidden-manual.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="vibrate" interface="Vibration" specification="Vibration API" section="Device" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/vibration/#methods</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Test checks that cancel ongoing vibrate() with [0]" type="compliance" status="ready" component="WebAPI/Device/Vibration API" execution_type="manual" priority="P1" id="cancel-with-array-0-manual">
+        <description>
+          <test_script_entry>/opt/tct-vibration-w3c-tests/vibration/w3c/cancel-with-array-0-manual.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="vibrate" interface="Vibration" specification="Vibration API" section="Device" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/vibration/#methods</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="If the length of pattern is three and the first two entries are 0, then first 0 have no vibration and second 0 no separated." type="compliance" status="ready" component="WebAPI/Device/Vibration API" execution_type="manual" priority="P1" id="pattern-arry-with-0-manual">
+        <description>
+          <test_script_entry>/opt/tct-vibration-w3c-tests/vibration/w3c/pattern-arry-with-0-manual.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="vibrate" interface="Vibration" specification="Vibration API" section="Device" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/vibration/#methods</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
     </set>
   </suite>
 </test_definition>

--- a/webapi/tct-vibration-w3c-tests/tests.xml
+++ b/webapi/tct-vibration-w3c-tests/tests.xml
@@ -48,6 +48,61 @@
           <test_script_entry>/opt/tct-vibration-w3c-tests/vibration/w3c/silent-ignore.html</test_script_entry>
         </description>
       </testcase>
+      <testcase component="WebAPI/Device/Vibration API" execution_type="auto" id="miss-pattern-argument" purpose="Test checks that vibrate throws a TypeError, when miss pattern argument">
+        <description>
+          <test_script_entry>/opt/tct-vibration-w3c-tests/vibration/w3c/invalid-values.html?total_num=8&amp;locator_key=id&amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Device/Vibration API" execution_type="auto" id="pattern-undefined-argument" purpose="Test checks that vibrate take no effect, when set pattern of undefined argument">
+        <description>
+          <test_script_entry>/opt/tct-vibration-w3c-tests/vibration/w3c/invalid-values.html?total_num=8&amp;locator_key=id&amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Device/Vibration API" execution_type="auto" id="pattern-null-argument" purpose="Test checks that vibrate take no effect, when set pattern of null argument">
+        <description>
+          <test_script_entry>/opt/tct-vibration-w3c-tests/vibration/w3c/invalid-values.html?total_num=8&amp;locator_key=id&amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Device/Vibration API" execution_type="auto" id="pattern-empty-string-argument" purpose="Test checks that vibrate take no effect, when set pattern of empty string argument">
+        <description>
+          <test_script_entry>/opt/tct-vibration-w3c-tests/vibration/w3c/invalid-values.html?total_num=8&amp;locator_key=id&amp;value=4</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Device/Vibration API" execution_type="auto" id="pattern-string-argument" purpose="Test checks that vibrate take no effect, when set pattern of string argument">
+        <description>
+          <test_script_entry>/opt/tct-vibration-w3c-tests/vibration/w3c/invalid-values.html?total_num=8&amp;locator_key=id&amp;value=5</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Device/Vibration API" execution_type="auto" id="pattern-String-instance-argument" purpose="Test checks that vibrate take no effect, when set pattern of String instance argument">
+        <description>
+          <test_script_entry>/opt/tct-vibration-w3c-tests/vibration/w3c/invalid-values.html?total_num=8&amp;locator_key=id&amp;value=6</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Device/Vibration API" execution_type="auto" id="pattern-NaN-argument" purpose="Test checks that vibrate take no effect, when set pattern of NaN argument">
+        <description>
+          <test_script_entry>/opt/tct-vibration-w3c-tests/vibration/w3c/invalid-values.html?total_num=8&amp;locator_key=id&amp;value=7</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Device/Vibration API" execution_type="auto" id="pattern-brace-argument" purpose="Test checks that vibrate take no effect, when set pattern of {} argument">
+        <description>
+          <test_script_entry>/opt/tct-vibration-w3c-tests/vibration/w3c/invalid-values.html?total_num=8&amp;locator_key=id&amp;value=8</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Device/Vibration API" execution_type="manual" id="cancel-when-hidden-manual" purpose="Test checks that cancel ongoing vibrate() when hidden by switching tab/window">
+        <description>
+          <test_script_entry>/opt/tct-vibration-w3c-tests/vibration/w3c/cancel-when-hidden-manual.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Device/Vibration API" execution_type="manual" id="cancel-with-array-0-manual" purpose="Test checks that cancel ongoing vibrate() with [0]">
+        <description>
+          <test_script_entry>/opt/tct-vibration-w3c-tests/vibration/w3c/cancel-with-array-0-manual.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/Device/Vibration API" execution_type="manual" id="pattern-arry-with-0-manual" purpose="If the length of pattern is three and the first two entries are 0, then first 0 have no vibration and second 0 no separated.">
+        <description>
+          <test_script_entry>/opt/tct-vibration-w3c-tests/vibration/w3c/pattern-arry-with-0-manual.html</test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>

--- a/webapi/tct-vibration-w3c-tests/vibration/w3c/cancel-when-hidden-manual.html
+++ b/webapi/tct-vibration-w3c-tests/vibration/w3c/cancel-when-hidden-manual.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset='utf-8'>
+<title>Vibration API: cancel ongoing vibrate() when hidden by switching tab/window</title>
+<link rel='author' title='Intel' href='http://www.intel.com'>
+<link rel='help' href='http://dev.w3.org/2009/dap/vibration/#vibration-interface'>
+<meta name='flags' content='interact'>
+<meta name='assert' content='If the visibilitychange event is dispatched at the Document in a browsing context, cancel the pre-existing instance of the processing vibration patterns algorithm'>
+<style>
+  button {
+    height: 100px;
+    width:  100px;
+  }
+</style>
+
+<h1>Description</h1>
+<p>
+  After hitting the button below, your device must vibrate for a short period of time (roughly one
+  second). If it vibrates for a longer time (roughly five seconds, it should feel somewhat long) then
+  the test has failed.
+</p>
+<button id='vib'>Vibrate!</button>
+<script src='vendor-prefix.js' data-prefixed-objects='[{"ancestors":["navigator"], "name":"vibrate"}]'></script>
+<script>
+  var win;
+
+  if (undefined !== navigator.vibrate) {
+    document.getElementById('vib').onclick = function () {
+      navigator.vibrate(5000);
+      setTimeout(function () {
+        win = window.open('about:blank', '_blank');
+        setTimeout(function() {
+          win.close();
+        }, 100);
+      }, 1000);
+    };
+  }
+</script>
+

--- a/webapi/tct-vibration-w3c-tests/vibration/w3c/cancel-with-array-0-manual.html
+++ b/webapi/tct-vibration-w3c-tests/vibration/w3c/cancel-with-array-0-manual.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta charset='utf-8'>
+<title>Vibration API: cancel ongoing vibrate() with [0]</title>
+<link rel='author' title='Intel' href='http://www.intel.com'>
+<link rel='help' href='http://dev.w3.org/2009/dap/vibration/#vibration-interface'>
+<meta name='flags' content='interact'>
+<meta name='assert' content='If pattern contains a single entry with a value of 0, cancel the pre-existing instance of the processing vibration patterns algorithm'>
+<style>
+  button {
+    height: 100px;
+    width:  100px;
+  }
+</style>
+
+<h1>Description</h1>
+<p>
+  After hitting the button below, your device must vibrate for a short period of time (roughly one
+  second). If it vibrates for a longer time (roughly five seconds, it should feel somewhat long) then
+  the test has failed.
+</p>
+<button id='vib'>Vibrate!</button>
+<script src='vendor-prefix.js' data-prefixed-objects='[{"ancestors":["navigator"], "name":"vibrate"}]'></script>
+<script>
+  if (undefined !== navigator.vibrate) {
+    document.getElementById('vib').onclick = function () {
+      navigator.vibrate(5000);
+      setTimeout(function () {
+        navigator.vibrate([0]);
+      }, 1000);
+    };
+  }
+</script>
+

--- a/webapi/tct-vibration-w3c-tests/vibration/w3c/invalid-values.html
+++ b/webapi/tct-vibration-w3c-tests/vibration/w3c/invalid-values.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<meta charset='utf-8'>
+<title>Vibration API: vibrate(invalid)</title>
+<link rel='author' title='Intel' href='http://www.intel.com'>
+<link rel='help' href='http://dev.w3.org/2009/dap/vibration/#vibration-interface'>
+
+<h1>Description</h1>
+<p>
+  This test checks the <code>vibrate()</code> method with invalid parameter,
+  taking vendor prefixes into account.
+</p>
+<div id='log'></div>
+<script src='../../resources/testharness.js'></script>
+<script src='../../resources/testharnessreport.js'></script>
+<script src='vendor-prefix.js' data-prefixed-objects='[{"ancestors":["navigator"], "name":"vibrate"}]'></script>
+<script>
+  test(function() {
+    assert_throws(new TypeError(), function() {
+      navigator.vibrate();
+    }, 'Argument is required, so was expecting a TypeError.');
+  }, 'Missing pattern argument');
+
+  test(function() {
+    try {
+      navigator.vibrate(undefined);
+    } catch(e) {
+      assert_unreached('error message: ' + e.message);
+    }
+  }, 'pattern of undefined resolves to []');
+
+  test(function() {
+    try {
+      navigator.vibrate(null);
+    } catch(e) {
+      assert_unreached('error message: ' + e.message);
+    }
+  }, 'pattern of null resolves to []');
+
+  test(function() {
+    try {
+      navigator.vibrate('');
+    } catch(e) {
+      assert_unreached('error message: ' + e.message);
+    }
+  }, 'pattern of empty string resolves to [""]');
+
+  test(function() {
+    try {
+      navigator.vibrate('one');
+    } catch(e) {
+      assert_unreached('error message: ' + e.message);
+    }
+  }, 'pattern of string resolves to ["one"]');
+
+  test(function() {
+    try {
+      navigator.vibrate(new String('one'));
+    } catch(e) {
+      assert_unreached('error message: ' + e.message);
+    }
+  }, 'pattern of String instance resolves to ["one"]');
+
+  test(function() {
+    try {
+      navigator.vibrate(NaN);
+    } catch(e) {
+      assert_unreached('error message: ' + e.message);
+    }
+  }, 'pattern of NaN resolves to [NaN]');
+
+  test(function() {
+    try {
+      navigator.vibrate({});
+    } catch(e) {
+      assert_unreached('error message: ' + e.message);
+    }
+  }, 'pattern of {} resolves to [{}]');
+</script>
+

--- a/webapi/tct-vibration-w3c-tests/vibration/w3c/pattern-array-with-0-manual.html
+++ b/webapi/tct-vibration-w3c-tests/vibration/w3c/pattern-array-with-0-manual.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset='utf-8'>
+<title>Vibration API: test a pattern array with 0ms vibration and still to vibrate()</title>
+<link rel='author' title='Intel' href='http://www.intel.com'>
+<link rel='help' href='http://dev.w3.org/2009/dap/vibration/#vibration-interface'>
+<meta name='flags' content='interact'>
+<style>
+  button {
+    height: 100px;
+    width:  100px;
+  }
+</style>
+
+<h1>Description</h1>
+<p>
+   After hitting the button below, your device must vibrate continuously for about two seconds, once.
+</p>
+<button id='vib'>Vibrate!</button>
+<div id='log'></div>
+<script src='/common/vendor-prefix.js' data-prefixed-objects='[{"ancestors":["navigator"], "name":"vibrate"}]'></script>
+<script>
+  document.getElementById("vib").onclick = function () {
+    navigator.vibrate([0, 0, 2000]);
+  };
+</script>
+


### PR DESCRIPTION
- Add 11 tests from upstream

Impacted tests(approved): new 11, update 0, delete 0
Unit test platform: [Android] crosswalk-10.38.222
Unit test result summary: pass 11, fail 0, block 0
