### PR TITLE
[webapi] Integrate 54 tests for W3C Selectors Level1

### DIFF
--- a/webapi/tct-selectorslevel1-w3c-tests/selectorslevel1/selectors1_documentfragment_queryselector_return_null.html
+++ b/webapi/tct-selectorslevel1-w3c-tests/selectorslevel1/selectors1_documentfragment_queryselector_return_null.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2014 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this lis
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work withou
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Yi <yix.xu@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<title>Selectors API Level1 Test: selectors1_documentfragment_queryselector_return_null</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions">
+<meta name="assert" content="Check if DocumentFragment.querySelector() method return null if there is no matching Element">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+
+<div id="log"></div>
+<script>
+  test(function () {
+    var docfrag = document.createDocumentFragment();
+    assert_equals(docfrag.querySelector("input"), null,
+      "DocumentFragment.querySelector should return null");
+  });
+</script>
+

--- a/webapi/tct-selectorslevel1-w3c-tests/selectorslevel1/selectors1_element_queryselector_return_null.html
+++ b/webapi/tct-selectorslevel1-w3c-tests/selectorslevel1/selectors1_element_queryselector_return_null.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2014 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this lis
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work withou
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Yi <yix.xu@intel.com>
+
+-->
+
+<meta charset="utf-8">
+<title>Selectors API Level1 Test: selectors1_element_queryselector_return_null</title>
+<link rel="author" title="Intel" href="http://www.intel.com/">
+<link rel="help" href="http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions">
+<meta name="assert" content="Check if element.querySelector() method return null if there is no matching Element">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+
+<div id="log"></div>
+<script>
+  test(function () {
+    var element = document.getElementById("log");
+    assert_equals(element.querySelector("input"), null, "The return value of element.querySelector");
+  });
+</script>
+

