### PR TITLE
[webapi] Add 1 test for sessionhistory from w3c

### DIFF
--- a/webapi/tct-sessionhistory-html5-tests/tests.full.xml
+++ b/webapi/tct-sessionhistory-html5-tests/tests.full.xml
@@ -261,9 +261,21 @@
           </spec>
         </specs>
       </testcase>
+      <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_length_update_when_loading_pages" priority="P2" purpose="history.length should update when loading pages in an iframe" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=1</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion element_type="attribute" element_name="length" interface="History" specification="HTML5 The session history of browsing contexts (Partial)" section="Communication" category="Tizen W3C API Specifications"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-html5-20121025/history.html#the-history-interface</spec_url>
+            <spec_statement/>
+          </spec>
+        </specs>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_length_update_when_setting_location_hash" priority="P2" purpose="history.length should update when setting location.hash" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=2</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -275,7 +287,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_exist_within_iframes" priority="P2" purpose="history.pushState must exist within iframes" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=4</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -287,7 +299,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_state_initial_be_null" priority="P1" purpose="initial history.state should be null" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=5</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -299,7 +311,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_length_when_pushing_state" priority="P2" purpose="history.length should update when pushing a state" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=6</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -311,7 +323,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_state_update_after_state_pushed" priority="P2" purpose="history.state should update after a state is pushed" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=7</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -323,7 +335,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_length_not_decrease_after_going_back" priority="P2" purpose="history.length should not decrease after going back" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=8</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -335,7 +347,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_traversed_must_traverse_pushed_states" priority="P3" purpose="traversing history must traverse pushed states" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=9</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -347,7 +359,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_traversed_must_traverse_hash_changes" priority="P3" purpose="traversing history must also traverse hash changes" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=10</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -359,7 +371,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_arguments_with_invalid_URLs" priority="P2" purpose="pushState must not be allowed to create invalid URLs" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=11</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -371,7 +383,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_arguments_with_cross-origin_URLs" priority="P2" purpose="pushState must not be allowed to create cross-origin URLs" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=12</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -383,7 +395,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_arguments_with_about_colon_blank" priority="P2" purpose="pushState must not be allowed to create cross-origin URLs (about:blank)" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=13</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -395,7 +407,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_arguments_with_data_colon_URI" priority="P2" purpose="pushState must not be allowed to create cross-origin URLs (data:URI)" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=14</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -407,7 +419,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_security_errors_test_pushState_with_URL" priority="P3" purpose="security errors are expected to be thrown in the context of the document that owns the history object, pushState with URL" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=15</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -419,7 +431,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="Location_hash_change_part_one" priority="P2" purpose="location.hash must be allowed to change (part 1)" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=16</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=16</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -431,7 +443,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="Location_hash_change_part_two" priority="P2" purpose="location.hash must be allowed to change (part 2)" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=17</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -443,7 +455,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_not_alter_with_no_URL_arguments" priority="P2" purpose="pushState must not alter location.hash when no URL is provided" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=18</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=18</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -455,7 +467,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_remove_history" priority="P2" purpose="pushState must remove all history after the current state" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=19</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=19</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -467,7 +479,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_able_to_set_location_hash" priority="P2" purpose="pushState must be able to set location.hash" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=20</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=20</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -479,7 +491,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_not_fire_hashchange_event" priority="P2" purpose="pushState must not fire hashchange events" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=22</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=22</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -491,7 +503,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_able_to_set_location_pathname" priority="P2" purpose="pushState must be able to set location.pathname" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=23</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=23</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -503,7 +515,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_able_to_set_absolute_URLs" priority="P2" purpose="pushState must be able to set absolute URLs to the same host" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=24</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=24</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -515,7 +527,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_not_able_to_use_function_as_data" priority="P2" purpose="pushState must not be able to use a function as data" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=25</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=25</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -527,7 +539,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_not_able_to_use_DOM_node_as_data" priority="P2" purpose="pushState must not be able to use a DOM node as data" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=26</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=26</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -539,7 +551,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_not_able_to_use_error_object_as_data" priority="P2" purpose="pushState must not be able to use an error object as data" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=27</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=27</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -551,7 +563,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_security_errors_test_pushState_with_empty" priority="P3" purpose="security errors are expected to be thrown in the context of the document that owns the history object, pushState with empty" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=28</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=28</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -563,7 +575,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_able_to_make_structured_clones" priority="P2" purpose="pushState must be able to make structured clones of complex objects" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=29</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=29</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -575,7 +587,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_state_reference_a_clone" priority="P2" purpose="history.state should also reference a clone of the original object" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=30</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=30</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -587,7 +599,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_state_reference_a_clone_not_reference_original" priority="P2" purpose="history.state should be a clone of the original object, not a reference to it" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=31</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=31</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -599,7 +611,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="PopStateEvent_fired_when_navigation_occurs" priority="P2" purpose="popstate event should fire when navigation occurs" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=32</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=32</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -611,7 +623,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="PopStateEvent_pass_the_state_data" priority="P2" purpose="popstate event should pass the state data" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=33</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=33</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -623,7 +635,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="PopStateEvent_state_data_cope" priority="P2" purpose="state data should cope with circular object references" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=34</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=34</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -635,7 +647,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="PopStateEvent_state_data_be_clone" priority="P2" purpose="state data should be a clone of the original object, not a reference to it" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=35</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=35</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -647,7 +659,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="PopStateEvent_get_history_state_be_a_clone" priority="P2" purpose="popstate event history.state should also reference a clone of the original object" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=36</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=36</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -659,7 +671,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="PopStateEvent_get_history_state_be_a_clone_not_reference_original" priority="P2" purpose="popstate event history.state should be a clone of the original object, not a reference to it" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=37</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=37</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -671,7 +683,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_not_load_new_URL" priority="P2" purpose="pushState should not actually load the new URL" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=39</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=39</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -683,7 +695,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_reloading_a_pushed_state" priority="P2" purpose="reloading a pushed state should actually load the new URL" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=40</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=40</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -695,7 +707,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_exist_within_iframes" priority="P1" purpose="history.replaceState must exist within iframes" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=4</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -707,7 +719,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_length_not_update_replacing_state_with_no_URL" priority="P2" purpose="history.length should not update when replacing a state with no URL" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=6</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -719,7 +731,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_without_URL" priority="P2" purpose="hash should not change when replaceState is called without a URL" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=8</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -731,7 +743,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_with_a_URL_length_no_update" priority="P2" purpose="history.length should not update when replacing a state with a URL" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=9</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -743,7 +755,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_with_a_URL_hash_change" priority="P2" purpose="hash should change when replaceState is called with a URL" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=10</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -755,7 +767,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_replace_existing_state" priority="P2" purpose="replaceState must replace the existing state and not add an extra one" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=11</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -767,7 +779,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_not_altering_forward_history" priority="P2" purpose="replaceState must replace the existing state without altering the forward history" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=12</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -779,7 +791,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_not_allowed_to_create_invalid_URLs" priority="P2" purpose="replaceState must not be allowed to create invalid URLs" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=13</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -791,7 +803,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_not_allowed_create_cross-origin_URLs" priority="P2" purpose="replaceState must not be allowed to create cross-origin URLs" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=14</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -803,7 +815,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_not_allowed_to_create_about_colon_blank" priority="P2" purpose="replaceState must not be allowed to create cross-origin URLs (about:blank)" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=15</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -815,7 +827,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_not_allowed_to_create_data_colon_URI" priority="P2" purpose="replaceState must not be allowed to create cross-origin URLs (data:URI)" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=16</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=16</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -827,7 +839,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_security_errors_test_replaceState_with_URL" priority="P3" purpose="security errors are expected to be thrown in the context of the document that owns the history object, replaceState with URL" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=17</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -839,7 +851,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_able_to_set_location_pathname" priority="P2" purpose="replaceState must be able to set location.pathname" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=18</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=18</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -851,7 +863,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_able_to_set_absolute_URLs" priority="P2" purpose="replaceState must be able to set absolute URLs to the same host" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=19</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=19</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -863,7 +875,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_not_remove_tasks_queued" priority="P2" purpose="replaceState must not remove any tasks queued by the history traversal task source" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=20</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=20</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -875,7 +887,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_traversal_task_source" priority="P3" purpose="go must queue a task with the history traversal task source (run asynchronously)" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=21</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=21</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -887,7 +899,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_not_fire_hashchange_event" priority="P2" purpose="replaceState must not fire hashchange events" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=22</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=22</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -899,7 +911,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_arguments_with_a_function" priority="P2" purpose="replaceState must not be able to use a function as data" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=23</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=23</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -911,7 +923,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_arguments_with_a_DOM" priority="P2" purpose="replaceState must not be able to use a DOM node as data" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=24</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=24</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -923,7 +935,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_arguments_with_a_error_object" priority="P2" purpose="replaceState must not be able to use an error object as data" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=25</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=25</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -935,7 +947,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_security_errors_test_replaceState_with_empty" priority="P3" purpose="security errors are expected to be thrown in the context of the document that owns the history object, replaceState with empty" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=26</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=26</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -947,7 +959,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_able_to_make_structured_clones" priority="P2" purpose="replaceState must be able to make structured clones of complex objects" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=27</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=27</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -959,7 +971,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_not_load_new_URL" priority="P2" purpose="replaceState should not actually load the new URL" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=37</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=37</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -971,7 +983,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_reloading_not_load_new_URL" priority="P2" purpose="reloading a replaced state should actually load the new URL" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=38</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=38</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -983,7 +995,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="PopStateEvent_exists" priority="P1" purpose="Check if PopStateEvent exists" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/003.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/003.html?total_num=8&amp;locator_key=id&amp;value=1</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -995,7 +1007,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="initPopStateEvent_instanceof_PopStateEvent" priority="P1" purpose="Check if the document.createEvent instanceof of PopStateEvent" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/003.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/003.html?total_num=8&amp;locator_key=id&amp;value=5</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1007,7 +1019,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="initPopStateEvent_property_Event" priority="P1" purpose="Check if the document.createEvent instanceof of Event" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/003.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/003.html?total_num=8&amp;locator_key=id&amp;value=6</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1019,7 +1031,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="initPopStateEvent_dispatchable" priority="P1" purpose="Check if initPopStateEvent can be dispatchable on the window object" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/003.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/003.html?total_num=8&amp;locator_key=id&amp;value=7</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1031,7 +1043,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="location_window_hash_basic" priority="P1" purpose="Check if Location.hash fire hashchange event and get the correct data " status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/004.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/004.html?total_num=4&amp;locator_key=id&amp;value=1</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1045,7 +1057,7 @@
     <set name="SessionHistory2" type="js">
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="location_body_onpopstate" priority="P1" purpose="Check if body onpopstate register a listener for the popstate event" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/005.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/005.html?total_num=3&amp;locator_key=id&amp;value=2</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1057,7 +1069,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="location_window_onpopstate" priority="P1" purpose="Check if window.onpopstate register a listener for the popstate event" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/005.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/005.html?total_num=3&amp;locator_key=id&amp;value=3</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1069,7 +1081,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_state_initial" priority="P1" purpose="Check if the value of history.state initialled to null" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/006.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/006.html?total_num=6&amp;locator_key=id&amp;value=1</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1081,7 +1093,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="popstate_event_fire_after_onload" priority="P1" purpose="Check if popstate event fired after onload event" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/006.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/006.html?total_num=6&amp;locator_key=id&amp;value=2</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1093,7 +1105,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_state_value_onload" priority="P1" purpose="Check if the value of history.state still be null on onload event occurs" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/006.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/006.html?total_num=6&amp;locator_key=id&amp;value=3</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1105,7 +1117,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_state_value_after_onload" priority="P1" purpose="Check if the value of history.state still be null after onload event occurs" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/006.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/006.html?total_num=6&amp;locator_key=id&amp;value=5</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1117,7 +1129,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_state_write" priority="P1" purpose="Check if writing to history.state should be silently ignored and not throw an error" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/006.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/006.html?total_num=6&amp;locator_key=id&amp;value=6</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1129,7 +1141,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_HTTP_Referer" priority="P3" purpose="Check if HTTP Referer should use the pushed state" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/009.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/009.html?total_num=4&amp;locator_key=id&amp;value=1</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1141,7 +1153,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_document_referrer" priority="P3" purpose="Check if document.referrer should use the pushed state" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/009.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/009.html?total_num=4&amp;locator_key=id&amp;value=2</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1153,7 +1165,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_HTTP_Referer" priority="P3" purpose="Check if HTTP Referer should use the replaced state" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/009.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/009.html?total_num=4&amp;locator_key=id&amp;value=3</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1165,7 +1177,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_document_referrer" priority="P3" purpose="Check if document.referrer should use the replaced state" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/009.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/009.html?total_num=4&amp;locator_key=id&amp;value=4</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1177,7 +1189,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_HTTP_Referer_2" priority="P3" purpose="Check if HTTP Referer should use the pushed state before onload" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/010.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/010.html?total_num=4&amp;locator_key=id&amp;value=1</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1189,7 +1201,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_document_referrer_2" priority="P3" purpose="Check if document.referrer should use the pushed state before onload" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/010.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/010.html?total_num=4&amp;locator_key=id&amp;value=2</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1201,7 +1213,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_HTTP_Referer_2" priority="P3" purpose="Check if HTTP Referer should use the replaced state before onload" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/010.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/010.html?total_num=4&amp;locator_key=id&amp;value=3</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1213,7 +1225,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_document_referrer_2" priority="P3" purpose="Check if document.referrer should use the replaced state before onload" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/010.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/010.html?total_num=4&amp;locator_key=id&amp;value=4</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1225,7 +1237,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_set_location_state" priority="P1" purpose="Check if history.pushState can be set the location state" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/011.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/011.html?total_num=3&amp;locator_key=id&amp;value=1</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1237,7 +1249,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_reflecte" priority="P1" purpose="Check if the pushed location can be reflected immediately" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/011.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/011.html?total_num=3&amp;locator_key=id&amp;value=2</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1249,7 +1261,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_retained_later" priority="P1" purpose="Check if the pushed location retained after the page has loaded" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/011.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/011.html?total_num=3&amp;locator_key=id&amp;value=3</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1261,7 +1273,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_set_location_state" priority="P1" purpose="Check if history.replaceState can be set the location state" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/012.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/012.html?total_num=3&amp;locator_key=id&amp;value=1</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1273,7 +1285,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_reflecte" priority="P1" purpose="Check if the replaced location can be reflected immediately" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/012.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/012.html?total_num=3&amp;locator_key=id&amp;value=2</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -1285,7 +1297,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_retained_later" priority="P1" purpose="Check if the replaced location retained after the page has loaded" status="approved" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/012.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/012.html?total_num=3&amp;locator_key=id&amp;value=3</test_script_entry>
         </description>
         <specs>
           <spec>

