### PR TITLE
[webapi] Add 35 tests for W3C CSP per spec 0241

### DIFF
--- a/webapi/tct-csp-w3c-tests/csp-py/csp_ro_connect-src_asterisk.cgi
+++ b/webapi/tct-csp-w3c-tests/csp-py/csp_ro_connect-src_asterisk.cgi
@@ -1,0 +1,66 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only: connect-src *"
+echo "X-Content-Security-Policy-Report-Only: connect-src *"
+echo "X-WebKit-CSP-Report-Only: connect-src *"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_connect-src_asterisk</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#connect-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="connect-src *"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <script>
+        test(function() {
+            var xhr = new XMLHttpRequest();
+            try {
+                xhr.open("GET", "support/csp.js");
+            } catch(e) {
+                assert_unreached("should not reach here, got exception: "+e.message);
+            }
+        }, document.title + "_allowed");
+
+        test(function() {
+            var xhr = new XMLHttpRequest();
+            try {
+                xhr.open("GET", "http://www.w3.org");
+            } catch(e) {
+                assert_unreached("should not reach here, got exception: "+e.message);
+            }
+        }, document.title + "_allowed_ext");
+
+        function log123(message) {
+            var client = new XMLHttpRequest();
+            client.open("POST", "http://127.0.0.1:8000/log123");
+            client.send(message);
+        }
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp-py/csp_ro_connect-src_cross-origin.cgi
+++ b/webapi/tct-csp-w3c-tests/csp-py/csp_ro_connect-src_cross-origin.cgi
@@ -1,0 +1,68 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only: connect-src http://www.w3.org"
+echo "X-Content-Security-Policy-Report-Only: connect-src http://www.w3.org"
+echo "X-WebKit-CSP-Report-Only: connect-src http://www.w3.org"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_connect-src_cross-origin_xmlhttprequest</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#connect-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="connect-src http://www.w3.org"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <script>
+        var xhr = new XMLHttpRequest();
+
+        test(function() {
+            try {
+                xhr.open("GET", "http://www.w3.org");
+            } catch(e) {
+                assert_unreached("Should not reach here, exception: " + e.message);
+            }
+        }, document.title + "_allowed");
+
+        test(function() {
+            try {
+                xhr.open("GET", "https://www.tizen.org");
+            } catch(e) {
+                assert_unreached("Should not reach here, exception: " + e.message);
+            }
+        }, document.title + "_blocked");
+
+        test(function() {
+            try {
+                xhr.open("GET", "support/csp.js");
+            } catch(e) {
+                assert_unreached("Should not reach here, exception: " + e.message);
+            }
+        }, document.title + "_blocked_int");
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp-py/csp_ro_connect-src_cross-origin_multi.cgi
+++ b/webapi/tct-csp-w3c-tests/csp-py/csp_ro_connect-src_cross-origin_multi.cgi
@@ -1,0 +1,76 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only: connect-src http://www.w3.org https://www.tizen.org; script-src 'self' 'unsafe-inline'"
+echo "X-Content-Security-Policy-Report-Only: connect-src http://www.w3.org https://www.tizen.org; script-src 'self' 'unsafe-inline'"
+echo "X-WebKit-CSP-Report-Only: connect-src http://www.w3.org https://www.tizen.org; script-src 'self' 'unsafe-inline'"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_connect-src_cross-origin_multi_xmlhttprequest</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#connect-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="connect-src http://www.w3.org https://www.tizen.org"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <script>
+        var xhr = new XMLHttpRequest();
+
+        test(function() {
+            try {
+                xhr.open("GET", "http://www.w3.org");
+            } catch(e) {
+                assert_unreached("Should not reach here, exception: " + e.message);
+            }
+        }, document.title + "_allowed_one");
+
+        test(function() {
+            try {
+                xhr.open("GET", "https://www.tizen.org");
+            } catch(e) {
+                assert_unreached("Should not reach here, exception: " + e.message);
+            }
+        }, document.title + "_allowed_two");
+
+        test(function() {
+            try {
+                xhr.open("GET", "http://www.google.com");
+              } catch(e) {
+                assert_unreached("Should not reach here, exception: " + e.message);
+            }
+        }, document.title + "_blocked");
+
+        test(function() {
+            try {
+                xhr.open("GET", "support/csp.js");
+            } catch(e) {
+              assert_unreached("Should not reach here, exception: " + e.message);
+            }
+        }, document.title + "_blocked_int");
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp-py/csp_ro_connect-src_none.cgi
+++ b/webapi/tct-csp-w3c-tests/csp-py/csp_ro_connect-src_none.cgi
@@ -1,0 +1,60 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only: connect-src 'none'; script-src 'self' 'unsafe-inline'"
+echo "X-Content-Security-Policy-Report-Only: connect-src 'none'; script-src 'self' 'unsafe-inline'"
+echo "X-WebKit-CSP-Report-Only: connect-src 'none'; script-src 'self' 'unsafe-inline'"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_connect-src_none_xmlhttprequest</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#connect-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="connect-src 'none'; script-src 'self' 'unsafe-inline'"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <script>
+        var xhr = new XMLHttpRequest();
+
+        test(function() {
+            try {
+                xhr.open("GET", "support/csp.js");
+            } catch(e) {
+                assert_unreached("Should not reach here, exception: " + e.message);
+            }
+        }, document.title + "_blocked");
+
+        test(function() {
+            try {
+                xhr.open("GET", "http://https://www.tizen.org");
+            } catch(e) {
+                assert_unreached("Should not reach here, exception: " + e.message);
+            }
+        }, document.title + "_blocked_ext");
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp-py/csp_ro_connect-src_self.cgi
+++ b/webapi/tct-csp-w3c-tests/csp-py/csp_ro_connect-src_self.cgi
@@ -1,0 +1,60 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only: connect-src 'self'; script-src 'self' 'unsafe-inline'"
+echo "X-Content-Security-Policy-Report-Only: connect-src 'self'; script-src 'self' 'unsafe-inline'"
+echo "X-WebKit-CSP-Report-Only: connect-src 'self'; script-src 'self' 'unsafe-inline'"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_connect-src_self_xmlhttprequest</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#connect-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="connect-src 'self'; script-src 'self' 'unsafe-inline'"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <script>
+        var xhr = new XMLHttpRequest();
+
+        test(function() {
+            try {
+                xhr.open("GET", "support/csp.js");
+            } catch(e) {
+                assert_unreached("Should not reach here, exception: " + e.message);
+            }
+        }, document.title + "_allowed");
+
+        test(function() {
+            try {
+                xhr.open("GET", "http://https://www.tizen.org");
+            } catch(e) {
+                assert_unreached("Should not reach here, exception: " + e.message);
+            }
+        }, document.title + "_blocked");
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp-py/csp_ro_media-src_corss-origin_audio_blocked_ext.cgi
+++ b/webapi/tct-csp-w3c-tests/csp-py/csp_ro_media-src_corss-origin_audio_blocked_ext.cgi
@@ -1,0 +1,54 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only: media-src http://www.w3.org; script-src 'self' 'unsafe-inline'"
+echo "X-Content-Security-Policy-Report-Only: media-src http://www.w3.org; script-src 'self' 'unsafe-inline'"
+echo "X-WebKit-CSP-Report-Only: media-src http://www.w3.org; script-src 'self' 'unsafe-inline'"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_media-src_cross-origin_audio_blocked_ext</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#media-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="media-src http://www.w3.org; script-src 'self' 'unsafe-inline'"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <audio id="m"></audio>
+    <script>
+        var t = async_test(document.title);
+        var m = document.getElementById("m");
+        m.src = "http://127.0.0.1:8083/opt/tct-csp-w3c-tests/csp/support/red-green.theora.ogv";
+        window.setTimeout(function() {
+            t.step(function() {
+                assert_false(m.currentSrc == "",
+                    "audio.currentSrc should not be empty even use the not allowed external audio resource in report only mode");
+            });
+            t.done();
+        }, 0);
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp-py/csp_ro_media-src_corss-origin_audio_blocked_int.cgi
+++ b/webapi/tct-csp-w3c-tests/csp-py/csp_ro_media-src_corss-origin_audio_blocked_int.cgi
@@ -1,0 +1,54 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only: media-src http://www.w3.org; script-src 'self' 'unsafe-inline'"
+echo "X-Content-Security-Policy-Report-Only: media-src http://www.w3.org; script-src 'self' 'unsafe-inline'"
+echo "X-WebKit-CSP-Report-Only: media-src http://www.w3.org; script-src 'self' 'unsafe-inline'"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_media-src_cross-origin_audio_blocked_int</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#media-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="media-src http://www.w3.org; script-src 'self' 'unsafe-inline'"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <audio id="m"></audio>
+    <script>
+        var t = async_test(document.title);
+        var m = document.getElementById("m");
+        m.src = "support/red-green.theora.ogv";
+        window.setTimeout(function() {
+            t.step(function() {
+                assert_false(m.currentSrc == "",
+                    "audio.currentSrc should not be empty even use the not allowed internal audio resource in report only mode");
+            });
+            t.done();
+        }, 0);
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp-py/csp_ro_media-src_corss-origin_video_blocked_ext.cgi
+++ b/webapi/tct-csp-w3c-tests/csp-py/csp_ro_media-src_corss-origin_video_blocked_ext.cgi
@@ -1,0 +1,54 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only: media-src 'none'; script-src 'self' 'unsafe-inline'"
+echo "X-Content-Security-Policy-Report-Only: media-src 'none'; script-src 'self' 'unsafe-inline'"
+echo "X-WebKit-CSP-Report-Only: media-src 'none'; script-src 'self' 'unsafe-inline'"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_media-src_none_video_blocked_ext</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#media-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="media-src *; script-src 'self' 'unsafe-inline'"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <video id="m"></video>
+    <script>
+        var t = async_test(document.title);
+        var m = document.getElementById("m");
+        m.src = "http://127.0.0.1:8083/opt/tct-csp-w3c-tests/csp/support/red-green.theora.ogv";
+        window.setTimeout(function() {
+            t.step(function() {
+                assert_false(m.currentSrc == "",
+                    "video.currentSrc should not be empty even use the not allowed external audio resource in report only mode");
+            });
+            t.done();
+        }, 0);
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp-py/csp_ro_media-src_corss-origin_video_blocked_int.cgi
+++ b/webapi/tct-csp-w3c-tests/csp-py/csp_ro_media-src_corss-origin_video_blocked_int.cgi
@@ -1,0 +1,54 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only: media-src http://www.w3.org; script-src 'self' 'unsafe-inline'"
+echo "X-Content-Security-Policy-Report-Only: media-src http://www.w3.org; script-src 'self' 'unsafe-inline'"
+echo "X-WebKit-CSP-Report-Only: media-src http://www.w3.org; script-src 'self' 'unsafe-inline'"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_media-src_cross-origin_video_blocked_int</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#media-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="media-src http://www.w3.org; script-src 'self' 'unsafe-inline'"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <video id="m"></video>
+    <script>
+        var t = async_test(document.title);
+        var m = document.getElementById("m");
+        m.src = "support/red-green.theora.ogv";
+        window.setTimeout(function() {
+            t.step(function() {
+                assert_false(m.currentSrc == "",
+                    "video.currentSrc should not be empty even use the not internal external audio resource in report only mode");
+            });
+            t.done();
+        }, 0);
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp-py/csp_ro_media-src_none_audio_blocked_ext.cgi
+++ b/webapi/tct-csp-w3c-tests/csp-py/csp_ro_media-src_none_audio_blocked_ext.cgi
@@ -1,0 +1,54 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only: media-src 'none'; script-src 'self' 'unsafe-inline'"
+echo "X-Content-Security-Policy-Report-Only: media-src 'none'; script-src 'self' 'unsafe-inline'"
+echo "X-WebKit-CSP-Report-Only: media-src 'none'; script-src 'self' 'unsafe-inline'"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_media-src_none_audio_blocked_ext</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#media-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="media-src *; script-src 'self' 'unsafe-inline'"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <audio id="m"></audio>
+    <script>
+        var t = async_test(document.title);
+        var m = document.getElementById("m");
+        m.src = "http://127.0.0.1:8083/opt/tct-csp-w3c-tests/csp/support/red-green.theora.ogv";
+        window.setTimeout(function() {
+            t.step(function() {
+                assert_false(m.currentSrc == "",
+                    "audio.currentSrc should not be empty if use the external audio resource when media-src is none in report only mode.");
+            });
+            t.done();
+        }, 0);
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp-py/csp_ro_media-src_none_audio_blocked_int.cgi
+++ b/webapi/tct-csp-w3c-tests/csp-py/csp_ro_media-src_none_audio_blocked_int.cgi
@@ -1,0 +1,54 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only: media-src 'none'; script-src 'self' 'unsafe-inline'"
+echo "X-Content-Security-Policy-Report-Only: media-src 'none'; script-src 'self' 'unsafe-inline'"
+echo "X-WebKit-CSP-Report-Only: media-src 'none'; script-src 'self' 'unsafe-inline'"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_media-src_none_audio_blocked_int</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#media-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="media-src *; script-src 'self' 'unsafe-inline'"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <audio id="m"></audio>
+    <script>
+        var t = async_test(document.title);
+        var m = document.getElementById("m");
+        m.src = "support/red-green.theora.ogv";
+        window.setTimeout(function() {
+            t.step(function() {
+                assert_false(m.currentSrc == "",
+                    "audio.currentSrc should not be empty if use the internal audio resource when media-src is none in report only mode.");
+            });
+            t.done();
+        }, 0);
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp-py/csp_ro_media-src_none_video_blocked_ext.cgi
+++ b/webapi/tct-csp-w3c-tests/csp-py/csp_ro_media-src_none_video_blocked_ext.cgi
@@ -1,0 +1,54 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only: media-src 'none'; script-src 'self' 'unsafe-inline'"
+echo "X-Content-Security-Policy-Report-Only: media-src 'none'; script-src 'self' 'unsafe-inline'"
+echo "X-WebKit-CSP-Report-Only: media-src 'none'; script-src 'self' 'unsafe-inline'"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_media-src_none_video_blocked_ext</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#media-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="media-src *; script-src 'self' 'unsafe-inline'"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <video id="m"></video>
+    <script>
+        var t = async_test(document.title);
+        var m = document.getElementById("m");
+        m.src = "http://127.0.0.1:8083/opt/tct-csp-w3c-tests/csp/support/red-green.theora.ogv";
+        window.setTimeout(function() {
+            t.step(function() {
+                assert_false(m.currentSrc == "",
+                    "video.currentSrc should not be empty if use the external video resource when media-src is none in report only mode.");
+            });
+            t.done();
+        }, 0);
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp-py/csp_ro_media-src_none_video_blocked_int.cgi
+++ b/webapi/tct-csp-w3c-tests/csp-py/csp_ro_media-src_none_video_blocked_int.cgi
@@ -1,0 +1,54 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only: media-src 'none'; script-src 'self' 'unsafe-inline'"
+echo "X-Content-Security-Policy-Report-Only: media-src 'none'; script-src 'self' 'unsafe-inline'"
+echo "X-WebKit-CSP-Report-Only: media-src 'none'; script-src 'self' 'unsafe-inline'"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_media-src_none_video_blocked_int</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#media-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="media-src *; script-src 'self' 'unsafe-inline'"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <video id="m"></video>
+    <script>
+        var t = async_test(document.title);
+        var m = document.getElementById("m");
+        m.src = "support/red-green.theora.ogv";
+        window.setTimeout(function() {
+            t.step(function() {
+                assert_false(m.currentSrc == "",
+                    "video.currentSrc should not be empty if use the internal video resource when media-src is none in report only mode.");
+            });
+            t.done();
+        }, 0);
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp-py/csp_ro_style-src_asterisk.cgi
+++ b/webapi/tct-csp-w3c-tests/csp-py/csp_ro_style-src_asterisk.cgi
@@ -1,0 +1,58 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only:style-src *"
+echo "X-Content-Security-Policy-Report-Only:style-src *"
+echo "X-WebKit-CSP-Report-Only:style-src *"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_style-src_asterisk</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com/"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#style-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="style-src *"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+    <link rel="stylesheet" type="text/css" href="http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/canvas-index.css"/>
+    <link rel="stylesheet" type="text/css" href="support/blue-100x100.css"/>
+    <style>
+      #test-green {
+        background-color: green;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="log"></div>
+    <div id="test-blue"></div>
+    <div id="test-green"></div>
+    <h3>ext-css:http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/canvas-index.css</h3>
+    <script>
+        test(function() {
+            var div = document.querySelector("#test-green");
+            var fix = getComputedStyle(div)["backgroundColor"];
+            assert_equals(fix, "rgb(0, 128, 0)", "style setted correctly");
+        }, document.title + "_blocked_inline");
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp-py/csp_ro_style-src_cross-origin.cgi
+++ b/webapi/tct-csp-w3c-tests/csp-py/csp_ro_style-src_cross-origin.cgi
@@ -1,0 +1,72 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only:style-src http://127.0.0.1:8081"
+echo "X-Content-Security-Policy-Report-Only:style-src http://127.0.0.1:8081"
+echo "X-WebKit-CSP-Report-Only:style-src http://127.0.0.1:8081"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_style-src_cross-origin</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#style-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="style-src http://127.0.0.1:8081"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+    <link rel="stylesheet" type="text/css" href="http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/canvas-index.css"/>
+    <link rel="stylesheet" type="text/css" href="http://127.0.0.1:8082/opt/tct-csp-w3c-tests/csp/support/a-green.css"/>
+    <link rel="stylesheet" type="text/css" href="support/blue-100x100.css"/>
+    <style>
+      #test-green {
+        background-color: green;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="log"></div>
+    <div id="test-blue"></div>
+    <h3>ext-css:http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/canvas-index.css</h3>
+    <div id="test-ext-a" class="a"></div>
+    <div id="test-green"></div>
+    <script>
+        test(function() {
+            var div = document.querySelector("#test-ext-a");
+            var fix = getComputedStyle(div)["color"];
+            assert_equals(fix, "rgb(0, 128, 0)", "style setted correctly");
+        }, document.title + "_blocked");
+
+        test(function() {
+            var div = document.querySelector("#test-blue");
+            var fix = getComputedStyle(div)["backgroundColor"];
+            assert_equals(fix, "rgb(0, 0, 255)", "style setted correctly");
+        }, document.title + "_blocked_int");
+
+        test(function() {
+            var div = document.querySelector("#test-green");
+            var fix = getComputedStyle(div)["backgroundColor"];
+            assert_equals(fix, "rgb(0, 128, 0)", "style setted correctly");
+        }, document.title + "_blocked_inline");
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp-py/csp_ro_style-src_cross-origin_multi.cgi
+++ b/webapi/tct-csp-w3c-tests/csp-py/csp_ro_style-src_cross-origin_multi.cgi
@@ -1,0 +1,74 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only:style-src http://127.0.0.1:8081 http://127.0.0.1:8082"
+echo "X-Content-Security-Policy-Report-Only:style-src http://127.0.0.1:8081 http://127.0.0.1:8082"
+echo "X-WebKit-CSP-Report-Only:style-src http://127.0.0.1:8081 http://127.0.0.1:8082"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_style-src_cross-origin_multi</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com/"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#style-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="style-src http://127.0.0.1:8081 http://127.0.0.1:8082"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+    <link rel="stylesheet" type="text/css" href="http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/canvas-index.css"/>
+    <link rel="stylesheet" type="text/css" href="http://127.0.0.1:8082/opt/tct-csp-w3c-tests/csp/support/a-green.css"/>
+    <link rel="stylesheet" type="text/css" href="http://127.0.0.1:8083/opt/tct-csp-w3c-tests/csp/support/test.css"/>
+    <link rel="stylesheet" type="text/css" href="support/blue-100x100.css"/>
+    <style>
+      #test-green {
+        background-color: green;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="log"></div>
+    <div id="test-blue"></div>
+    <div id="test-green"></div>
+    <h3>ext-css:http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/canvas-index.css</h3>
+    <div id="test2" class="a">green</div>
+    <div id="test3" class="str">maroon</div>
+    <script>
+        test(function() {
+            var div = document.querySelector("#test3");
+            var fix = getComputedStyle(div)["color"];
+            assert_equals(fix, "rgb(128, 0, 0)", "style setted correctly");
+        }, document.title + "_blocked");
+
+        test(function() {
+            var div = document.querySelector("#test-blue");
+            var fix = getComputedStyle(div)["backgroundColor"];
+            assert_equals(fix, "rgb(0, 0, 255)", "style setted correctly");
+        }, document.title + "_blocked_int");
+
+        test(function() {
+            var div = document.querySelector("#test-green");
+            var fix = getComputedStyle(div)["backgroundColor"];
+            assert_equals(fix, "rgb(0, 128, 0)", "style setted correctly");
+        }, document.title + "_blocked_inline");
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp-py/csp_ro_style-src_none.cgi
+++ b/webapi/tct-csp-w3c-tests/csp-py/csp_ro_style-src_none.cgi
@@ -1,0 +1,70 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only:style-src 'none'"
+echo "X-Content-Security-Policy-Report-Only:style-src 'none'"
+echo "X-WebKit-CSP-Report-Only:style-src 'none'"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_style-src_none</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#style-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="style-src 'none'"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+    <link rel="stylesheet" type="text/css" href="http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/canvas-index.css"/>
+    <link rel="stylesheet" type="text/css" href="support/blue-100x100.css"/>
+    <style>
+      #test-green {
+        background-color: green;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="log"></div>
+    <div id="test-blue"></div>
+    <div id="test-green"></div>
+    <h3>ext-css:http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/canvas-index.css</h3>
+    <script>
+        test(function() {
+            var div = document.querySelector("h3");
+            var fix = getComputedStyle(div)["display"];
+            assert_equals(fix, "inline", "style setted correctly");
+        }, document.title + "_blocked_ext");
+
+        test(function() {
+            var div = document.querySelector("#test-blue");
+            var fix = getComputedStyle(div)["backgroundColor"];
+            assert_equals(fix, "rgb(0, 0, 255)", "style setted correctly");
+        }, document.title + "_blocked_int");
+
+        test(function() {
+            var div = document.querySelector("#test-green");
+            var fix = getComputedStyle(div)["backgroundColor"];
+            assert_equals(fix, "rgb(0, 128, 0)", "style setted correctly");
+        }, document.title + "_blocked_inline");
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp-py/csp_ro_style-src_self.cgi
+++ b/webapi/tct-csp-w3c-tests/csp-py/csp_ro_style-src_self.cgi
@@ -1,0 +1,64 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only:style-src 'self'"
+echo "X-Content-Security-Policy-Report-Only:style-src 'self'"
+echo "X-WebKit-CSP-Report-Only:style-src 'self'"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_style-src_self</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#style-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="style-src 'self'"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+    <link rel="stylesheet" type="text/css" href="http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/canvas-index.css"/>
+    <link rel="stylesheet" type="text/css" href="support/blue-100x100.css"/>
+    <style>
+      #test-green {
+        background-color: green;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="log"></div>
+    <div id="test-blue"></div>
+    <div id="test-green"></div>
+    <h3>ext-css:http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/canvas-index.css</h3>
+    <script>
+        test(function() {
+            var div = document.querySelector("h3");
+            var fix = getComputedStyle(div)["display"];
+            assert_equals(fix, "inline", "style setted correctly");
+        }, document.title + "_blocked");
+
+        test(function() {
+            var div = document.querySelector("#test-green");
+            var fix = getComputedStyle(div)["backgroundColor"];
+            assert_equals(fix, "rgb(0, 128, 0)", "style setted correctly");
+        }, document.title + "_blocked_inline");
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp-py/csp_ro_style-src_unsafe-inline.cgi
+++ b/webapi/tct-csp-w3c-tests/csp-py/csp_ro_style-src_unsafe-inline.cgi
@@ -1,0 +1,64 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only:default *;style-src 'unsafe-inline'"
+echo "X-Content-Security-Policy-Report-Only:default *;style-src 'unsafe-inline'"
+echo "X-WebKit-CSP-Report-Only:default *;style-src 'unsafe-inline'"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_style-src_unsafe-inline</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#style-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="default *;style-src 'unsafe-inline'"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+    <link rel="stylesheet" type="text/css" href="http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/canvas-index.css"/>
+    <link rel="stylesheet" type="text/css" href="support/blue-100x100.css"/>
+    <style>
+      #test-green {
+        background-color: green;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="log"></div>
+    <div id="test-blue"></div>
+    <div id="test-green"></div>
+    <h3>ext-css:http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/canvas-index.css</h3>
+    <script>
+        test(function() {
+            var div = document.querySelector("h3");
+            var fix = getComputedStyle(div)["display"];
+            assert_equals(fix, "inline", "style setted correctly");
+        }, document.title + "_blocked_ext");
+
+        test(function() {
+            var div = document.querySelector("#test-blue");
+            var fix = getComputedStyle(div)["backgroundColor"];
+            assert_equals(fix, "rgb(0, 0, 255)", "style setted correctly");
+        }, document.title + "_bloced_int");
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp-py/support/a-green.css
+++ b/webapi/tct-csp-w3c-tests/csp-py/support/a-green.css
@@ -1,0 +1,1 @@
+.a { color: green; }