--- a/webapi/tct-selectorslevel1-w3c-tests/tests.full.xml
+++ b/webapi/tct-selectorslevel1-w3c-tests/tests.full.xml
@@ -113,7 +113,7 @@
       </testcase>
       <testcase purpose="Check if document.querySelector() method is of type function" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_document_queryselector_type">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=1</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -125,7 +125,7 @@
       </testcase>
       <testcase purpose="Check if document.querySelectorAll() method is of type function" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_document_queryselectorall_type">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=2</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -137,7 +137,7 @@
       </testcase>
       <testcase purpose="Check if document.querySelectorAll() method return a NodeList containing all of the matching Element nodes within the subtrees of the context node" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_document_queryselectorall_return_nodelist">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=3</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -149,7 +149,7 @@
       </testcase>
       <testcase purpose="Check if DocumentFragment.querySelector() method is of type function" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_documentfragment_queryselector_type">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=7</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -161,7 +161,7 @@
       </testcase>
       <testcase purpose="Check if DocumentFragment.querySelectorAll() method is of type function" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_documentfragment_queryselectorall_type">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=8</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -173,7 +173,7 @@
       </testcase>
       <testcase purpose="Check if DocumentFragment.querySelectorAll() method return a NodeList containing all of the matching Element nodes within the subtrees of the context node, in document order" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_documentfragment_queryselectorall_return_nodelist">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=9</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -185,7 +185,7 @@
       </testcase>
       <testcase purpose="Check if element.querySelector() method is of type function" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_element_queryselector_type">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=10</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -197,7 +197,7 @@
       </testcase>
       <testcase purpose="Check if element.querySelectorAll() method is of type function" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_element_queryselectorall_type">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=11</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -209,7 +209,115 @@
       </testcase>
       <testcase purpose="Check if element.querySelectorAll() method must return a NodeList containing all of the matching Element nodes within the subtrees of the context node, in document order" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_element_queryselectorall_return_nodelist">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=12</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelectorAll" interface="Element" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if document.querySelectorAll() method with argument of null that return object type of NodeList" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_document_queryselectorall_argument_null">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=13</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelectorAll" interface="Document" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if document.querySelector() method with argument of null that must return null" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_document_queryselector_argument_null">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=16</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelector" interface="Document" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if DocumentFragment.querySelectorAll() method with argument of null that return object type of NodeList" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_documentfragment_queryselectorall_argument_null">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=27</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelectorAll" interface="DocumentFragment" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if DocumentFragment.querySelector() method with argument of null that must return null" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_documentfragment_queryselector_argument_null">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=30</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelector" interface="DocumentFragment" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if element.querySelectorAll() method with argument of null that return object type of NodeList" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_element_queryselectorall_argument_null">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=34</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelectorAll" interface="Element" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if element.querySelector() method with argument of null that must return null" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_element_queryselector_argument_null">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=37</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelector" interface="Element" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if document.querySelectorAll() method must return an empty NodeList if there are no matching nodes" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_document_queryselectorall_return_empty_nodelist">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=50</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelectorAll" interface="Document" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if DocumentFragment.querySelectorAll() method must return an empty NodeList if there are no matching Element nodes" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_documentfragment_queryselectorall_return_empty_nodelist">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=178</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelectorAll" interface="DocumentFragment" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if element.querySelectorAll() method return an empty NodeList if there are no matching nodes" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_element_queryselectorall_return_empty_nodelist">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=242</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -221,7 +329,7 @@
       </testcase>
       <testcase purpose="Check if document.querySelectorAll() method with argument of tag name should return the expected number of matches" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_document_queryselectorall_argument_tag">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=305</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=305</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -233,7 +341,7 @@
       </testcase>
       <testcase purpose="Check if document.querySelector() method must match element with specified tag" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_document_queryselector_argument_tag">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=306</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=306</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -245,7 +353,7 @@
       </testcase>
       <testcase purpose="Check if document.querySelectorAll() method with argument of class name should return the expected number of matches" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_document_queryselectorall_argument_class">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=409</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=409</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -257,7 +365,7 @@
       </testcase>
       <testcase purpose="Check if document.querySelector() method must match element with specified class" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_document_queryselector_argument_class">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=410</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=410</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -269,7 +377,7 @@
       </testcase>
       <testcase purpose="Check if document.querySelectorAll() method with argument of id name should return the expected number of matches" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_document_queryselectorall_argument_id">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=425</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=425</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -281,7 +389,7 @@
       </testcase>
       <testcase purpose="Check if document.querySelector() method must match element with specified id" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_document_queryselector_argument_id">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=426</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=426</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -291,9 +399,117 @@
           </spec>
         </specs>
       </testcase>
+      <testcase purpose="Check if document.querySelector() method must return the first matching Element node within the subtrees of the context node" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_document_queryselector_return_first">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=430</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelector" interface="Document" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if document.querySelectorAll() method with argument of element's tag name and id that must return a NodeList containing all of the matching Element nodes" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_document_queryselectorall_argument_tag_id">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=473</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelectorAll" interface="Document" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if document.querySelector() method with argument of element's tag name and id that must return the first matching Element node" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_document_queryselector_argument_tag_id">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=474</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelector" interface="Document" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if document.querySelectorAll() method with argument of element's 2 tags name that must return a NodeList containing all of the matching Element nodes" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_document_queryselectorall_argument_tag_tag">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=475</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelectorAll" interface="Document" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if document.querySelector() method with argument of element's 2 tags name that must return the first matching Element node" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_document_queryselector_argument_tag_tag">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=476</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelector" interface="Document" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if document.querySelectorAll() method with argument of element's tag name and classname that must return a NodeList containing all of the matching Element nodes" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_document_queryselectorall_argument_tag_class">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=477</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelectorAll" interface="Document" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if document.querySelector() method with argument of element's tag name and classname that must return the first matching Element node" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_document_queryselector_argument_tag_class">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=478</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelector" interface="Document" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if document.querySelectorAll() method with argument of element's classname and id that must return a NodeList containing all of the matching Element nodes" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_document_queryselectorall_argument_class_id">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=483</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelectorAll" interface="Document" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if document.querySelector() method with argument of element's classname and id that must return the first matching Element node" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_document_queryselector_argument_class_id">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=484</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelector" interface="Document" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
       <testcase purpose="Check if documentfragment.querySelectorAll() method with argument of tag name should return the expected number of matches" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_documentfragment_queryselectorall_argument_tag">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=745</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=745</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -305,7 +521,7 @@
       </testcase>
       <testcase purpose="Check if documentfragment.querySelector() method must match element with specified tag" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_documentfragment_queryselector_argument_tag">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=746</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=746</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -317,7 +533,7 @@
       </testcase>
       <testcase purpose="Check if documentfragment.querySelectorAll() method with argument of class name should return the expected number of matches" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_documentfragment_queryselectorall_argument_class">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=851</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=851</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -329,7 +545,7 @@
       </testcase>
       <testcase purpose="Check if documentfragment.querySelector() method must match element with specified class" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_documentfragment_queryselector_argument_class">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=852</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=852</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -341,7 +557,7 @@
       </testcase>
       <testcase purpose="Check if documentfragment.querySelectorAll() method with argument of id name should return the expected number of matches" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_documentfragment_queryselectorall_argument_id">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=867</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=867</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -353,7 +569,7 @@
       </testcase>
       <testcase purpose="Check if documentfragment.querySelector() method must match element with specified id" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_documentfragment_queryselector_argument_id">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=868</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=868</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -363,9 +579,105 @@
           </spec>
         </specs>
       </testcase>