--- a/webapi/tct-sessionhistory-html5-tests/tests.xml
+++ b/webapi/tct-sessionhistory-html5-tests/tests.xml
@@ -5,105 +5,105 @@
         <description>
           <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/history_back_exists.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_forward_exists" purpose="Check if history.forward method exists">
         <description>
           <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/history_forward_exists.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_length_exists" purpose="Check if history.length attribute exists">
         <description>
           <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/history_length_exists.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_basic" purpose="Check if the location.href is '002.html' when history.pushstate method is set to '002.html'">
         <description>
           <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/history_pushState_basic.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_exists" purpose="Check if history.pushState method exists">
         <description>
           <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/history_pushState_exists.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_basic" purpose="Check if the location.href is '002.html' when history.replaceState method param url set '002.html'">
         <description>
           <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/history_replaceState_basic.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_exists" purpose="Check if history.replaceState method exists">
         <description>
           <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/history_replaceState_exists.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_state_exists" purpose="Check if history.state attribute exists">
         <description>
           <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/history_state_exists.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="location_document_hostname_exists" purpose="Check if location.hostname exists">
         <description>
           <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/location_document_hostname_exists.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="location_document_protocol_exists" purpose="Check if location.protocol attribute exists">
         <description>
           <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/location_document_protocol_exists.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="location_document_search_exists" purpose="Check if location.search attribute exists">
         <description>
           <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/location_document_search_exists.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="location_window_assign_basic" purpose="Check if the location.href is '002.html' when location.assign is '002.html'">
         <description>
           <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/location_window_assign_basic.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="location_window_assign_exists" purpose="Check if location.assign method exists">
         <description>
           <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/location_window_assign_exists.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="location_window_hash_exists" purpose="Check if Location.hash attribute exists">
         <description>
           <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/location_window_hash_exists.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="location_window_host_exists" purpose="Check if Location.host attribute exists">
         <description>
           <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/location_window_host_exists.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="location_window_href_exists" purpose="Check if Location.href attribute exists">
         <description>
           <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/location_window_href_exists.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="location_window_pathname_exists" purpose="Check if Location.pathname attribute exists">
         <description>
           <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/location_window_pathname_exists.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="location_window_port_exists" purpose="Check if Location.port attribute exists">
         <description>
           <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/location_window_port_exists.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="location_window_replace_basic" purpose="Check if the location.href is 'id=1' when location.replace method is set to 'id=1'">
         <description>
           <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/location_window_replace_basic.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="location_window_replace_exists" purpose="Check if location.replace method exists">
         <description>
           <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/location_window_replace_exists.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="manual" id="history_forward_basic" purpose="Check if the history.forward method works well.">
         <description>
