### PR TITLE
[webapi][xwalk-2411] Remove 1 test for battery level in Tizen SystemInfo

### DIFF
--- a/webapi/tct-systeminfo-tizen-tests/tests.full.xml
+++ b/webapi/tct-systeminfo-tizen-tests/tests.full.xml
@@ -879,7 +879,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase purpose="Check attribute level in SystemInfoBattery" type="compliance" onload_delay="90" status="approved" component="TizenAPI/System/SystemInfo" execution_type="auto" priority="P1" id="SystemInfoBattery_level_attribute">
+      <testcase purpose="Check attribute level in SystemInfoBattery" type="compliance" onload_delay="90" status="designed" component="TizenAPI/System/SystemInfo" execution_type="auto" priority="P1" id="SystemInfoBattery_level_attribute">
         <description>
           <test_script_entry>/opt/tct-systeminfo-tizen-tests/systeminfo/SystemInfoBattery_level_attribute.html</test_script_entry>
         </description>

--- a/webapi/tct-systeminfo-tizen-tests/tests.xml
+++ b/webapi/tct-systeminfo-tizen-tests/tests.xml
@@ -368,11 +368,6 @@
           <test_script_entry>/opt/tct-systeminfo-tizen-tests/systeminfo/SystemInfoBattery_extend.html</test_script_entry>
         </description>
       </testcase>
-      <testcase purpose="Check attribute level in SystemInfoBattery" onload_delay="90" component="TizenAPI/System/SystemInfo" execution_type="auto" id="SystemInfoBattery_level_attribute">
-        <description>
-          <test_script_entry>/opt/tct-systeminfo-tizen-tests/systeminfo/SystemInfoBattery_level_attribute.html</test_script_entry>
-        </description>
-      </testcase>
       <testcase purpose="Check attribute isCharging in SystemInfoBattery" onload_delay="90" component="TizenAPI/System/SystemInfo" execution_type="auto" id="SystemInfoBattery_isCharging_attribute">
         <description>
           <test_script_entry>/opt/tct-systeminfo-tizen-tests/systeminfo/SystemInfoBattery_isCharging_attribute.html</test_script_entry>


### PR DESCRIPTION
- Platform specific, IVI have no an on-board battery, this case is not applicable, change it to 'designed' in tests.full.xml, remove it from tests.xml
