### PR TITLE
[webapi][xwalk-3001] Remove HTML Templates test suite from pack script

### DIFF
--- a/misc/webapi-noneservice-cordova-tests/webapi-noneservice-cordova-tests.spec
+++ b/misc/webapi-noneservice-cordova-tests/webapi-noneservice-cordova-tests.spec
@@ -12,7 +12,6 @@ LIST="
 BLACK="webapi-style-css3-tests
 webapi-ambientlight-w3c-tests
 webapi-imports-w3c-tests
-webapi-htmltemplates-html5-tests
 webapi-runtime-xwalk-tests
 webapi-shadowdom-w3c-tests
 ivi-tests

--- a/misc/webapi-noneservice-tests/webapi-noneservice-tests.spec
+++ b/misc/webapi-noneservice-tests/webapi-noneservice-tests.spec
@@ -24,7 +24,6 @@ tct-xmlhttprequest-w3c-tests
 tizen-tests
 webapi-ambientlight-w3c-tests
 webapi-dlna-xwalk-tests
-webapi-htmltemplates-html5-tests
 webapi-imports-w3c-tests
 webapi-resourcetiming-w3c-tests
 webapi-runtime-xwalk-tests

--- a/webapi/suite-list.sh
+++ b/webapi/suite-list.sh
@@ -33,7 +33,6 @@ LIST=`find -maxdepth 1 -type d`
 APKBLACK="webapi-style-css3-tests
 webapi-ambientlight-w3c-tests
 webapi-imports-w3c-tests
-webapi-htmltemplates-html5-tests
 webapi-shadowdom-w3c-tests
 webapi-taskscheduler-sysapps-tests
 ivi-tests
@@ -49,7 +48,6 @@ XPKBLACK="webapi-contactsmanager-sysapps-tests
 webapi-style-css3-tests
 webapi-ambientlight-w3c-tests
 webapi-imports-w3c-tests
-webapi-htmltemplates-html5-tests
 webapi-presentation-xwalk-tests
 webapi-shadowdom-w3c-tests
 webapi-taskscheduler-sysapps-tests


### PR DESCRIPTION
- The test suite of HTML Templates have been removed in [PR#1258](https://github.com/crosswalk-project/crosswalk-test-suite/pull/1258)