--- a/webapi/tct-csp-w3c-tests/csp-py/support/canvas-index.css
+++ b/webapi/tct-csp-w3c-tests/csp-py/support/canvas-index.css
@@ -1,0 +1,31 @@
+body {
+    font-size: small;
+    font-family: sans-serif;
+}
+
+a {
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+h3 {
+    display: inline;
+    font-size: medium;
+}
+
+h3 + p {
+    display: inline;
+    margin-left: 0.5em;
+}
+
+li {
+    list-style-type: none;
+}
+
+ul {
+    padding-left: 2em;
+    margin-left: 0;
+}

--- a/webapi/tct-csp-w3c-tests/csp/csp_ro_connect-src_asterisk.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_ro_connect-src_asterisk.cgi
@@ -1,0 +1,66 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only: connect-src *"
+echo "X-Content-Security-Policy-Report-Only: connect-src *"
+echo "X-WebKit-CSP-Report-Only: connect-src *"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_connect-src_asterisk</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#connect-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="connect-src *"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <script>
+        test(function() {
+            var xhr = new XMLHttpRequest();
+            try {
+                xhr.open("GET", "support/csp.js");
+            } catch(e) {
+                assert_unreached("should not reach here, got exception: "+e.message);
+            }
+        }, document.title + "_allowed");
+
+        test(function() {
+            var xhr = new XMLHttpRequest();
+            try {
+                xhr.open("GET", "http://www.w3.org");
+            } catch(e) {
+                assert_unreached("should not reach here, got exception: "+e.message);
+            }
+        }, document.title + "_allowed_ext");
+
+        function log123(message) {
+            var client = new XMLHttpRequest();
+            client.open("POST", "http://127.0.0.1:8000/log123");
+            client.send(message);
+        }
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_ro_connect-src_cross-origin.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_ro_connect-src_cross-origin.cgi
@@ -1,0 +1,68 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only: connect-src http://www.w3.org"
+echo "X-Content-Security-Policy-Report-Only: connect-src http://www.w3.org"
+echo "X-WebKit-CSP-Report-Only: connect-src http://www.w3.org"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_connect-src_cross-origin_xmlhttprequest</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#connect-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="connect-src http://www.w3.org"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <script>
+        var xhr = new XMLHttpRequest();
+
+        test(function() {
+            try {
+                xhr.open("GET", "http://www.w3.org");
+            } catch(e) {
+                assert_unreached("Should not reach here, exception: " + e.message);
+            }
+        }, document.title + "_allowed");
+
+        test(function() {
+            try {
+                xhr.open("GET", "https://www.tizen.org");
+            } catch(e) {
+                assert_unreached("Should not reach here, exception: " + e.message);
+            }
+        }, document.title + "_blocked");
+
+        test(function() {
+            try {
+                xhr.open("GET", "support/csp.js");
+            } catch(e) {
+                assert_unreached("Should not reach here, exception: " + e.message);
+            }
+        }, document.title + "_blocked_int");
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_ro_connect-src_cross-origin_multi.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_ro_connect-src_cross-origin_multi.cgi
@@ -1,0 +1,76 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only: connect-src http://www.w3.org https://www.tizen.org; script-src 'self' 'unsafe-inline'"
+echo "X-Content-Security-Policy-Report-Only: connect-src http://www.w3.org https://www.tizen.org; script-src 'self' 'unsafe-inline'"
+echo "X-WebKit-CSP-Report-Only: connect-src http://www.w3.org https://www.tizen.org; script-src 'self' 'unsafe-inline'"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_connect-src_cross-origin_multi_xmlhttprequest</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#connect-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="connect-src http://www.w3.org https://www.tizen.org"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <script>
+        var xhr = new XMLHttpRequest();
+
+        test(function() {
+            try {
+                xhr.open("GET", "http://www.w3.org");
+            } catch(e) {
+                assert_unreached("Should not reach here, exception: " + e.message);
+            }
+        }, document.title + "_allowed_one");
+
+        test(function() {
+            try {
+                xhr.open("GET", "https://www.tizen.org");
+            } catch(e) {
+                assert_unreached("Should not reach here, exception: " + e.message);
+            }
+        }, document.title + "_allowed_two");
+
+        test(function() {
+            try {
+                xhr.open("GET", "http://www.google.com");
+              } catch(e) {
+                assert_unreached("Should not reach here, exception: " + e.message);
+            }
+        }, document.title + "_blocked");
+
+        test(function() {
+            try {
+                xhr.open("GET", "support/csp.js");
+            } catch(e) {
+              assert_unreached("Should not reach here, exception: " + e.message);
+            }
+        }, document.title + "_blocked_int");
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_ro_connect-src_none.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_ro_connect-src_none.cgi
@@ -1,0 +1,60 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only: connect-src 'none'; script-src 'self' 'unsafe-inline'"
+echo "X-Content-Security-Policy-Report-Only: connect-src 'none'; script-src 'self' 'unsafe-inline'"
+echo "X-WebKit-CSP-Report-Only: connect-src 'none'; script-src 'self' 'unsafe-inline'"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_connect-src_none_xmlhttprequest</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#connect-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="connect-src 'none'; script-src 'self' 'unsafe-inline'"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <script>
+        var xhr = new XMLHttpRequest();
+
+        test(function() {
+            try {
+                xhr.open("GET", "support/csp.js");
+            } catch(e) {
+                assert_unreached("Should not reach here, exception: " + e.message);
+            }
+        }, document.title + "_blocked");
+
+        test(function() {
+            try {
+                xhr.open("GET", "http://https://www.tizen.org");
+            } catch(e) {
+                assert_unreached("Should not reach here, exception: " + e.message);
+            }
+        }, document.title + "_blocked_ext");
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_ro_connect-src_self.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_ro_connect-src_self.cgi
@@ -1,0 +1,60 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only: connect-src 'self'; script-src 'self' 'unsafe-inline'"
+echo "X-Content-Security-Policy-Report-Only: connect-src 'self'; script-src 'self' 'unsafe-inline'"
+echo "X-WebKit-CSP-Report-Only: connect-src 'self'; script-src 'self' 'unsafe-inline'"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_connect-src_self_xmlhttprequest</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#connect-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="connect-src 'self'; script-src 'self' 'unsafe-inline'"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <script>
+        var xhr = new XMLHttpRequest();
+
+        test(function() {
+            try {
+                xhr.open("GET", "support/csp.js");
+            } catch(e) {
+                assert_unreached("Should not reach here, exception: " + e.message);
+            }
+        }, document.title + "_allowed");
+
+        test(function() {
+            try {
+                xhr.open("GET", "http://https://www.tizen.org");
+            } catch(e) {
+                assert_unreached("Should not reach here, exception: " + e.message);
+            }
+        }, document.title + "_blocked");
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_ro_media-src_corss-origin_audio_blocked_ext.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_ro_media-src_corss-origin_audio_blocked_ext.cgi
@@ -1,0 +1,54 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only: media-src http://www.w3.org; script-src 'self' 'unsafe-inline'"
+echo "X-Content-Security-Policy-Report-Only: media-src http://www.w3.org; script-src 'self' 'unsafe-inline'"
+echo "X-WebKit-CSP-Report-Only: media-src http://www.w3.org; script-src 'self' 'unsafe-inline'"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_media-src_cross-origin_audio_blocked_ext</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#media-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="media-src http://www.w3.org; script-src 'self' 'unsafe-inline'"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <audio id="m"></audio>
+    <script>
+        var t = async_test(document.title);
+        var m = document.getElementById("m");
+        m.src = "http://127.0.0.1:8083/opt/tct-csp-w3c-tests/csp/support/red-green.theora.ogv";
+        window.setTimeout(function() {
+            t.step(function() {
+                assert_false(m.currentSrc == "",
+                    "audio.currentSrc should not be empty even use the not allowed external audio resource in report only mode");
+            });
+            t.done();
+        }, 0);
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_ro_media-src_corss-origin_audio_blocked_int.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_ro_media-src_corss-origin_audio_blocked_int.cgi
@@ -1,0 +1,54 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only: media-src http://www.w3.org; script-src 'self' 'unsafe-inline'"
+echo "X-Content-Security-Policy-Report-Only: media-src http://www.w3.org; script-src 'self' 'unsafe-inline'"
+echo "X-WebKit-CSP-Report-Only: media-src http://www.w3.org; script-src 'self' 'unsafe-inline'"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_media-src_cross-origin_audio_blocked_int</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#media-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="media-src http://www.w3.org; script-src 'self' 'unsafe-inline'"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <audio id="m"></audio>
+    <script>
+        var t = async_test(document.title);
+        var m = document.getElementById("m");
+        m.src = "support/red-green.theora.ogv";
+        window.setTimeout(function() {
+            t.step(function() {
+                assert_false(m.currentSrc == "",
+                    "audio.currentSrc should not be empty even use the not allowed internal audio resource in report only mode");
+            });
+            t.done();
+        }, 0);
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_ro_media-src_corss-origin_video_blocked_ext.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_ro_media-src_corss-origin_video_blocked_ext.cgi
@@ -1,0 +1,54 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only: media-src 'none'; script-src 'self' 'unsafe-inline'"
+echo "X-Content-Security-Policy-Report-Only: media-src 'none'; script-src 'self' 'unsafe-inline'"
+echo "X-WebKit-CSP-Report-Only: media-src 'none'; script-src 'self' 'unsafe-inline'"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_media-src_none_video_blocked_ext</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#media-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="media-src *; script-src 'self' 'unsafe-inline'"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <video id="m"></video>
+    <script>
+        var t = async_test(document.title);
+        var m = document.getElementById("m");
+        m.src = "http://127.0.0.1:8083/opt/tct-csp-w3c-tests/csp/support/red-green.theora.ogv";
+        window.setTimeout(function() {
+            t.step(function() {
+                assert_false(m.currentSrc == "",
+                    "video.currentSrc should not be empty even use the not allowed external audio resource in report only mode");
+            });
+            t.done();
+        }, 0);
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_ro_media-src_corss-origin_video_blocked_int.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_ro_media-src_corss-origin_video_blocked_int.cgi
@@ -1,0 +1,54 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only: media-src http://www.w3.org; script-src 'self' 'unsafe-inline'"
+echo "X-Content-Security-Policy-Report-Only: media-src http://www.w3.org; script-src 'self' 'unsafe-inline'"
+echo "X-WebKit-CSP-Report-Only: media-src http://www.w3.org; script-src 'self' 'unsafe-inline'"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_media-src_cross-origin_video_blocked_int</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#media-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="media-src http://www.w3.org; script-src 'self' 'unsafe-inline'"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <video id="m"></video>
+    <script>
+        var t = async_test(document.title);
+        var m = document.getElementById("m");
+        m.src = "support/red-green.theora.ogv";
+        window.setTimeout(function() {
+            t.step(function() {
+                assert_false(m.currentSrc == "",
+                    "video.currentSrc should not be empty even use the not internal external audio resource in report only mode");
+            });
+            t.done();
+        }, 0);
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_ro_media-src_none_audio_blocked_ext.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_ro_media-src_none_audio_blocked_ext.cgi
@@ -1,0 +1,54 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only: media-src 'none'; script-src 'self' 'unsafe-inline'"
+echo "X-Content-Security-Policy-Report-Only: media-src 'none'; script-src 'self' 'unsafe-inline'"
+echo "X-WebKit-CSP-Report-Only: media-src 'none'; script-src 'self' 'unsafe-inline'"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_media-src_none_audio_blocked_ext</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#media-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="media-src *; script-src 'self' 'unsafe-inline'"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <audio id="m"></audio>
+    <script>
+        var t = async_test(document.title);
+        var m = document.getElementById("m");
+        m.src = "http://127.0.0.1:8083/opt/tct-csp-w3c-tests/csp/support/red-green.theora.ogv";
+        window.setTimeout(function() {
+            t.step(function() {
+                assert_false(m.currentSrc == "",
+                    "audio.currentSrc should not be empty if use the external audio resource when media-src is none in report only mode.");
+            });
+            t.done();
+        }, 0);
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_ro_media-src_none_audio_blocked_int.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_ro_media-src_none_audio_blocked_int.cgi
@@ -1,0 +1,54 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only: media-src 'none'; script-src 'self' 'unsafe-inline'"
+echo "X-Content-Security-Policy-Report-Only: media-src 'none'; script-src 'self' 'unsafe-inline'"
+echo "X-WebKit-CSP-Report-Only: media-src 'none'; script-src 'self' 'unsafe-inline'"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_media-src_none_audio_blocked_int</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#media-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="media-src *; script-src 'self' 'unsafe-inline'"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <audio id="m"></audio>
+    <script>
+        var t = async_test(document.title);
+        var m = document.getElementById("m");
+        m.src = "support/red-green.theora.ogv";
+        window.setTimeout(function() {
+            t.step(function() {
+                assert_false(m.currentSrc == "",
+                    "audio.currentSrc should not be empty if use the internal audio resource when media-src is none in report only mode.");
+            });
+            t.done();
+        }, 0);
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_ro_media-src_none_video_blocked_ext.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_ro_media-src_none_video_blocked_ext.cgi
@@ -1,0 +1,54 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only: media-src 'none'; script-src 'self' 'unsafe-inline'"
+echo "X-Content-Security-Policy-Report-Only: media-src 'none'; script-src 'self' 'unsafe-inline'"
+echo "X-WebKit-CSP-Report-Only: media-src 'none'; script-src 'self' 'unsafe-inline'"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_media-src_none_video_blocked_ext</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#media-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="media-src *; script-src 'self' 'unsafe-inline'"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <video id="m"></video>
+    <script>
+        var t = async_test(document.title);
+        var m = document.getElementById("m");
+        m.src = "http://127.0.0.1:8083/opt/tct-csp-w3c-tests/csp/support/red-green.theora.ogv";
+        window.setTimeout(function() {
+            t.step(function() {
+                assert_false(m.currentSrc == "",
+                    "video.currentSrc should not be empty if use the external video resource when media-src is none in report only mode.");
+            });
+            t.done();
+        }, 0);
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_ro_media-src_none_video_blocked_int.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_ro_media-src_none_video_blocked_int.cgi
@@ -1,0 +1,54 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only: media-src 'none'; script-src 'self' 'unsafe-inline'"
+echo "X-Content-Security-Policy-Report-Only: media-src 'none'; script-src 'self' 'unsafe-inline'"
+echo "X-WebKit-CSP-Report-Only: media-src 'none'; script-src 'self' 'unsafe-inline'"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_media-src_none_video_blocked_int</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#media-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="media-src *; script-src 'self' 'unsafe-inline'"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <video id="m"></video>
+    <script>
+        var t = async_test(document.title);
+        var m = document.getElementById("m");
+        m.src = "support/red-green.theora.ogv";
+        window.setTimeout(function() {
+            t.step(function() {
+                assert_false(m.currentSrc == "",
+                    "video.currentSrc should not be empty if use the internal video resource when media-src is none in report only mode.");
+            });
+            t.done();
+        }, 0);
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_ro_style-src_asterisk.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_ro_style-src_asterisk.cgi
@@ -1,0 +1,58 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only:style-src *"
+echo "X-Content-Security-Policy-Report-Only:style-src *"
+echo "X-WebKit-CSP-Report-Only:style-src *"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_style-src_asterisk</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com/"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#style-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="style-src *"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+    <link rel="stylesheet" type="text/css" href="http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/canvas-index.css"/>
+    <link rel="stylesheet" type="text/css" href="support/blue-100x100.css"/>
+    <style>
+      #test-green {
+        background-color: green;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="log"></div>
+    <div id="test-blue"></div>
+    <div id="test-green"></div>
+    <h3>ext-css:http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/canvas-index.css</h3>
+    <script>
+        test(function() {
+            var div = document.querySelector("#test-green");
+            var fix = getComputedStyle(div)["backgroundColor"];
+            assert_equals(fix, "rgb(0, 128, 0)", "style setted correctly");
+        }, document.title + "_blocked_inline");
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_ro_style-src_cross-origin.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_ro_style-src_cross-origin.cgi
@@ -1,0 +1,72 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only:style-src http://127.0.0.1:8081"
+echo "X-Content-Security-Policy-Report-Only:style-src http://127.0.0.1:8081"
+echo "X-WebKit-CSP-Report-Only:style-src http://127.0.0.1:8081"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_style-src_cross-origin</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#style-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="style-src http://127.0.0.1:8081"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+    <link rel="stylesheet" type="text/css" href="http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/canvas-index.css"/>
+    <link rel="stylesheet" type="text/css" href="http://127.0.0.1:8082/opt/tct-csp-w3c-tests/csp/support/a-green.css"/>
+    <link rel="stylesheet" type="text/css" href="support/blue-100x100.css"/>
+    <style>
+      #test-green {
+        background-color: green;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="log"></div>
+    <div id="test-blue"></div>
+    <h3>ext-css:http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/canvas-index.css</h3>
+    <div id="test-ext-a" class="a"></div>
+    <div id="test-green"></div>
+    <script>
+        test(function() {
+            var div = document.querySelector("#test-ext-a");
+            var fix = getComputedStyle(div)["color"];
+            assert_equals(fix, "rgb(0, 128, 0)", "style setted correctly");
+        }, document.title + "_blocked");
+
+        test(function() {
+            var div = document.querySelector("#test-blue");
+            var fix = getComputedStyle(div)["backgroundColor"];
+            assert_equals(fix, "rgb(0, 0, 255)", "style setted correctly");
+        }, document.title + "_blocked_int");
+
+        test(function() {
+            var div = document.querySelector("#test-green");
+            var fix = getComputedStyle(div)["backgroundColor"];
+            assert_equals(fix, "rgb(0, 128, 0)", "style setted correctly");
+        }, document.title + "_blocked_inline");
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_ro_style-src_cross-origin_multi.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_ro_style-src_cross-origin_multi.cgi
@@ -1,0 +1,74 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only:style-src http://127.0.0.1:8081 http://127.0.0.1:8082"
+echo "X-Content-Security-Policy-Report-Only:style-src http://127.0.0.1:8081 http://127.0.0.1:8082"
+echo "X-WebKit-CSP-Report-Only:style-src http://127.0.0.1:8081 http://127.0.0.1:8082"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_style-src_cross-origin_multi</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com/"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#style-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="style-src http://127.0.0.1:8081 http://127.0.0.1:8082"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+    <link rel="stylesheet" type="text/css" href="http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/canvas-index.css"/>
+    <link rel="stylesheet" type="text/css" href="http://127.0.0.1:8082/opt/tct-csp-w3c-tests/csp/support/a-green.css"/>
+    <link rel="stylesheet" type="text/css" href="http://127.0.0.1:8083/opt/tct-csp-w3c-tests/csp/support/test.css"/>
+    <link rel="stylesheet" type="text/css" href="support/blue-100x100.css"/>
+    <style>
+      #test-green {
+        background-color: green;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="log"></div>
+    <div id="test-blue"></div>
+    <div id="test-green"></div>
+    <h3>ext-css:http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/canvas-index.css</h3>
+    <div id="test2" class="a">green</div>
+    <div id="test3" class="str">maroon</div>
+    <script>
+        test(function() {
+            var div = document.querySelector("#test3");
+            var fix = getComputedStyle(div)["color"];
+            assert_equals(fix, "rgb(128, 0, 0)", "style setted correctly");
+        }, document.title + "_blocked");
+
+        test(function() {
+            var div = document.querySelector("#test-blue");
+            var fix = getComputedStyle(div)["backgroundColor"];
+            assert_equals(fix, "rgb(0, 0, 255)", "style setted correctly");
+        }, document.title + "_blocked_int");
+
+        test(function() {
+            var div = document.querySelector("#test-green");
+            var fix = getComputedStyle(div)["backgroundColor"];
+            assert_equals(fix, "rgb(0, 128, 0)", "style setted correctly");
+        }, document.title + "_blocked_inline");
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_ro_style-src_none.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_ro_style-src_none.cgi
@@ -1,0 +1,70 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only:style-src 'none'"
+echo "X-Content-Security-Policy-Report-Only:style-src 'none'"
+echo "X-WebKit-CSP-Report-Only:style-src 'none'"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_style-src_none</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#style-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="style-src 'none'"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+    <link rel="stylesheet" type="text/css" href="http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/canvas-index.css"/>
+    <link rel="stylesheet" type="text/css" href="support/blue-100x100.css"/>
+    <style>
+      #test-green {
+        background-color: green;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="log"></div>
+    <div id="test-blue"></div>
+    <div id="test-green"></div>
+    <h3>ext-css:http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/canvas-index.css</h3>
+    <script>
+        test(function() {
+            var div = document.querySelector("h3");
+            var fix = getComputedStyle(div)["display"];
+            assert_equals(fix, "inline", "style setted correctly");
+        }, document.title + "_blocked_ext");
+
+        test(function() {
+            var div = document.querySelector("#test-blue");
+            var fix = getComputedStyle(div)["backgroundColor"];
+            assert_equals(fix, "rgb(0, 0, 255)", "style setted correctly");
+        }, document.title + "_blocked_int");
+
+        test(function() {
+            var div = document.querySelector("#test-green");
+            var fix = getComputedStyle(div)["backgroundColor"];
+            assert_equals(fix, "rgb(0, 128, 0)", "style setted correctly");
+        }, document.title + "_blocked_inline");
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_ro_style-src_self.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_ro_style-src_self.cgi
@@ -1,0 +1,64 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only:style-src 'self'"
+echo "X-Content-Security-Policy-Report-Only:style-src 'self'"
+echo "X-WebKit-CSP-Report-Only:style-src 'self'"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_style-src_self</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#style-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="style-src 'self'"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+    <link rel="stylesheet" type="text/css" href="http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/canvas-index.css"/>
+    <link rel="stylesheet" type="text/css" href="support/blue-100x100.css"/>
+    <style>
+      #test-green {
+        background-color: green;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="log"></div>
+    <div id="test-blue"></div>
+    <div id="test-green"></div>
+    <h3>ext-css:http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/canvas-index.css</h3>
+    <script>
+        test(function() {
+            var div = document.querySelector("h3");
+            var fix = getComputedStyle(div)["display"];
+            assert_equals(fix, "inline", "style setted correctly");
+        }, document.title + "_blocked");
+
+        test(function() {
+            var div = document.querySelector("#test-green");
+            var fix = getComputedStyle(div)["backgroundColor"];
+            assert_equals(fix, "rgb(0, 128, 0)", "style setted correctly");
+        }, document.title + "_blocked_inline");
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp/csp_ro_style-src_unsafe-inline.cgi
+++ b/webapi/tct-csp-w3c-tests/csp/csp_ro_style-src_unsafe-inline.cgi
@@ -1,0 +1,64 @@
+#!/bin/sh
+echo "Content-Security-Policy-Report-Only:default *;style-src 'unsafe-inline'"
+echo "X-Content-Security-Policy-Report-Only:default *;style-src 'unsafe-inline'"
+echo "X-WebKit-CSP-Report-Only:default *;style-src 'unsafe-inline'"
+echo
+echo '<!DOCTYPE html>
+
+<!--
+Copyright (c) 2013 Samsung Electronics Co., Ltd.
+
+Licensed under the Apache License, Version 2.0 (the License);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Authors:
+        Ran, Wang <ran22.wang@samsung.com>
+-->
+
+<html>
+  <head>
+    <title>CSP Test: csp_ro_style-src_unsafe-inline</title>
+    <link rel="author" title="Samsung" href="http://www.Samsung.com"/>
+    <link rel="help" href="http://www.w3.org/TR/2012/CR-CSP-20121115/#style-src"/>
+    <meta name="flags" content=""/>
+    <meta name="assert" content="default *;style-src 'unsafe-inline'"/>
+    <meta charset="utf-8"/>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+    <link rel="stylesheet" type="text/css" href="http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/canvas-index.css"/>
+    <link rel="stylesheet" type="text/css" href="support/blue-100x100.css"/>
+    <style>
+      #test-green {
+        background-color: green;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="log"></div>
+    <div id="test-blue"></div>
+    <div id="test-green"></div>
+    <h3>ext-css:http://127.0.0.1:8081/opt/tct-csp-w3c-tests/csp/support/canvas-index.css</h3>
+    <script>
+        test(function() {
+            var div = document.querySelector("h3");
+            var fix = getComputedStyle(div)["display"];
+            assert_equals(fix, "inline", "style setted correctly");
+        }, document.title + "_blocked_ext");
+
+        test(function() {
+            var div = document.querySelector("#test-blue");
+            var fix = getComputedStyle(div)["backgroundColor"];
+            assert_equals(fix, "rgb(0, 0, 255)", "style setted correctly");
+        }, document.title + "_bloced_int");
+    </script>
+  </body>
+</html> '

--- a/webapi/tct-csp-w3c-tests/csp/support/a-green.css
+++ b/webapi/tct-csp-w3c-tests/csp/support/a-green.css
@@ -1,0 +1,1 @@
+.a { color: green; }

--- a/webapi/tct-csp-w3c-tests/csp/support/canvas-index.css
+++ b/webapi/tct-csp-w3c-tests/csp/support/canvas-index.css
@@ -1,0 +1,31 @@
+body {
+    font-size: small;
+    font-family: sans-serif;
+}
+
+a {
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+h3 {
+    display: inline;
+    font-size: medium;
+}
+
+h3 + p {
+    display: inline;
+    margin-left: 0.5em;
+}
+
+li {
+    list-style-type: none;
+}
+
+ul {
+    padding-left: 2em;
+    margin-left: 0;
+}

--- a/webapi/tct-csp-w3c-tests/tests.full.xml
+++ b/webapi/tct-csp-w3c-tests/tests.full.xml
@@ -192,6 +192,71 @@
           </spec>
         </specs>
       </testcase>
+      <testcase purpose="Check if user agent is able to open internal resource by xhr when only connect-src is *." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_connect-src_asterisk_allowed">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_connect-src_asterisk.cgi?total_num=2&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to open external resource by xhr when only connect-src is *." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_connect-src_asterisk_allowed_ext">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_connect-src_asterisk.cgi?total_num=2&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to open external resource by xhr when only connect-src is cross-origin." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_connect-src_cross-origin_xmlhttprequest_allowed">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_connect-src_cross-origin.cgi?total_num=3&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to open not-allowed external resource by xhr when connect-src is cross-origin." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_connect-src_cross-origin_xmlhttprequest_blocked">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_connect-src_cross-origin.cgi?total_num=3&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to open internal resource by xhr when connect-src is cross-origin." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_connect-src_cross-origin_xmlhttprequest_blocked_int">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_connect-src_cross-origin.cgi?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to open first allowed external resource by xhr when only connect-src is cross-origin." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_connect-src_cross-origin_multi_xmlhttprequest_allowed_one">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_connect-src_cross-origin_multi.cgi?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to open second allowed external resource by xhr when only connect-src is cross-origin." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_connect-src_cross-origin_multi_xmlhttprequest_allowed_two">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_connect-src_cross-origin_multi.cgi?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to open not-allowed external resource by xhr when connect-src is multi cross-origin." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_connect-src_cross-origin_multi_xmlhttprequest_blocked">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_connect-src_cross-origin_multi.cgi?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to open internal resource by xhr when connect-src is multi cross-origin." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_connect-src_cross-origin_multi_xmlhttprequest_blocked_int">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_connect-src_cross-origin_multi.cgi?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to open internal resource by xhr when connect-src is none." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_connect-src_none_xmlhttprequest_blocked">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_connect-src_none.cgi?total_num=2&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to open external resource by xhr when connect-src is none." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_connect-src_none_xmlhttprequest_blocked_ext">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_connect-src_none.cgi?total_num=2&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to open internal resource by xhr when only connect-src is 'self'." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_connect-src_self_xmlhttprequest_allowed">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_connect-src_self.cgi?total_num=2&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to open external resource by xhr when connect-src is 'self'." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_connect-src_self_xmlhttprequest_blocked">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_connect-src_self.cgi?total_num=2&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
     </set>
     <set name="default-src" type="js">
       <testcase purpose="Check if default-src is '*' that inline script won't be executed" type="compliance" status="approved" component="WebAPI/Security/Content Security Policy" execution_type="auto" priority="P1" id="csp_default-src_asterisk">
@@ -867,6 +932,46 @@
           </spec>
         </specs>
       </testcase>
+      <testcase purpose="Check if user agent is able to use the not allowed external audio resource when media-src is cross-origin in report only mode." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_media-src_corss-origin_audio_blocked_ext">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_media-src_corss-origin_audio_blocked_ext.cgi</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to use the internal audio resource when media-src is cross-origin in report only mode." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_media-src_corss-origin_audio_blocked_int">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_media-src_corss-origin_audio_blocked_int.cgi</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to use the not allowed external video resource when media-src is cross-origin in report only mode." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_media-src_corss-origin_video_blocked_ext">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_media-src_corss-origin_video_blocked_ext.cgi</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to use the internal video resource when media-src is cross-origin in report only mode." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_media-src_corss-origin_video_blocked_int">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_media-src_corss-origin_video_blocked_int.cgi</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to use the external audio resource when media-src is none in report only mode." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_media-src_none_audio_blocked_ext">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_media-src_none_audio_blocked_ext.cgi</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to use the internal audio resource when media-src is none in report only mode." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_media-src_none_audio_blocked_int">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_media-src_none_audio_blocked_int.cgi</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to use the external video resource when media-src is none in report only mode." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_media-src_none_video_blocked_ext">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_media-src_none_video_blocked_ext.cgi</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to use the internal video resource when media-src is none in report only mode." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_media-src_none_video_blocked_int">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_media-src_none_video_blocked_int.cgi</test_script_entry>
+        </description>
+      </testcase>
     </set>
     <set name="style-src" type="js">
       <testcase purpose="Check if user agent is able to use external style resource when style-src is *." type="compliance" status="approved" component="WebAPI/Security/Content Security Policy" execution_type="auto" priority="P2" id="csp_style-src_asterisk_allowed_ext">
@@ -1099,6 +1204,76 @@
             <spec_url>http://www.w3.org/TR/2012/CR-CSP-20121115/#style-src</spec_url>
           </spec>
         </specs>
+      </testcase>
+      <testcase purpose="Check if user agent is able to use inline style resource when style-src is * in report only mode." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_style-src_asterisk_blocked_inline" >
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_style-src_asterisk.cgi</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to use not allowed external style resource when style-src is cross origin in report only mode." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_style-src_cross-origin_blocked">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_style-src_cross-origin.cgi?total_num=3&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to use internal style resource when style-src is cross origin in report only mode." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_style-src_cross-origin_blocked_int">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_style-src_cross-origin.cgi?total_num=3&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to use inline style resource when style-src is cross origin in report only mode." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_style-src_cross-origin_blocked_inline">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_style-src_cross-origin.cgi?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to use not allowed external style resource when style-src is multi cross origin in report only mode." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_style-src_cross-origin_multi_blocked">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_style-src_cross-origin_multi.cgi?total_num=3&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to use internal style resource when style-src is multi cross origin in report only mode." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_style-src_cross-origin_multi_blocked_int">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_style-src_cross-origin_multi.cgi?total_num=3&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to use inline style resource when style-src is multi cross origin in report only mode." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_style-src_cross-origin_multi_blocked_inline">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_style-src_cross-origin_multi.cgi?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to use external style resource when style-src is none in report only mode." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_style-src_none_blocked_ext">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_style-src_none.cgi?total_num=3&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to use internal style resource when style-src is none in report only mode." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_style-src_none_blocked_int">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_style-src_none.cgi?total_num=3&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to use inline style resource when style-src is none in report only mode." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_style-src_none_blocked_inline">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_style-src_none.cgi?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to use external style resource when style-src is self in report only mode." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_style-src_self_blocked">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_style-src_self.cgi?total_num=2&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to use inline style resource when style-src is self in report only mode." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_style-src_self_blocked_inline">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_style-src_self.cgi?total_num=2&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to use external style resource when style-src is unsafe-inline in report only mode." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_style-src_unsafe-inline_blocked_ext">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_style-src_unsafe-inline.cgi?total_num=2&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase purpose="Check if user agent is able to use internal style resource when style-src is unsafe-inline in report only mode." type="compliance" status="approved" component="WebAPI/TBD/Content Security Policy" execution_type="auto" priority="P2" id="csp_ro_style-src_unsafe-inline_blocked_int">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_style-src_unsafe-inline.cgi?total_num=2&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
       </testcase>
     </set>
     <set name="script-src" type="js">

--- a/webapi/tct-csp-w3c-tests/tests.xml
+++ b/webapi/tct-csp-w3c-tests/tests.xml
@@ -90,6 +90,71 @@
           <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_connect-src_self.cgi?total_num=2&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
       </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_connect-src_asterisk_allowed" purpose="Check if user agent is able to open internal resource by xhr when only connect-src is *.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_connect-src_asterisk.cgi?total_num=2&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_connect-src_asterisk_allowed_ext" purpose="Check if user agent is able to open external resource by xhr when only connect-src is *.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_connect-src_asterisk.cgi?total_num=2&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_connect-src_cross-origin_xmlhttprequest_allowed" purpose="Check if user agent is able to open external resource by xhr when only connect-src is cross-origin.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_connect-src_cross-origin.cgi?total_num=3&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_connect-src_cross-origin_xmlhttprequest_blocked" purpose="Check if user agent is able to open not-allowed external resource by xhr when connect-src is cross-origin.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_connect-src_cross-origin.cgi?total_num=3&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_connect-src_cross-origin_xmlhttprequest_blocked_int" purpose="Check if user agent is able to open internal resource by xhr when connect-src is cross-origin.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_connect-src_cross-origin.cgi?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_connect-src_cross-origin_multi_xmlhttprequest_allowed_one" purpose="Check if user agent is able to open first allowed external resource by xhr when only connect-src is cross-origin.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_connect-src_cross-origin_multi.cgi?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_connect-src_cross-origin_multi_xmlhttprequest_allowed_two" purpose="Check if user agent is able to open second allowed external resource by xhr when only connect-src is cross-origin.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_connect-src_cross-origin_multi.cgi?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_connect-src_cross-origin_multi_xmlhttprequest_blocked" purpose="Check if user agent is able to open not-allowed external resource by xhr when connect-src is multi cross-origin.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_connect-src_cross-origin_multi.cgi?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_connect-src_cross-origin_multi_xmlhttprequest_blocked_int" purpose="Check if user agent is able to open internal resource by xhr when connect-src is multi cross-origin.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_connect-src_cross-origin_multi.cgi?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_connect-src_none_xmlhttprequest_blocked" purpose="Check if user agent is able to open internal resource by xhr when connect-src is none.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_connect-src_none.cgi?total_num=2&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_connect-src_none_xmlhttprequest_blocked_ext" purpose="Check if user agent is able to open external resource by xhr when connect-src is none.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_connect-src_none.cgi?total_num=2&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_connect-src_self_xmlhttprequest_allowed" purpose="Check if user agent is able to open internal resource by xhr when only connect-src is 'self'.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_connect-src_self.cgi?total_num=2&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_connect-src_self_xmlhttprequest_blocked" purpose="Check if user agent is able to open external resource by xhr when connect-src is 'self'.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_connect-src_self.cgi?total_num=2&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
     </set>
     <set name="default-src" type="js">
       <testcase component="WebAPI/Security/Content Security Policy" execution_type="auto" id="csp_default-src_asterisk" purpose="Check if default-src is '*' that inline script won't be executed">
@@ -399,6 +464,46 @@
           <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_media-src_none_video_blocked_int.cgi</test_script_entry>
         </description>
       </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_media-src_corss-origin_audio_blocked_ext" purpose="Check if user agent is able to use the not allowed external audio resource when media-src is cross-origin in report only mode.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_media-src_corss-origin_audio_blocked_ext.cgi</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_media-src_corss-origin_audio_blocked_int" purpose="Check if user agent is able to use the internal audio resource when media-src is cross-origin in report only mode.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_media-src_corss-origin_audio_blocked_int.cgi</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_media-src_corss-origin_video_blocked_ext" purpose="Check if user agent is able to use the not allowed external video resource when media-src is cross-origin in report only mode.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_media-src_corss-origin_video_blocked_ext.cgi</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_media-src_corss-origin_video_blocked_int" purpose="Check if user agent is able to use the internal video resource when media-src is cross-origin in report only mode.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_media-src_corss-origin_video_blocked_int.cgi</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_media-src_none_audio_blocked_ext" purpose="Check if user agent is able to use the external audio resource when media-src is none in report only mode.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_media-src_none_audio_blocked_ext.cgi</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_media-src_none_audio_blocked_int" purpose="Check if user agent is able to use the internal audio resource when media-src is none in report only mode.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_media-src_none_audio_blocked_int.cgi</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_media-src_none_video_blocked_ext" purpose="Check if user agent is able to use the external video resource when media-src is none in report only mode.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_media-src_none_video_blocked_ext.cgi</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_media-src_none_video_blocked_int" purpose="Check if user agent is able to use the internal video resource when media-src is none in report only mode.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_media-src_none_video_blocked_int.cgi</test_script_entry>
+        </description>
+      </testcase>
     </set>
     <set name="style-src" type="js">
       <testcase component="WebAPI/Security/Content Security Policy" execution_type="auto" id="csp_style-src_asterisk_allowed_ext" purpose="Check if user agent is able to use external style resource when style-src is *.">
@@ -504,6 +609,76 @@
       <testcase component="WebAPI/Security/Content Security Policy" execution_type="auto" id="csp_style-src_unsafe-inline_allowed" purpose="Check if user agent is able to use inline style resource when style-src is unsafe-inline.">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_style-src_unsafe-inline.cgi?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_style-src_asterisk_blocked_inline" purpose="Check if user agent is able to use inline style resource when style-src is * in report only mode.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_style-src_asterisk.cgi</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_style-src_cross-origin_blocked" purpose="Check if user agent is able to use not allowed external style resource when style-src is cross origin in report only mode.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_style-src_cross-origin.cgi?total_num=3&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_style-src_cross-origin_blocked_int" purpose="Check if user agent is able to use internal style resource when style-src is cross origin in report only mode.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_style-src_cross-origin.cgi?total_num=3&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_style-src_cross-origin_blocked_inline" purpose="Check if user agent is able to use inline style resource when style-src is cross origin in report only mode.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_style-src_cross-origin.cgi?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_style-src_cross-origin_multi_blocked" purpose="Check if user agent is able to use not allowed external style resource when style-src is multi cross origin in report only mode.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_style-src_cross-origin_multi.cgi?total_num=3&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_style-src_cross-origin_multi_blocked_int" purpose="Check if user agent is able to use internal style resource when style-src is multi cross origin in report only mode.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_style-src_cross-origin_multi.cgi?total_num=3&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_style-src_cross-origin_multi_blocked_inline" purpose="Check if user agent is able to use inline style resource when style-src is multi cross origin in report only mode.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_style-src_cross-origin_multi.cgi?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_style-src_none_blocked_ext" purpose="Check if user agent is able to use external style resource when style-src is none in report only mode.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_style-src_none.cgi?total_num=3&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_style-src_none_blocked_int" purpose="Check if user agent is able to use internal style resource when style-src is none in report only mode.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_style-src_none.cgi?total_num=3&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_style-src_none_blocked_inline" purpose="Check if user agent is able to use inline style resource when style-src is none in report only mode.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_style-src_none.cgi?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_style-src_self_blocked" purpose="Check if user agent is able to use external style resource when style-src is self in report only mode.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_style-src_self.cgi?total_num=2&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_style-src_self_blocked_inline" purpose="Check if user agent is able to use inline style resource when style-src is self in report only mode.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_style-src_self.cgi?total_num=2&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_style-src_unsafe-inline_blocked_ext" purpose="Check if user agent is able to use external style resource when style-src is unsafe-inline in report only mode.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_style-src_unsafe-inline.cgi?total_num=2&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="WebAPI/TBD/Content Security Policy" execution_type="auto" id="csp_ro_style-src_unsafe-inline_blocked_int" purpose="Check if user agent is able to use internal style resource when style-src is unsafe-inline in report only mode.">
+        <description>
+          <test_script_entry test_script_expected_result="0">/opt/tct-csp-w3c-tests/csp/csp_ro_style-src_unsafe-inline.cgi?total_num=2&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
       </testcase>
     </set>


### PR DESCRIPTION
- Re-wirte php files to cgi files

Impacted tests(approved): new 35, update 0, delete 0
Unit test platform: [IVI] crosswalk-10.38.222, t-e-c 0.107
Unit test result summary: pass 35, fail 0, block 0