+      <testcase purpose="Check if DocumentFragment.querySelectorAll() method with argument of tag name and id that return a NodeList containing all of the matching Element nodes" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_documentfragment_queryselectorall_argument_tag_id">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=913</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelectorAll" interface="DocumentFragment" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if DocumentFragment.querySelector() method with argument of element's tag name and id that return the first matching Element node" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_documentfragment_queryselector_argument_tag_id">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=914</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelector" interface="DocumentFragment" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if DocumentFragment.querySelectorAll() method with argument of 2 tags name that return a NodeList containing all of the matching Element nodes" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_documentfragment_queryselectorall_argument_tag_tag">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=915</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelectorAll" interface="DocumentFragment" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if DocumentFragment.querySelector() method with argument of element's 2 tags name that return the first matching Element node" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_documentfragment_queryselector_argument_tag_tag">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=916</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelector" interface="DocumentFragment" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if DocumentFragment.querySelectorAll() method with argument of tag name and classname that return a NodeList containing all of the matching Element nodes" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_documentfragment_queryselectorall_argument_tag_class">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=917</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelectorAll" interface="DocumentFragment" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if DocumentFragment.querySelector() method with argument of element's tag name and classname that return the first matching Element node" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_documentfragment_queryselector_argument_tag_class">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=918</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelector" interface="DocumentFragment" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if DocumentFragment.querySelectorAll() method with argument of classname and id that return a NodeList containing all of the matching Element nodes" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_documentfragment_queryselectorall_argument_class_id">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=923</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelectorAll" interface="DocumentFragment" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if DocumentFragment.querySelector() method with argument of element's classname and id that return the first matching Element node with argument of element class" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_documentfragment_queryselector_argument_class_id">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=924</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelector" interface="DocumentFragment" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
       <testcase purpose="Check if element.querySelectorAll() method with argument of tag name should return the expected number of matches" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_element_queryselectorall_argument_tag">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=965</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=965</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -377,7 +689,7 @@
       </testcase>
       <testcase purpose="Check if element.querySelector() method must match element with specified tag" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_element_queryselector_argument_tag">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=966</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=966</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -389,7 +701,7 @@
       </testcase>
       <testcase purpose="Check if element.querySelectorAll() method with argument of class name should return the expected number of matches" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_element_queryselectorall_argument_class">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=1071</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=1071</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -401,7 +713,7 @@
       </testcase>
       <testcase purpose="Check if element.querySelector() method must match element with specified class" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_element_queryselector_argument_class">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=1072</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=1072</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -413,7 +725,7 @@
       </testcase>
       <testcase purpose="Check if element.querySelectorAll() method with argument of id name should return the expected number of matches" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_element_queryselectorall_argument_id">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=1087</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=1087</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -425,12 +737,132 @@
       </testcase>
       <testcase purpose="Check if element.querySelector() method must match element with specified id" type="compliance" status="ready" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_element_queryselector_argument_id">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=1088</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=1088</test_script_entry>
         </description>
         <specs>
           <spec>
             <spec_assertion element_type="method" element_name="querySelector" interface="Document" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="W3C API Specifications"/>
             <spec_url>http://www.w3.org/TR/selectors-api/</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if element.querySelectorAll() method with argument of element's tag name and id that must return a NodeList containing all of the matching Element nodes" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_element_queryselectorall_argument_tag_id">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=1135</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelectorAll" interface="Element" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if element.querySelector() method with argument of element's tag name and id that must return the first matching Element node" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_element_queryselector_argument_tag_id">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=1136</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelector" interface="Element" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if element.querySelectorAll() method with argument of element's 2 tags name that must return a NodeList containing all of the matching Element nodes" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_element_queryselectorall_argument_tag_tag">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=1137</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelectorAll" interface="Element" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if element.querySelector() method with argument of element's 2 tags name that must return the first matching Element node" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_element_queryselector_argument_tag_tag">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=1138</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelector" interface="Element" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if element.querySelectorAll() method with argument of element's tag name and classname that must return a NodeList containing all of the matching Element nodes" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_element_queryselectorall_argument_tag_class">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=1139</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelectorAll" interface="Element" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if element.querySelector() method with argument of element's tag name and classname that must return the first matching Element node" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_element_queryselector_argument_tag_class">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=1140</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelector" interface="Element" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if element.querySelectorAll() method with argument of element's classname and id that must return a NodeList containing all of the matching Element nodes" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_element_queryselectorall_argument_class_id">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=1145</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelectorAll" interface="Element" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if element.querySelector() method with argument of element's classname and id that must return the first matching Element node" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_element_queryselector_argument_class_id">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=1146</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelector" interface="Element" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if DocumentFragment.querySelector() method return null if there is no matching Element" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_documentfragment_queryselector_return_null">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/selectors1_documentfragment_queryselector_return_null.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelector" interface="DocumentFragment" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
