### PR TITLE
[webapi] Fix screen orientation test cases according to spec.

### DIFF
--- a/webapi/tct-screenorientation-w3c-tests/screenorientation/ScreenOrientation_lock_orientation_invalid.html
+++ b/webapi/tct-screenorientation-w3c-tests/screenorientation/ScreenOrientation_lock_orientation_invalid.html
@@ -43,8 +43,10 @@ var t = async_test("Test checks that screen.orientation.lock(invalid) invoke err
 
 t.step(function () {
   var p = screen.orientation.lock("invalid-landsapce");
-  p.then(t.unreached_func("Unexpected success callback"), t.step_func(function(e) {
-    t.done();
+  p.then(function(){
+      t.unreached_func("Unexpected success callback");
+    }, t.step_func(function(e) {
+      t.done();
   }));
 });
 

--- a/webapi/tct-screenorientation-w3c-tests/screenorientation/ScreenOrientation_lock_orientation_null.html
+++ b/webapi/tct-screenorientation-w3c-tests/screenorientation/ScreenOrientation_lock_orientation_null.html
@@ -43,8 +43,10 @@ var t = async_test("Test checks that screen.orientation.lock(null) invoke error 
 
 t.step(function () {
   var p = screen.orientation.lock(null);
-  p.then(t.unreached_func("Unexpected success callback"), t.step_func(function(e) {
-    t.done();
+  p.then(function(){
+      t.unreached_func("Unexpected success callback");
+    }, t.step_func(function(e) {
+      t.done();
   }));
 });
 </script>

--- a/webapi/tct-screenorientation-w3c-tests/screenorientation/blink/lockOrientation-basic.html
+++ b/webapi/tct-screenorientation-w3c-tests/screenorientation/blink/lockOrientation-basic.html
@@ -16,20 +16,31 @@ https://chromium.googlesource.com/chromium/blink/+/master/LICENSE
 <div id="log"></div>
 <script>
 var t = async_test("Basic screen.orientation.lock() and screen.orientation.unlock() testing", {timeout: 2000});
-var orientation_num = 0;
 
-t.step(function () {
+t.step(function() {
+  var orientations = [
+    "any", "natural",  "landscape", "portrait", "portrait-primary", "portrait-secondary",
+    "landscape-primary", "landscape-secondary"
+  ];
+
+  var setOrientation = function(idx) {
+    if (idx === orientations.length) {
+      t.done();
+      return;
+    }
+    (function(i){
+      screen.orientation.lock(orientations[i]).then(
+        t.step_func(function(e){
+          setOrientation(i+1);
+        }),
+        function() {
+          t.unreached_func('Unexpected error callback');
+      });
+    })(idx);
+  };
+
   screen.orientation.unlock();
-  [
-    "any", "landscape", "portrait", "portrait-primary", "portrait-secondary",
-    "landscape-primary", "landscape-secondary", "0",  "90", "180", "270"
-  ].forEach(function(orientation) {
-    orientation_num++;
-    screen.orientation.lock(orientation).then(t.step_func(function(e) {
-      if (orientation_num == 11) {
-        t.done();
-      }
-    }), t.unreached_func("Unexpected error callback"));
-  });
+  setOrientation(0);
+
 });
 </script>


### PR DESCRIPTION
1, We need to use a valid functionn to wrap the "fake" function callback (e.g. unreached_func() in this case).
2, According to screen orientation w3c spec http://www.w3.org/TR/screen-orientation/#orientationlocktype-enum, the "OrientationLockType" cannot be angle value such as "0", "90", "180", "270"
3, The screen.orientation.lock() cannot be invoked in parallel. That might cause the JavaScript Promise object's resolved callback not be invoked. Instead, we should call them in sequence.

BUG=XWALK-2513
