### PR TITLE
[usecase] Add 1 usecase for Picture Element

### DIFF
--- a/usecase/usecase-webapi-xwalk-tests/samples/PictureElement/README.md
+++ b/usecase/usecase-webapi-xwalk-tests/samples/PictureElement/README.md
@@ -1,0 +1,5 @@
+## Usecase Design
+
+This sample demonstrates Picture Element feature basic functionalities, include:
+
+* Provide multiple sources to its contained img element that enables it to choose from multiple URLs

--- a/usecase/usecase-webapi-xwalk-tests/samples/PictureElement/index.html
+++ b/usecase/usecase-webapi-xwalk-tests/samples/PictureElement/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2014 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xu, Kang <kangx.xu@intel.com>
+
+-->
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, width=device-width" />
+    <link rel="stylesheet" type="text/css" href="../../css/jquery.mobile.css" />
+    <link rel="stylesheet" type="text/css" href="../../css/main.css" />
+    <link rel="stylesheet" type="text/css" href="../../css/style.css" />
+    <script src="../../js/jquery/jquery.js"></script>
+    <script src="../../js/jquery/jquery.mobile.js"></script>
+    <script src="../../js/tests.js"></script>
+  </head>
+  <body>
+    <div data-role="header">
+      <h1 id="main_page_title"></h1>
+    </div>
+    <div data-role="content">
+      <picture>
+        <source media="(max-width: 7000px)" src="../../res/images/green-100x100.png">
+        <img src="../../res/images/red-100x100.png" alt="This picture loads on non-supporting device.">
+      </picture>
+    </div>
+    <div data-role="footer" data-position="fixed">
+    </div>
+    <div data-role="popup" id="popup_info">
+      <font style="font-size:85%">
+        <p>Check if the device support Picture Element</p>
+      </font>
+    </div>
+  </body>
+</html>

--- a/usecase/usecase-webapi-xwalk-tests/steps/PictureElement/step.js
+++ b/usecase/usecase-webapi-xwalk-tests/steps/PictureElement/step.js
@@ -1,0 +1,6 @@
+var step = '<font style="font-size:85%">'
+           + '<p>Test Purpose: </p>'
+           + '<p>Check if the device support Picture Element.</p>'
+           + '<p>Expected Result: </p>'
+           + '<p>Test passes if there is a green box.</p>'
+         + '</font>'

--- a/usecase/usecase-webapi-xwalk-tests/tests.android.xml
+++ b/usecase/usecase-webapi-xwalk-tests/tests.android.xml
@@ -5,6 +5,8 @@
     <set name="Multimedia &amp;amp; Graphics">
       <testcase component="usecase" execution_type="manual" id="Jsenhance" purpose="Jsenhance">
       </testcase>
+      <testcase component="usecase" execution_type="manual" id="PictureElement" purpose="PictureElement">
+      </testcase>
     </set>
     <set name="Networking &amp;amp; Storage">
       <testcase component="usecase" execution_type="manual" id="FileSystem" purpose="File System">

--- a/usecase/usecase-webapi-xwalk-tests/tests.full.xml
+++ b/usecase/usecase-webapi-xwalk-tests/tests.full.xml
@@ -5,6 +5,8 @@
     <set name="Multimedia &amp;amp; Graphics">
       <testcase component="usecase" type="functional_positive" status="approved" execution_type="manual" platform="all" priority="P0" id="Jsenhance" purpose="Jsenhance">
       </testcase>
+      <testcase component="usecase" type="functional_positive" status="approved" execution_type="manual" platform="all" priority="P0" id="PictureElement" purpose="PictureElement">
+      </testcase>
     </set>
     <set name="Networking &amp;amp; Storage">
       <testcase component="usecase" type="functional_positive" status="approved" execution_type="manual" platform="all" priority="P0" id="FileSystem" purpose="File System">

--- a/usecase/usecase-webapi-xwalk-tests/tests.tizen.xml
+++ b/usecase/usecase-webapi-xwalk-tests/tests.tizen.xml
@@ -5,6 +5,8 @@
     <set name="Multimedia &amp;amp; Graphics">
       <testcase component="usecase" execution_type="manual" id="Jsenhance" purpose="Jsenhance">
       </testcase>
+      <testcase component="usecase" execution_type="manual" id="PictureElement" purpose="PictureElement">
+      </testcase>
     </set>
     <set name="Networking &amp;amp; Storage">
       <testcase component="usecase" execution_type="manual" id="FileSystem" purpose="File System">


### PR DESCRIPTION
- Fail Reason: XWALK-3065 Image of <source> inside <picture> can't be displayed when the device width conform to the media strategy

Impacted tests(approved): new 1, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 0, fail 1, block 0