+      <testcase purpose="Check if element.querySelector() method return null if there is no matching Element" type="compliance" status="approved" component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" priority="P2" id="selectors1_element_queryselector_return_null">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/selectors1_element_queryselector_return_null.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="method" element_name="querySelector" interface="Element" specification="Selectors API Level 1" section="DOM, Forms and Styles" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-selectors-api-20120628/#interface-definitions</spec_url>
             <spec_statement/>
           </spec>
         </specs>

--- a/webapi/tct-selectorslevel1-w3c-tests/tests.xml
+++ b/webapi/tct-selectorslevel1-w3c-tests/tests.xml
@@ -1,186 +1,366 @@
 <?xml version="1.0" encoding="UTF-8"?>
-    <?xml-stylesheet type="text/xsl" href="./testcase.xsl"?>
+<?xml-stylesheet type="text/xsl" href="./testcase.xsl"?>
 <test_definition>
-  <suite name="tct-selectorslevel1-w3c-tests" category="W3C/HTML5 APIs">
+  <suite category="W3C/HTML5 APIs" name="tct-selectorslevel1-w3c-tests">
     <set name="SelectorsLevel1" type="js">
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_documentfragment_queryselectorall_exists" purpose="Check if DocumentFragment.querySelectorAll() method exists">
         <description>
           <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/selectors1_documentfragment_queryselectorall_exists.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_documentfragment_queryselector_exists" purpose="Check if DocumentFragment.querySelector() method exists">
         <description>
           <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/selectors1_documentfragment_queryselector_exists.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_document_queryselectorall_exists" purpose="Check if document.querySelectorAll() method exists">
         <description>
           <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/selectors1_document_queryselectorall_exists.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_document_queryselector_exists" purpose="Check if document.querySelector() method exists">
         <description>
           <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/selectors1_document_queryselector_exists.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_element_queryselectorall_exists" purpose="Check if element.querySelectorAll() method exists">
         <description>
           <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/selectors1_element_queryselectorall_exists.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_element_queryselector_exists" purpose="Check if element.querySelector() method exists">
         <description>
           <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/selectors1_element_queryselector_exists.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_documentfragment_queryselector_return_first" purpose="Check if DocumentFragment.querySelector() method must return the first matching Element node within the subtrees of the context node">
         <description>
           <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/selectors1_documentfragment_queryselector_return_first.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_document_queryselector_return_null" purpose="Check if document.querySelector() method return null if there is no matching Element">
         <description>
           <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/selectors1_document_queryselector_return_null.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_element_queryselector_return_first" purpose="Check if element.querySelector() method must return the first matching Element node within the subtrees of the context node">
         <description>
           <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/selectors1_element_queryselector_return_first.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_document_queryselector_type" purpose="Check if document.querySelector() method is of type function">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=1</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_document_queryselectorall_type" purpose="Check if document.querySelectorAll() method is of type function">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=2</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_document_queryselectorall_return_nodelist" purpose="Check if document.querySelectorAll() method return a NodeList containing all of the matching Element nodes within the subtrees of the context node">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=3</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_documentfragment_queryselector_type" purpose="Check if DocumentFragment.querySelector() method is of type function">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=7</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_documentfragment_queryselectorall_type" purpose="Check if DocumentFragment.querySelectorAll() method is of type function">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=8</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_documentfragment_queryselectorall_return_nodelist" purpose="Check if DocumentFragment.querySelectorAll() method return a NodeList containing all of the matching Element nodes within the subtrees of the context node, in document order">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=9</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_element_queryselector_type" purpose="Check if element.querySelector() method is of type function">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=10</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_element_queryselectorall_type" purpose="Check if element.querySelectorAll() method is of type function">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=11</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_element_queryselectorall_return_nodelist" purpose="Check if element.querySelectorAll() method must return a NodeList containing all of the matching Element nodes within the subtrees of the context node, in document order">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=12</test_script_entry>
         </description>