-          <pre_condition />
+          <pre_condition/>
           <steps>
             <step order="1">
               <step_desc>Click the forward button</step_desc>
@@ -112,437 +112,442 @@
           </steps>
           <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/history_forward_basic.html</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_length_update_when_loading_pages" purpose="history.length should update when loading pages in an iframe">
+        <description>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=1</test_script_entry>
+        </description>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_length_update_when_setting_location_hash" purpose="history.length should update when setting location.hash">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=2</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_exist_within_iframes" purpose="history.pushState must exist within iframes">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=4</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_state_initial_be_null" purpose="initial history.state should be null">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=5</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_length_when_pushing_state" purpose="history.length should update when pushing a state">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=6</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_state_update_after_state_pushed" purpose="history.state should update after a state is pushed">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=7</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_length_not_decrease_after_going_back" purpose="history.length should not decrease after going back">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=8</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_traversed_must_traverse_pushed_states" purpose="traversing history must traverse pushed states">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=9</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_traversed_must_traverse_hash_changes" purpose="traversing history must also traverse hash changes">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=10</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_arguments_with_invalid_URLs" purpose="pushState must not be allowed to create invalid URLs">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=11</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_arguments_with_cross-origin_URLs" purpose="pushState must not be allowed to create cross-origin URLs">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=12</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_arguments_with_about_colon_blank" purpose="pushState must not be allowed to create cross-origin URLs (about:blank)">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=13</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_arguments_with_data_colon_URI" purpose="pushState must not be allowed to create cross-origin URLs (data:URI)">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=14</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_security_errors_test_pushState_with_URL" purpose="security errors are expected to be thrown in the context of the document that owns the history object, pushState with URL">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=15</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="Location_hash_change_part_one" purpose="location.hash must be allowed to change (part 1)">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=16</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=16</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="Location_hash_change_part_two" purpose="location.hash must be allowed to change (part 2)">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=17</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_not_alter_with_no_URL_arguments" purpose="pushState must not alter location.hash when no URL is provided">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=18</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=18</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_remove_history" purpose="pushState must remove all history after the current state">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=19</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=19</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_able_to_set_location_hash" purpose="pushState must be able to set location.hash">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=20</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=20</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_not_fire_hashchange_event" purpose="pushState must not fire hashchange events">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=22</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=22</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_able_to_set_location_pathname" purpose="pushState must be able to set location.pathname">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=23</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=23</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_able_to_set_absolute_URLs" purpose="pushState must be able to set absolute URLs to the same host">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=24</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=24</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_not_able_to_use_function_as_data" purpose="pushState must not be able to use a function as data">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=25</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=25</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_not_able_to_use_DOM_node_as_data" purpose="pushState must not be able to use a DOM node as data">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=26</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=26</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_not_able_to_use_error_object_as_data" purpose="pushState must not be able to use an error object as data">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=27</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=27</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_security_errors_test_pushState_with_empty" purpose="security errors are expected to be thrown in the context of the document that owns the history object, pushState with empty">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=28</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=28</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_able_to_make_structured_clones" purpose="pushState must be able to make structured clones of complex objects">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=29</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=29</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_state_reference_a_clone" purpose="history.state should also reference a clone of the original object">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=30</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=30</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_state_reference_a_clone_not_reference_original" purpose="history.state should be a clone of the original object, not a reference to it">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=31</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=31</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="PopStateEvent_fired_when_navigation_occurs" purpose="popstate event should fire when navigation occurs">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=32</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=32</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="PopStateEvent_pass_the_state_data" purpose="popstate event should pass the state data">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=33</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=33</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="PopStateEvent_state_data_cope" purpose="state data should cope with circular object references">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=34</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=34</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="PopStateEvent_state_data_be_clone" purpose="state data should be a clone of the original object, not a reference to it">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=35</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=35</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="PopStateEvent_get_history_state_be_a_clone" purpose="popstate event history.state should also reference a clone of the original object">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=36</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=36</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="PopStateEvent_get_history_state_be_a_clone_not_reference_original" purpose="popstate event history.state should be a clone of the original object, not a reference to it">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=37</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=37</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_not_load_new_URL" purpose="pushState should not actually load the new URL">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=39</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=39</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_reloading_a_pushed_state" purpose="reloading a pushed state should actually load the new URL">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;amp;locator_key=id&amp;amp;value=40</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/001.html?total_num=40&amp;locator_key=id&amp;value=40</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_exist_within_iframes" purpose="history.replaceState must exist within iframes">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=4</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_length_not_update_replacing_state_with_no_URL" purpose="history.length should not update when replacing a state with no URL">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=6</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_without_URL" purpose="hash should not change when replaceState is called without a URL">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=8</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=8</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_with_a_URL_length_no_update" purpose="history.length should not update when replacing a state with a URL">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=9</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_with_a_URL_hash_change" purpose="hash should change when replaceState is called with a URL">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=10</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_replace_existing_state" purpose="replaceState must replace the existing state and not add an extra one">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=11</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_not_altering_forward_history" purpose="replaceState must replace the existing state without altering the forward history">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=12</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_not_allowed_to_create_invalid_URLs" purpose="replaceState must not be allowed to create invalid URLs">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=13</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=13</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_not_allowed_create_cross-origin_URLs" purpose="replaceState must not be allowed to create cross-origin URLs">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=14</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=14</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_not_allowed_to_create_about_colon_blank" purpose="replaceState must not be allowed to create cross-origin URLs (about:blank)">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=15</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=15</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_not_allowed_to_create_data_colon_URI" purpose="replaceState must not be allowed to create cross-origin URLs (data:URI)">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=16</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=16</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_security_errors_test_replaceState_with_URL" purpose="security errors are expected to be thrown in the context of the document that owns the history object, replaceState with URL">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=17</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=17</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_able_to_set_location_pathname" purpose="replaceState must be able to set location.pathname">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=18</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=18</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_able_to_set_absolute_URLs" purpose="replaceState must be able to set absolute URLs to the same host">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=19</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=19</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_not_remove_tasks_queued" purpose="replaceState must not remove any tasks queued by the history traversal task source">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=20</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=20</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_traversal_task_source" purpose="go must queue a task with the history traversal task source (run asynchronously)">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=21</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=21</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_not_fire_hashchange_event" purpose="replaceState must not fire hashchange events">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=22</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=22</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_arguments_with_a_function" purpose="replaceState must not be able to use a function as data">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=23</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=23</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_arguments_with_a_DOM" purpose="replaceState must not be able to use a DOM node as data">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=24</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=24</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_arguments_with_a_error_object" purpose="replaceState must not be able to use an error object as data">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=25</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=25</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_security_errors_test_replaceState_with_empty" purpose="security errors are expected to be thrown in the context of the document that owns the history object, replaceState with empty">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=26</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=26</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_able_to_make_structured_clones" purpose="replaceState must be able to make structured clones of complex objects">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=27</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=27</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_not_load_new_URL" purpose="replaceState should not actually load the new URL">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=37</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=37</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_reloading_not_load_new_URL" purpose="reloading a replaced state should actually load the new URL">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;amp;locator_key=id&amp;amp;value=38</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/002.html?total_num=38&amp;locator_key=id&amp;value=38</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="PopStateEvent_exists" purpose="Check if PopStateEvent exists">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/003.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/003.html?total_num=8&amp;locator_key=id&amp;value=1</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="initPopStateEvent_instanceof_PopStateEvent" purpose="Check if the document.createEvent instanceof of PopStateEvent">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/003.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/003.html?total_num=8&amp;locator_key=id&amp;value=5</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="initPopStateEvent_property_Event" purpose="Check if the document.createEvent instanceof of Event">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/003.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/003.html?total_num=8&amp;locator_key=id&amp;value=6</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="initPopStateEvent_dispatchable" purpose="Check if initPopStateEvent can be dispatchable on the window object">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/003.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/003.html?total_num=8&amp;locator_key=id&amp;value=7</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="location_window_hash_basic" purpose="Check if Location.hash fire hashchange event and get the correct data ">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/004.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/004.html?total_num=4&amp;locator_key=id&amp;value=1</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
     </set>
     <set name="SessionHistory2" type="js">
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="location_body_onpopstate" purpose="Check if body onpopstate register a listener for the popstate event">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/005.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/005.html?total_num=3&amp;locator_key=id&amp;value=2</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="location_window_onpopstate" purpose="Check if window.onpopstate register a listener for the popstate event">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/005.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/005.html?total_num=3&amp;locator_key=id&amp;value=3</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_state_initial" purpose="Check if the value of history.state initialled to null">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/006.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/006.html?total_num=6&amp;locator_key=id&amp;value=1</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="popstate_event_fire_after_onload" purpose="Check if popstate event fired after onload event">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/006.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/006.html?total_num=6&amp;locator_key=id&amp;value=2</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_state_value_onload" purpose="Check if the value of history.state still be null on onload event occurs">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/006.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/006.html?total_num=6&amp;locator_key=id&amp;value=3</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_state_value_after_onload" purpose="Check if the value of history.state still be null after onload event occurs">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/006.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/006.html?total_num=6&amp;locator_key=id&amp;value=5</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_state_write" purpose="Check if writing to history.state should be silently ignored and not throw an error">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/006.html?total_num=6&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/006.html?total_num=6&amp;locator_key=id&amp;value=6</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_HTTP_Referer" purpose="Check if HTTP Referer should use the pushed state">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/009.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/009.html?total_num=4&amp;locator_key=id&amp;value=1</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_document_referrer" purpose="Check if document.referrer should use the pushed state">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/009.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/009.html?total_num=4&amp;locator_key=id&amp;value=2</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_HTTP_Referer" purpose="Check if HTTP Referer should use the replaced state">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/009.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/009.html?total_num=4&amp;locator_key=id&amp;value=3</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_document_referrer" purpose="Check if document.referrer should use the replaced state">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/009.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/009.html?total_num=4&amp;locator_key=id&amp;value=4</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_HTTP_Referer_2" purpose="Check if HTTP Referer should use the pushed state before onload">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/010.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/010.html?total_num=4&amp;locator_key=id&amp;value=1</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_document_referrer_2" purpose="Check if document.referrer should use the pushed state before onload">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/010.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/010.html?total_num=4&amp;locator_key=id&amp;value=2</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_HTTP_Referer_2" purpose="Check if HTTP Referer should use the replaced state before onload">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/010.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/010.html?total_num=4&amp;locator_key=id&amp;value=3</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_document_referrer_2" purpose="Check if document.referrer should use the replaced state before onload">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/010.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/010.html?total_num=4&amp;locator_key=id&amp;value=4</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_set_location_state" purpose="Check if history.pushState can be set the location state">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/011.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/011.html?total_num=3&amp;locator_key=id&amp;value=1</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_reflecte" purpose="Check if the pushed location can be reflected immediately">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/011.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/011.html?total_num=3&amp;locator_key=id&amp;value=2</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_pushState_retained_later" purpose="Check if the pushed location retained after the page has loaded">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/011.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/011.html?total_num=3&amp;locator_key=id&amp;value=3</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_set_location_state" purpose="Check if history.replaceState can be set the location state">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/012.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/012.html?total_num=3&amp;locator_key=id&amp;value=1</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_reflecte" purpose="Check if the replaced location can be reflected immediately">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/012.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/012.html?total_num=3&amp;locator_key=id&amp;value=2</test_script_entry>
         </description>
-        </testcase>
+      </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_replaceState_retained_later" purpose="Check if the replaced location retained after the page has loaded">
         <description>
-          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/012.html?total_num=3&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
+          <test_script_entry>/opt/tct-sessionhistory-html5-tests/sessionhistory/w3c/012.html?total_num=3&amp;locator_key=id&amp;value=3</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Communication/HTML5 The session history of browsing contexts (Partial)" execution_type="auto" id="history_go_exists" purpose="Check if history.go method exists">


### PR DESCRIPTION
- Update tests.full.xml and tests.xml, add 1 check point about sessionhistory/w3c/001.html

Impacted tests(approved): new 1, update 0, delete 0
Unit test platform: [IVI] crosswalk-10.38.222, t-e-c 0.107
Unit test result summary: pass 1, fail 0, block 0
