### PR TITLE
[ivi-tct][webapi] Integrate 1 test for drag and drop from w3c

### DIFF
--- a/webapi/tct-dnd-html5-tests/dnd/w3c/009.html
+++ b/webapi/tct-dnd-html5-tests/dnd/w3c/009.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Adding element to datastore on drag</title>
+<style type="text/css">
+span, strong
+	{color:green;
+	background-color:yellow;}
+strong
+	{color:red;}
+</style>
+<script type="application/ecmascript">
+function start(event)
+	{event.dataTransfer.effectAllowed = 'copy';
+	event.dataTransfer.addElement(document.querySelector('span'));}
+function resetImage(event)
+	{event.dataTransfer.addElement(document.querySelector('strong'));}
+</script>
+</head>
+<body>
+<p><a href="data:text/plain,1" ondragstart="start(event)" ondrag="resetImage(event)">Drag me</a></p>
+<p>Try to drag link above. You should see word <span>PASS</span> not <strong>FAIL</strong> in feedback overlay all the time.</p>
+</body>
+</html>

--- a/webapi/tct-dnd-html5-tests/tests.full.xml
+++ b/webapi/tct-dnd-html5-tests/tests.full.xml
@@ -73,6 +73,18 @@
           </spec>
         </specs>
       </testcase>
+      <testcase component="W3C_HTML5 APIs/UI/HTML5 Drag and drop (Partial)" execution_type="manual" id="DataTransfer_addElement_basic" priority="P1" purpose="Test checks that DataTransfer addElement work" status="approved" type="compliance">
+        <description>
+          <test_script_entry>/opt/tct-dnd-html5-tests/dnd/w3c/009.html</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion category="Tizen W3C API Specifications" element_name="addElement" element_type="method" interface="DataTransfer" section="UI" specification="HTML5 Drag and drop"/>
+            <spec_url>http://www.w3.org/TR/2012/WD-html5-20120329/dnd.html#the-draggable-attribute</spec_url>
+            <spec_statement />
+          </spec>
+        </specs>
+      </testcase>
     </set>
   </suite>
 </test_definition>

--- a/webapi/tct-dnd-html5-tests/tests.xml
+++ b/webapi/tct-dnd-html5-tests/tests.xml
@@ -31,6 +31,11 @@
           <test_script_entry>/opt/tct-dnd-html5-tests/dnd/w3c/dragdrop_006.htm</test_script_entry>
         </description>
         </testcase>
+      <testcase component="W3C_HTML5 APIs/UI/HTML5 Drag and drop (Partial)" execution_type="manual" id="DataTransfer_addElement_basic" purpose="Test checks that DataTransfer addElement work">
+        <description>
+          <test_script_entry>/opt/tct-dnd-html5-tests/dnd/w3c/009.html</test_script_entry>
+        </description>
+      </testcase>
     </set>
   </suite>
 </test_definition>


### PR DESCRIPTION
- Add addElement of DataTransfer interface
- Test come from https://github.com/w3c/web-platform-tests/tree/master/html/editing/dnd/overlay (commit: c68a7f796eb7df702becafadb64df8b930093bb2)
- Update xhtml file to html file

Impacted tests(approved): new 1, update 0, delete 0
Unit test platform: [IVI] crosswalk-10.39.233, t-e-c 0.120
Unit test result summary: pass 1, fail 0, block 0
