### PR TITLE
[ivi-tct][webapi] Add 2 tests for web notificaition

### DIFF
--- a/webapi/tct-notification-w3c-tests/notification/notification_bodyDir-manual.html
+++ b/webapi/tct-notification-w3c-tests/notification/notification_bodyDir-manual.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2014 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xinx, liu <xinx.liu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>Notification Test: notification_bodyDir</title>
+<link rel="author" title="Intel" href="http://www.intel.com/" />
+<link rel="help" href="http://www.w3.org/TR/2012/WD-notifications-20120614/#api" />
+<meta name="flags" content="interact" />
+<style>
+  button {
+    height: 100px;
+    width:  100px;
+  }
+</style>
+<h1>Description</h1>
+<p>
+   After hitting the button below, your device must show two same notifications, only their bodys on different edge.
+</p>
+<button id='vib'>Show notificaiton</button>
+<script>
+  document.getElementById("vib").onclick = function () {
+    notification1 = typeof Notification != "undefined" ?
+                    new Notification("New Email Received",
+                    {   
+                      bodyDir: "ltr",
+                      body: "Room 101",
+                    })
+                    : window.webkitNotifications.createNotification("New Email Received",
+                    {   
+                      bodyDir: "ltr",
+                      body: "Room 101",
+                    });
+    notification2 = typeof Notification != "undefined" ?
+                    new Notification("New Email Received",
+                    {   
+                      bodyDir: "rtl",
+                      body: "Room 101",
+                    })
+                    : window.webkitNotifications.createNotification("New Email Received",
+                    {   
+                      bodyDir: "rtl",
+                      body: "Room 101",
+                    });
+  };
+</script>
+

--- a/webapi/tct-notification-w3c-tests/notification/notification_titleDir-manual.html
+++ b/webapi/tct-notification-w3c-tests/notification/notification_titleDir-manual.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2014 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Authors:
+        Xinx, liu <xinx.liu@intel.com>
+
+-->
+
+<meta charset='utf-8'>
+<title>Notification Test: notification_titleDir</title>
+<link rel="author" title="Intel" href="http://www.intel.com/" />
+<link rel="help" href="http://www.w3.org/TR/2012/WD-notifications-20120614/#api" />
+<meta name="flags" content="interact" />
+<style>
+  button {
+    height: 100px;
+    width:  100px;
+  }
+</style>
+<h1>Description</h1>
+<p>
+   After hitting the button below, your device must show two same notifications, only their titles on different edge.
+</p>
+<button id='vib'>Show notificaiton</button>
+<script>
+  document.getElementById("vib").onclick = function () {
+    notification1 = typeof Notification != "undefined" ?
+                    new Notification("New Email Received",
+                    {   
+                      titleDir: "ltr",
+                      body: "Room 101",
+                    })
+                    : window.webkitNotifications.createNotification("New Email Received",
+                    {   
+                      titleDir: "ltr",
+                      body: "Room 101",
+                    });
+    notification2 = typeof Notification != "undefined" ?
+                    new Notification("New Email Received",
+                    {   
+                      titleDir: "rtl",
+                      body: "Room 101",
+                    })
+                    : window.webkitNotifications.createNotification("New Email Received",
+                    {   
+                      titleDir: "rtl",
+                      body: "Room 101",
+                    });
+  };
+</script>
+

--- a/webapi/tct-notification-w3c-tests/tests.full.xml
+++ b/webapi/tct-notification-w3c-tests/tests.full.xml
@@ -205,6 +205,30 @@
           </spec>
         </specs>
       </testcase>
+      <testcase component="W3C_HTML5 APIs/UI/Web Notifications (Partial)" execution_type="manual" id="notification_bodyDir-manual" priority="P1" purpose="Check if bodyDir is NotificationOptions dictionary" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/tct-notification-w3c-tests/notification/notification_bodyDir-manual.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion category="Tizen W3C API Specifications" element_name="bodyDir" element_type="attribute" interface="Notification" section="UI" specification="Web Notifications (Partial)" />
+            <spec_url>http://www.w3.org/TR/2012/WD-notifications-20120614/#notificationdirection</spec_url>
+            <spec_statement />
+          </spec>
+        </specs>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/UI/Web Notifications (Partial)" execution_type="manual" id="notification_titleDir-manual" priority="P1" purpose="Check if titleDir is NotificationOptions dictionary" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/tct-notification-w3c-tests/notification/notification_titleDir-manual.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion category="Tizen W3C API Specifications" element_name="titleDir" element_type="attribute" interface="Notification" section="UI" specification="Web Notifications (Partial)" />
+            <spec_url>http://www.w3.org/TR/2012/WD-notifications-20120614/#notificationdirection</spec_url>
+            <spec_statement />
+          </spec>
+        </specs>
+      </testcase>
     </set>
   </suite>
 </test_definition>

--- a/webapi/tct-notification-w3c-tests/tests.xml
+++ b/webapi/tct-notification-w3c-tests/tests.xml
@@ -86,6 +86,16 @@
           <test_script_entry>/opt/tct-notification-w3c-tests/notification/onshow_using.html</test_script_entry>
         </description>
         </testcase>
+      <testcase component="W3C_HTML5 APIs/UI/Web Notifications (Partial)" execution_type="manual" id="notification_bodyDir-manual" purpose="Check if bodyDir is NotificationOptions dictionary">
+        <description>
+          <test_script_entry>/opt/tct-notification-w3c-tests/notification/notification_bodyDir-manual.html</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="W3C_HTML5 APIs/UI/Web Notifications (Partial)" execution_type="manual" id="notification_titleDir-manual" purpose="Check if titleDir is NotificationOptions dictionary">
+        <description>
+          <test_script_entry>/opt/tct-notification-w3c-tests/notification/notification_titleDir-manual.html</test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>


### PR DESCRIPTION
- Add titleDir, bodyDir of NotificationOptions dictionary

Impacted tests(approved): new 2, update 0, delete 0
Unit test platform: [IVI] crosswalk-10.39.233, t-e-c 0.120
Unit test result summary: pass 0, fail 2, block 0