-        </testcase>
-     <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_document_queryselectorall_argument_tag" purpose="Check if document.querySelectorAll() method with argument of tag name should return the expected number of matches">
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_document_queryselectorall_argument_null" purpose="Check if document.querySelectorAll() method with argument of null that return object type of NodeList">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=305</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=13</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_document_queryselector_argument_null" purpose="Check if document.querySelector() method with argument of null that must return null">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=16</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_documentfragment_queryselectorall_argument_null" purpose="Check if DocumentFragment.querySelectorAll() method with argument of null that return object type of NodeList">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=27</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_documentfragment_queryselector_argument_null" purpose="Check if DocumentFragment.querySelector() method with argument of null that must return null">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=30</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_element_queryselectorall_argument_null" purpose="Check if element.querySelectorAll() method with argument of null that return object type of NodeList">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=34</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_element_queryselector_argument_null" purpose="Check if element.querySelector() method with argument of null that must return null">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=37</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_document_queryselectorall_return_empty_nodelist" purpose="Check if document.querySelectorAll() method must return an empty NodeList if there are no matching nodes">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=50</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_documentfragment_queryselectorall_return_empty_nodelist" purpose="Check if DocumentFragment.querySelectorAll() method must return an empty NodeList if there are no matching Element nodes">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=178</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_element_queryselectorall_return_empty_nodelist" purpose="Check if element.querySelectorAll() method return an empty NodeList if there are no matching nodes">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=242</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_document_queryselectorall_argument_tag" purpose="Check if document.querySelectorAll() method with argument of tag name should return the expected number of matches">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=305</test_script_entry>
         </description>
       </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_document_queryselector_argument_tag" purpose="Check if document.querySelector() method must match element with specified tag">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=306</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=306</test_script_entry>
         </description>
       </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_document_queryselectorall_argument_class" purpose="Check if document.querySelectorAll() method with argument of class name should return the expected number of matches">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=409</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=409</test_script_entry>
         </description>
       </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_document_queryselector_argument_class" purpose="Check if document.querySelector() method must match element with specified class">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=410</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=410</test_script_entry>
         </description>
       </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_document_queryselectorall_argument_id" purpose="Check if document.querySelectorAll() method with argument of id name should return the expected number of matches">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=425</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=425</test_script_entry>
         </description>
       </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_document_queryselector_argument_id" purpose="Check if document.querySelector() method must match element with specified id">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=426</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=426</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_document_queryselector_return_first" purpose="Check if document.querySelector() method must return the first matching Element node within the subtrees of the context node">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=430</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_document_queryselectorall_argument_tag_id" purpose="Check if document.querySelectorAll() method with argument of element's tag name and id that must return a NodeList containing all of the matching Element nodes">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=473</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_document_queryselector_argument_tag_id" purpose="Check if document.querySelector() method with argument of element's tag name and id that must return the first matching Element node">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=474</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_document_queryselectorall_argument_tag_tag" purpose="Check if document.querySelectorAll() method with argument of element's 2 tags name that must return a NodeList containing all of the matching Element nodes">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=475</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_document_queryselector_argument_tag_tag" purpose="Check if document.querySelector() method with argument of element's 2 tags name that must return the first matching Element node">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=476</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_document_queryselectorall_argument_tag_class" purpose="Check if document.querySelectorAll() method with argument of element's tag name and classname that must return a NodeList containing all of the matching Element nodes">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=477</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_document_queryselector_argument_tag_class" purpose="Check if document.querySelector() method with argument of element's tag name and classname that must return the first matching Element node">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=478</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_document_queryselectorall_argument_class_id" purpose="Check if document.querySelectorAll() method with argument of element's classname and id that must return a NodeList containing all of the matching Element nodes">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=483</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_document_queryselector_argument_class_id" purpose="Check if document.querySelector() method with argument of element's classname and id that must return the first matching Element node">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=484</test_script_entry>
         </description>
       </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_documentfragment_queryselectorall_argument_tag" purpose="Check if documentfragment.querySelectorAll() method with argument of tag name should return the expected number of matches">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=745</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=745</test_script_entry>
         </description>
       </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_documentfragment_queryselector_argument_tag" purpose="Check if documentfragment.querySelector() method must match element with specified tag">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=746</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=746</test_script_entry>
         </description>
       </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_documentfragment_queryselectorall_argument_class" purpose="Check if documentfragment.querySelectorAll() method with argument of class name should return the expected number of matches">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=851</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=851</test_script_entry>
         </description>
       </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_documentfragment_queryselector_argument_class" purpose="Check if documentfragment.querySelector() method must match element with specified class">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=852</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=852</test_script_entry>
         </description>
       </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_documentfragment_queryselectorall_argument_id" purpose="Check if documentfragment.querySelectorAll() method with argument of id name should return the expected number of matches">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=867</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=867</test_script_entry>
         </description>
       </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_documentfragment_queryselector_argument_id" purpose="Check if documentfragment.querySelector() method must match element with specified id">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=868</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=868</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_documentfragment_queryselectorall_argument_tag_id" purpose="Check if DocumentFragment.querySelectorAll() method with argument of tag name and id that return a NodeList containing all of the matching Element nodes">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=913</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_documentfragment_queryselector_argument_tag_id" purpose="Check if DocumentFragment.querySelector() method with argument of element's tag name and id that return the first matching Element node">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=914</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_documentfragment_queryselectorall_argument_tag_tag" purpose="Check if DocumentFragment.querySelectorAll() method with argument of 2 tags name that return a NodeList containing all of the matching Element nodes">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=915</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_documentfragment_queryselector_argument_tag_tag" purpose="Check if DocumentFragment.querySelector() method with argument of element's 2 tags name that return the first matching Element node">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=916</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_documentfragment_queryselectorall_argument_tag_class" purpose="Check if DocumentFragment.querySelectorAll() method with argument of tag name and classname that return a NodeList containing all of the matching Element nodes">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=917</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_documentfragment_queryselector_argument_tag_class" purpose="Check if DocumentFragment.querySelector() method with argument of element's tag name and classname that return the first matching Element node">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=918</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_documentfragment_queryselectorall_argument_class_id" purpose="Check if DocumentFragment.querySelectorAll() method with argument of classname and id that return a NodeList containing all of the matching Element nodes">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=923</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_documentfragment_queryselector_argument_class_id" purpose="Check if DocumentFragment.querySelector() method with argument of element's classname and id that return the first matching Element node with argument of element class">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=924</test_script_entry>
         </description>
       </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_element_queryselectorall_argument_tag" purpose="Check if element.querySelectorAll() method with argument of tag name should return the expected number of matches">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=965</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=965</test_script_entry>
         </description>
       </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_element_queryselector_argument_tag" purpose="Check if element.querySelector() method must match element with specified tag">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=966</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=966</test_script_entry>
         </description>
       </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_element_queryselectorall_argument_class" purpose="Check if element.querySelectorAll() method with argument of class name should return the expected number of matches">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=1071</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=1071</test_script_entry>
         </description>
       </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_element_queryselector_argument_class" purpose="Check if element.querySelector() method must match element with specified class">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=1072</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=1072</test_script_entry>
         </description>
       </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_element_queryselectorall_argument_id" purpose="Check if element.querySelectorAll() method with argument of id name should return the expected number of matches">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=1087</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=1087</test_script_entry>
         </description>
       </testcase>
       <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_element_queryselector_argument_id" purpose="Check if element.querySelector() method must match element with specified id">
         <description>
-          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;amp;locator_key=id&amp;amp;value=1088</test_script_entry>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=1088</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_element_queryselectorall_argument_tag_id" purpose="Check if element.querySelectorAll() method with argument of element's tag name and id that must return a NodeList containing all of the matching Element nodes">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=1135</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_element_queryselector_argument_tag_id" purpose="Check if element.querySelector() method with argument of element's tag name and id that must return the first matching Element node">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=1136</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_element_queryselectorall_argument_tag_tag" purpose="Check if element.querySelectorAll() method with argument of element's 2 tags name that must return a NodeList containing all of the matching Element nodes">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=1137</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_element_queryselector_argument_tag_tag" purpose="Check if element.querySelector() method with argument of element's 2 tags name that must return the first matching Element node">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=1138</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_element_queryselectorall_argument_tag_class" purpose="Check if element.querySelectorAll() method with argument of element's tag name and classname that must return a NodeList containing all of the matching Element nodes">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=1139</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_element_queryselector_argument_tag_class" purpose="Check if element.querySelector() method with argument of element's tag name and classname that must return the first matching Element node">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=1140</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_element_queryselectorall_argument_class_id" purpose="Check if element.querySelectorAll() method with argument of element's classname and id that must return a NodeList containing all of the matching Element nodes">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=1145</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_element_queryselector_argument_class_id" purpose="Check if element.querySelector() method with argument of element's classname and id that must return the first matching Element node">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/w3c/level1-baseline.html?total_num=1186&amp;locator_key=id&amp;value=1146</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_documentfragment_queryselector_return_null" purpose="Check if DocumentFragment.querySelector() method return null if there is no matching Element">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/selectors1_documentfragment_queryselector_return_null.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/DOM, Forms and Styles/Selectors API Level 1" execution_type="auto" id="selectors1_element_queryselector_return_null" purpose="Check if element.querySelector() method return null if there is no matching Element">
+        <description>
+          <test_script_entry>/opt/tct-selectorslevel1-w3c-tests/selectorslevel1/selectors1_element_queryselector_return_null.html</test_script_entry>
         </description>
       </testcase>
     </set>


### PR DESCRIPTION
- approved: 36
- Another 18 cases about w3c/level1-content.html have been integrated.

Impacted tests(approved): new 36, update 0, delete 0
Unit test platform: [IVI] crosswalk-10.38.222, t-e-c 0.107
Unit test result summary: pass 36, fail 0, block 0
