### PR TITLE
Sync to latest the XSLT style for test case and test result

### DIFF
--- a/behavior/res/css/testkit/tests.css
+++ b/behavior/res/css/testkit/tests.css
@@ -1,123 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
 }
 
 #suite_title {
-	text-align: left;
+  text-align: left;
 }
 
 #btc {
-	text-align: right;
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
 }
 
 #fail_cases table {
-	width: 101%;
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child,#testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table,#title tr,#title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif;
-	font-weight: bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
 }
 
 #goTopBtn {
-	right: 0px;
-	bottom: 0px;
-	position: fixed; +position: absolute;
-	top: expression(parseInt(document.body.scrollTop)+document.body.clientHeight-40);
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/behavior/res/js/testkit/application.js
+++ b/behavior/res/js/testkit/application.js
@@ -1,44 +1,47 @@
-function getScrollTop(){
-    return f_scrollTop();
+function getScrollTop() {
+  return f_scrollTop();
 }
 
 function f_scrollTop() {
-	return f_filterResults (
-		$(window) ? $(window).scrollTop() : 0,
-		document.documentElement ? document.documentElement.scrollTop : 0,
-		document.body ? document.body.scrollTop : 0
-	);
+  return f_filterResults (
+    $(window) ? $(window).scrollTop() : 0,
+    document.documentElement ? document.documentElement.scrollTop : 0,
+    document.body ? document.body.scrollTop : 0
+  );
 }
+
 function f_filterResults(n_win, n_docel, n_body) {
-	var n_result = n_win ? n_win : 0;
-	if (n_docel && (!n_result || (n_result > n_docel)))
-		n_result = n_docel;
-	return n_body && (!n_result || (n_result > n_body)) ? n_body : n_result;
+  var n_result = n_win ? n_win : 0;
+  if (n_docel && (!n_result || (n_result > n_docel)))
+    n_result = n_docel;
+  return n_body && (!n_result || (n_result > n_body)) ? n_body : n_result;
 }
 
-function setScrollTop(){
-    $(window) ? $(window).scrollTop(0): 0;
-	document.documentElement ? document.documentElement.scrollTop = 0 :0;
-	document.body ? document.body.scrollTop = 0 : 0;
-} 
-
-function goTopEx(){
-    $node = $('#goTopBtn');
-	if(getScrollTop() > 0){
-		    $node.show();
-	}else{
-		    $node.hide();
-	}
-	
-    $(window).scroll(function(){
-	    if(getScrollTop() > 0){
-		    $node.show();
-	    }else{
-		    $node.hide();
-	    }
-    });
-	
-    $node.click(function(){
-	        setScrollTop();
-    });
+function setScrollTop() {
+  $(window) ? $(window).scrollTop(0): 0;
+  document.documentElement ? document.documentElement.scrollTop = 0 :0;
+  document.body ? document.body.scrollTop = 0 : 0;
 }
+
+function goTopEx() {
+  $node = $('#goTopBtn');
+
+  if (getScrollTop() > 0) {
+    $node.show();
+  } else {
+    $node.hide();
+  }
+
+  $(window).scroll(function () {
+    if (getScrollTop() > 0) {
+      $node.show();
+    } else {
+      $node.hide();
+    }
+  });
+
+  $node.click(function () {
+    setScrollTop();
+  });
+}
+

--- a/behavior/testcase.xsl
+++ b/behavior/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/behavior/testresult.xsl
+++ b/behavior/testresult.xsl
@@ -1,324 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-			<head>
-				<script type="text/javascript" src="jquery.js" />
-			</head>
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Block</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<a name="contents"></a>
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>Blocked</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<a>
-											<xsl:attribute name="href">
-                                                                                      #<xsl:value-of
-												select="@name" />
-                                                                                   </xsl:attribute>
-											<xsl:value-of select="@name" />
-										</a>
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="fail_cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">
-											Test Failures (
-											<xsl:value-of
-												select="count(test_definition/suite/set//testcase[@result = 'FAIL'])" />
-											)
-										</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<div id="btc">
-								<a href="#contents">Back to Contents</a>
-							</div>
-							<div id="suite_title">
-								Test Suite:
-								<xsl:value-of select="@name" />
-								<a>
-									<xsl:attribute name="name">
-                                          <xsl:value-of
-										select="@name" />
-                                    </xsl:attribute>
-								</a>
-							</div>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<xsl:choose>
-											<xsl:when test="@result">
-												<xsl:if test="@result = 'FAIL'">
-
-													<tr>
-														<td>
-															<xsl:value-of select="@id" />
-														</td>
-														<td>
-															<xsl:value-of select="@purpose" />
-														</td>
-
-
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-
-														<td>
-															<xsl:value-of select=".//result_info/stdout" />
-															<xsl:if test=".//result_info/stdout = ''">
-																N/A
-															</xsl:if>
-														</td>
-													</tr>
-												</xsl:if>
-											</xsl:when>
-										</xsl:choose>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<div id="btc">
-								<a href="#contents">Back to Contents</a>
-							</div>
-							<div id="suite_title">
-								Test Suite:
-								<xsl:value-of select="@name" />
-								<a>
-									<xsl:attribute name="name">
-                                                                     <xsl:value-of
-										select="@name" />
-                                                                  </xsl:attribute>
-								</a>
-							</div>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-													<xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
-														<td>
-															Not Run
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-				<div id="goTopBtn">
-					<img border="0" src="./back_top.png" />
-				</div>
-				<script type="text/javascript" src="application.js" />
-				<script language="javascript" type="text/javascript">
-					$(document).ready(function(){
-					goTopEx();
-					});
-				</script>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/behavior/tests.css
+++ b/behavior/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/cordova/cordova-mobilespec-android-tests/testcase.xsl
+++ b/cordova/cordova-mobilespec-android-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/cordova/cordova-mobilespec-android-tests/tests.css
+++ b/cordova/cordova-mobilespec-android-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/cordova/cordova-sampleapp-android-tests/testcase.xsl
+++ b/cordova/cordova-sampleapp-android-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/cordova/cordova-sampleapp-android-tests/tests.css
+++ b/cordova/cordova-sampleapp-android-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/cordova/cordova-webapp-android-tests/testcase.xsl
+++ b/cordova/cordova-webapp-android-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/cordova/cordova-webapp-android-tests/tests.css
+++ b/cordova/cordova-webapp-android-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/embeddingapi/embedding-build-android-tests/testcase.xsl
+++ b/embeddingapi/embedding-build-android-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/embeddingapi/embedding-build-android-tests/tests.css
+++ b/embeddingapi/embedding-build-android-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/misc/web-abat-xwalk-tests/testcase.xsl
+++ b/misc/web-abat-xwalk-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/misc/web-abat-xwalk-tests/testresult.xsl
+++ b/misc/web-abat-xwalk-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/misc/web-abat-xwalk-tests/tests.css
+++ b/misc/web-abat-xwalk-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/misc/web-mbat-xwalk-tests/testcase.xsl
+++ b/misc/web-mbat-xwalk-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/misc/web-mbat-xwalk-tests/tests.css
+++ b/misc/web-mbat-xwalk-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/misc/webapi-uiautomation-xwalk-tests/testcase.xsl
+++ b/misc/webapi-uiautomation-xwalk-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/misc/webapi-uiautomation-xwalk-tests/testresult.xsl
+++ b/misc/webapi-uiautomation-xwalk-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/misc/webapi-uiautomation-xwalk-tests/tests.css
+++ b/misc/webapi-uiautomation-xwalk-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/misc/wrt-documentation-verification-tests/testcase.xsl
+++ b/misc/wrt-documentation-verification-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/misc/wrt-documentation-verification-tests/tests.css
+++ b/misc/wrt-documentation-verification-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/misc/wrt-sampleapp-android-tests/testcase.xsl
+++ b/misc/wrt-sampleapp-android-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/misc/wrt-sampleapp-android-tests/testresult.xsl
+++ b/misc/wrt-sampleapp-android-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/misc/wrt-sampleapp-android-tests/tests.css
+++ b/misc/wrt-sampleapp-android-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/misc/wrt-sampleapp-tizen-tests/testcase.xsl
+++ b/misc/wrt-sampleapp-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/misc/wrt-sampleapp-tizen-tests/testresult.xsl
+++ b/misc/wrt-sampleapp-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/misc/wrt-sampleapp-tizen-tests/tests.css
+++ b/misc/wrt-sampleapp-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/stability/stability-iterative-android-tests/testcase.xsl
+++ b/stability/stability-iterative-android-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/stability/stability-iterative-android-tests/tests.css
+++ b/stability/stability-iterative-android-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/stability/stability-iterative-tizen-tests/testcase.xsl
+++ b/stability/stability-iterative-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/stability/stability-iterative-tizen-tests/tests.css
+++ b/stability/stability-iterative-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/stability/stability-longlasting-android-tests/testcase.xsl
+++ b/stability/stability-longlasting-android-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/stability/stability-longlasting-android-tests/testresult.xsl
+++ b/stability/stability-longlasting-android-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/stability/stability-longlasting-android-tests/tests.css
+++ b/stability/stability-longlasting-android-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/stability/stability-longlasting-tizen-tests/testcase.xsl
+++ b/stability/stability-longlasting-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/stability/stability-longlasting-tizen-tests/testresult.xsl
+++ b/stability/stability-longlasting-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/stability/stability-longlasting-tizen-tests/tests.css
+++ b/stability/stability-longlasting-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/stability/stability-lowresource-tizen-tests/testcase.xsl
+++ b/stability/stability-lowresource-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/stability/stability-lowresource-tizen-tests/tests.css
+++ b/stability/stability-lowresource-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/stability/stability-manual-android-tests/testcase.xsl
+++ b/stability/stability-manual-android-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/stability/stability-manual-android-tests/tests.css
+++ b/stability/stability-manual-android-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/stability/stability-manual-tizen-tests/testcase.xsl
+++ b/stability/stability-manual-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/stability/stability-manual-tizen-tests/tests.css
+++ b/stability/stability-manual-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/stability/stability-overload-android-tests/testcase.xsl
+++ b/stability/stability-overload-android-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/stability/stability-overload-android-tests/tests.css
+++ b/stability/stability-overload-android-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/tools/changes/testcase.xsl
+++ b/tools/changes/testcase.xsl
@@ -1,166 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<a name="top"/>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Add</th>
-								<th>Update</th>
-								<th>Remove</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite//testcase[@changes = 'Add'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite//testcase[@changes = 'Update'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite//testcase[@changes = 'Remove'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<a>
-											<xsl:attribute name="href">
-												#<xsl:value-of select="@name" />
-											</xsl:attribute>
-											<xsl:value-of select="@name" />
-										</a>
-									</td>
-									<td>
-										<xsl:value-of select="count(testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(testcase[@changes = 'Add'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(testcase[@changes = 'Update'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(testcase[@changes = 'Remove'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-							<table>
-								<tr>
-									<th>Case ID</th>
-									<th>Priority</th>
-									<th>Status</th>
-									<th>Changes</th>
-									<th>Source</th>
-									<th>Description</th>
-								</tr>
-								<xsl:for-each select=".//suite">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="6">
-											<h3>Test Suite:
-											<xsl:value-of select="@name" /></h3>
-											<a>
-												<xsl:attribute name="name">
-													<xsl:value-of select="@name" />
-												</xsl:attribute>
-											</a>
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@changes" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@priority" />
-											</td>
-											<td>
-												<xsl:value-of select="@status" />
-											</td>
-											<td>
-												<xsl:value-of select="@changes" />
-											</td>
-											<td>
-												<xsl:value-of select="@source" />
-											</td>
-											<td>
-												<xsl:value-of select=".//description" />
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-					</div>
-				</div>
-				<div id="goTopBtn">
-					<a href="#top">
-						<img border="0" src="./back_top.png" />
-					</a>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-			</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/tools/changes/tests.css
+++ b/tools/changes/tests.css
@@ -1,123 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
 }
 
 #suite_title {
-	text-align: left;
+  text-align: left;
 }
 
 #btc {
-	text-align: right;
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
 }
 
 #fail_cases table {
-	width: 101%;
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child,#testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table,#title tr,#title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif;
-	font-weight: bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
 }
 
 #goTopBtn {
-	right: 0px;
-	bottom: 0px;
-	position: fixed; +position: absolute;
-	top: expression(parseInt(document.body.scrollTop)+document.body.clientHeight-40);
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/usecase/usecase-cordova-android-tests/testcase.xsl
+++ b/usecase/usecase-cordova-android-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/usecase/usecase-cordova-android-tests/testresult.xsl
+++ b/usecase/usecase-cordova-android-tests/testresult.xsl
@@ -1,324 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-			<head>
-				<script type="text/javascript" src="jquery.js" />
-			</head>
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Block</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<a name="contents"></a>
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>Blocked</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<a>
-											<xsl:attribute name="href">
-                                                                                      #<xsl:value-of
-												select="@name" />
-                                                                                   </xsl:attribute>
-											<xsl:value-of select="@name" />
-										</a>
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="fail_cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">
-											Test Failures (
-											<xsl:value-of
-												select="count(test_definition/suite/set//testcase[@result = 'FAIL'])" />
-											)
-										</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<div id="btc">
-								<a href="#contents">Back to Contents</a>
-							</div>
-							<div id="suite_title">
-								Test Suite:
-								<xsl:value-of select="@name" />
-								<a>
-									<xsl:attribute name="name">
-                                          <xsl:value-of
-										select="@name" />
-                                    </xsl:attribute>
-								</a>
-							</div>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<xsl:choose>
-											<xsl:when test="@result">
-												<xsl:if test="@result = 'FAIL'">
-
-													<tr>
-														<td>
-															<xsl:value-of select="@id" />
-														</td>
-														<td>
-															<xsl:value-of select="@purpose" />
-														</td>
-
-
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-
-														<td>
-															<xsl:value-of select=".//result_info/stdout" />
-															<xsl:if test=".//result_info/stdout = ''">
-																N/A
-															</xsl:if>
-														</td>
-													</tr>
-												</xsl:if>
-											</xsl:when>
-										</xsl:choose>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<div id="btc">
-								<a href="#contents">Back to Contents</a>
-							</div>
-							<div id="suite_title">
-								Test Suite:
-								<xsl:value-of select="@name" />
-								<a>
-									<xsl:attribute name="name">
-                                                                     <xsl:value-of
-										select="@name" />
-                                                                  </xsl:attribute>
-								</a>
-							</div>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-													<xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
-														<td>
-															Not Run
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-				<div id="goTopBtn">
-					<img border="0" src="./back_top.png" />
-				</div>
-				<script type="text/javascript" src="application.js" />
-				<script language="javascript" type="text/javascript">
-					$(document).ready(function(){
-					goTopEx();
-					});
-				</script>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/usecase/usecase-cordova-android-tests/tests.css
+++ b/usecase/usecase-cordova-android-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/usecase/usecase-embedding-android-tests/testcase.xsl
+++ b/usecase/usecase-embedding-android-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/usecase/usecase-embedding-android-tests/testresult.xsl
+++ b/usecase/usecase-embedding-android-tests/testresult.xsl
@@ -1,324 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-			<head>
-				<script type="text/javascript" src="jquery.js" />
-			</head>
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Block</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<a name="contents"></a>
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>Blocked</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<a>
-											<xsl:attribute name="href">
-                                                                                      #<xsl:value-of
-												select="@name" />
-                                                                                   </xsl:attribute>
-											<xsl:value-of select="@name" />
-										</a>
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="fail_cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">
-											Test Failures (
-											<xsl:value-of
-												select="count(test_definition/suite/set//testcase[@result = 'FAIL'])" />
-											)
-										</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<div id="btc">
-								<a href="#contents">Back to Contents</a>
-							</div>
-							<div id="suite_title">
-								Test Suite:
-								<xsl:value-of select="@name" />
-								<a>
-									<xsl:attribute name="name">
-                                          <xsl:value-of
-										select="@name" />
-                                    </xsl:attribute>
-								</a>
-							</div>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<xsl:choose>
-											<xsl:when test="@result">
-												<xsl:if test="@result = 'FAIL'">
-
-													<tr>
-														<td>
-															<xsl:value-of select="@id" />
-														</td>
-														<td>
-															<xsl:value-of select="@purpose" />
-														</td>
-
-
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-
-														<td>
-															<xsl:value-of select=".//result_info/stdout" />
-															<xsl:if test=".//result_info/stdout = ''">
-																N/A
-															</xsl:if>
-														</td>
-													</tr>
-												</xsl:if>
-											</xsl:when>
-										</xsl:choose>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<div id="btc">
-								<a href="#contents">Back to Contents</a>
-							</div>
-							<div id="suite_title">
-								Test Suite:
-								<xsl:value-of select="@name" />
-								<a>
-									<xsl:attribute name="name">
-                                                                     <xsl:value-of
-										select="@name" />
-                                                                  </xsl:attribute>
-								</a>
-							</div>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-													<xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
-														<td>
-															Not Run
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-				<div id="goTopBtn">
-					<img border="0" src="./back_top.png" />
-				</div>
-				<script type="text/javascript" src="application.js" />
-				<script language="javascript" type="text/javascript">
-					$(document).ready(function(){
-					goTopEx();
-					});
-				</script>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/usecase/usecase-embedding-android-tests/tests.css
+++ b/usecase/usecase-embedding-android-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/usecase/usecase-webapi-xwalk-tests/res/css/testkit/tests.css
+++ b/usecase/usecase-webapi-xwalk-tests/res/css/testkit/tests.css
@@ -1,123 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
 }
 
 #suite_title {
-	text-align: left;
+  text-align: left;
 }
 
 #btc {
-	text-align: right;
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
 }
 
 #fail_cases table {
-	width: 101%;
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child,#testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table,#title tr,#title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif;
-	font-weight: bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
 }
 
 #goTopBtn {
-	right: 0px;
-	bottom: 0px;
-	position: fixed; +position: absolute;
-	top: expression(parseInt(document.body.scrollTop)+document.body.clientHeight-40);
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/usecase/usecase-webapi-xwalk-tests/testcase.xsl
+++ b/usecase/usecase-webapi-xwalk-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/usecase/usecase-webapi-xwalk-tests/testresult.xsl
+++ b/usecase/usecase-webapi-xwalk-tests/testresult.xsl
@@ -1,324 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-			<head>
-				<script type="text/javascript" src="jquery.js" />
-			</head>
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Block</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<a name="contents"></a>
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>Blocked</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<a>
-											<xsl:attribute name="href">
-                                                                                      #<xsl:value-of
-												select="@name" />
-                                                                                   </xsl:attribute>
-											<xsl:value-of select="@name" />
-										</a>
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="fail_cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">
-											Test Failures (
-											<xsl:value-of
-												select="count(test_definition/suite/set//testcase[@result = 'FAIL'])" />
-											)
-										</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<div id="btc">
-								<a href="#contents">Back to Contents</a>
-							</div>
-							<div id="suite_title">
-								Test Suite:
-								<xsl:value-of select="@name" />
-								<a>
-									<xsl:attribute name="name">
-                                          <xsl:value-of
-										select="@name" />
-                                    </xsl:attribute>
-								</a>
-							</div>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<xsl:choose>
-											<xsl:when test="@result">
-												<xsl:if test="@result = 'FAIL'">
-
-													<tr>
-														<td>
-															<xsl:value-of select="@id" />
-														</td>
-														<td>
-															<xsl:value-of select="@purpose" />
-														</td>
-
-
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-
-														<td>
-															<xsl:value-of select=".//result_info/stdout" />
-															<xsl:if test=".//result_info/stdout = ''">
-																N/A
-															</xsl:if>
-														</td>
-													</tr>
-												</xsl:if>
-											</xsl:when>
-										</xsl:choose>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<div id="btc">
-								<a href="#contents">Back to Contents</a>
-							</div>
-							<div id="suite_title">
-								Test Suite:
-								<xsl:value-of select="@name" />
-								<a>
-									<xsl:attribute name="name">
-                                                                     <xsl:value-of
-										select="@name" />
-                                                                  </xsl:attribute>
-								</a>
-							</div>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-													<xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
-														<td>
-															Not Run
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-				<div id="goTopBtn">
-					<img border="0" src="./back_top.png" />
-				</div>
-				<script type="text/javascript" src="application.js" />
-				<script language="javascript" type="text/javascript">
-					$(document).ready(function(){
-					goTopEx();
-					});
-				</script>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/usecase/usecase-webapi-xwalk-tests/tests.css
+++ b/usecase/usecase-webapi-xwalk-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/usecase/usecase-wrt-android-tests/testcase.xsl
+++ b/usecase/usecase-wrt-android-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/usecase/usecase-wrt-android-tests/testresult.xsl
+++ b/usecase/usecase-wrt-android-tests/testresult.xsl
@@ -1,324 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-			<head>
-				<script type="text/javascript" src="jquery.js" />
-			</head>
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Block</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<a name="contents"></a>
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>Blocked</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<a>
-											<xsl:attribute name="href">
-                                                                                      #<xsl:value-of
-												select="@name" />
-                                                                                   </xsl:attribute>
-											<xsl:value-of select="@name" />
-										</a>
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="fail_cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">
-											Test Failures (
-											<xsl:value-of
-												select="count(test_definition/suite/set//testcase[@result = 'FAIL'])" />
-											)
-										</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<div id="btc">
-								<a href="#contents">Back to Contents</a>
-							</div>
-							<div id="suite_title">
-								Test Suite:
-								<xsl:value-of select="@name" />
-								<a>
-									<xsl:attribute name="name">
-                                          <xsl:value-of
-										select="@name" />
-                                    </xsl:attribute>
-								</a>
-							</div>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<xsl:choose>
-											<xsl:when test="@result">
-												<xsl:if test="@result = 'FAIL'">
-
-													<tr>
-														<td>
-															<xsl:value-of select="@id" />
-														</td>
-														<td>
-															<xsl:value-of select="@purpose" />
-														</td>
-
-
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-
-														<td>
-															<xsl:value-of select=".//result_info/stdout" />
-															<xsl:if test=".//result_info/stdout = ''">
-																N/A
-															</xsl:if>
-														</td>
-													</tr>
-												</xsl:if>
-											</xsl:when>
-										</xsl:choose>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<div id="btc">
-								<a href="#contents">Back to Contents</a>
-							</div>
-							<div id="suite_title">
-								Test Suite:
-								<xsl:value-of select="@name" />
-								<a>
-									<xsl:attribute name="name">
-                                                                     <xsl:value-of
-										select="@name" />
-                                                                  </xsl:attribute>
-								</a>
-							</div>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-													<xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
-														<td>
-															Not Run
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-				<div id="goTopBtn">
-					<img border="0" src="./back_top.png" />
-				</div>
-				<script type="text/javascript" src="application.js" />
-				<script language="javascript" type="text/javascript">
-					$(document).ready(function(){
-					goTopEx();
-					});
-				</script>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/usecase/usecase-wrt-android-tests/tests.css
+++ b/usecase/usecase-wrt-android-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/usecase/usecase-wrt-tizen-tests/res/css/testkit/tests.css
+++ b/usecase/usecase-wrt-tizen-tests/res/css/testkit/tests.css
@@ -1,123 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
 }
 
 #suite_title {
-	text-align: left;
+  text-align: left;
 }
 
 #btc {
-	text-align: right;
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
 }
 
 #fail_cases table {
-	width: 101%;
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child,#testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table,#title tr,#title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif;
-	font-weight: bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
 }
 
 #goTopBtn {
-	right: 0px;
-	bottom: 0px;
-	position: fixed; +position: absolute;
-	top: expression(parseInt(document.body.scrollTop)+document.body.clientHeight-40);
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/usecase/usecase-wrt-tizen-tests/res/js/testkit/application.js
+++ b/usecase/usecase-wrt-tizen-tests/res/js/testkit/application.js
@@ -1,44 +1,47 @@
-function getScrollTop(){
-    return f_scrollTop();
+function getScrollTop() {
+  return f_scrollTop();
 }
 
 function f_scrollTop() {
-	return f_filterResults (
-		$(window) ? $(window).scrollTop() : 0,
-		document.documentElement ? document.documentElement.scrollTop : 0,
-		document.body ? document.body.scrollTop : 0
-	);
+  return f_filterResults (
+    $(window) ? $(window).scrollTop() : 0,
+    document.documentElement ? document.documentElement.scrollTop : 0,
+    document.body ? document.body.scrollTop : 0
+  );
 }
+
 function f_filterResults(n_win, n_docel, n_body) {
-	var n_result = n_win ? n_win : 0;
-	if (n_docel && (!n_result || (n_result > n_docel)))
-		n_result = n_docel;
-	return n_body && (!n_result || (n_result > n_body)) ? n_body : n_result;
+  var n_result = n_win ? n_win : 0;
+  if (n_docel && (!n_result || (n_result > n_docel)))
+    n_result = n_docel;
+  return n_body && (!n_result || (n_result > n_body)) ? n_body : n_result;
 }
 
-function setScrollTop(){
-    $(window) ? $(window).scrollTop(0): 0;
-	document.documentElement ? document.documentElement.scrollTop = 0 :0;
-	document.body ? document.body.scrollTop = 0 : 0;
-} 
-
-function goTopEx(){
-    $node = $('#goTopBtn');
-	if(getScrollTop() > 0){
-		    $node.show();
-	}else{
-		    $node.hide();
-	}
-	
-    $(window).scroll(function(){
-	    if(getScrollTop() > 0){
-		    $node.show();
-	    }else{
-		    $node.hide();
-	    }
-    });
-	
-    $node.click(function(){
-	        setScrollTop();
-    });
+function setScrollTop() {
+  $(window) ? $(window).scrollTop(0): 0;
+  document.documentElement ? document.documentElement.scrollTop = 0 :0;
+  document.body ? document.body.scrollTop = 0 : 0;
 }
+
+function goTopEx() {
+  $node = $('#goTopBtn');
+
+  if (getScrollTop() > 0) {
+    $node.show();
+  } else {
+    $node.hide();
+  }
+
+  $(window).scroll(function () {
+    if (getScrollTop() > 0) {
+      $node.show();
+    } else {
+      $node.hide();
+    }
+  });
+
+  $node.click(function () {
+    setScrollTop();
+  });
+}
+

--- a/usecase/usecase-wrt-tizen-tests/testcase.xsl
+++ b/usecase/usecase-wrt-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/usecase/usecase-wrt-tizen-tests/testresult.xsl
+++ b/usecase/usecase-wrt-tizen-tests/testresult.xsl
@@ -1,324 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-			<head>
-				<script type="text/javascript" src="jquery.js" />
-			</head>
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Block</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<a name="contents"></a>
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>Blocked</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<a>
-											<xsl:attribute name="href">
-                                                                                      #<xsl:value-of
-												select="@name" />
-                                                                                   </xsl:attribute>
-											<xsl:value-of select="@name" />
-										</a>
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="fail_cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">
-											Test Failures (
-											<xsl:value-of
-												select="count(test_definition/suite/set//testcase[@result = 'FAIL'])" />
-											)
-										</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<div id="btc">
-								<a href="#contents">Back to Contents</a>
-							</div>
-							<div id="suite_title">
-								Test Suite:
-								<xsl:value-of select="@name" />
-								<a>
-									<xsl:attribute name="name">
-                                          <xsl:value-of
-										select="@name" />
-                                    </xsl:attribute>
-								</a>
-							</div>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<xsl:choose>
-											<xsl:when test="@result">
-												<xsl:if test="@result = 'FAIL'">
-
-													<tr>
-														<td>
-															<xsl:value-of select="@id" />
-														</td>
-														<td>
-															<xsl:value-of select="@purpose" />
-														</td>
-
-
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-
-														<td>
-															<xsl:value-of select=".//result_info/stdout" />
-															<xsl:if test=".//result_info/stdout = ''">
-																N/A
-															</xsl:if>
-														</td>
-													</tr>
-												</xsl:if>
-											</xsl:when>
-										</xsl:choose>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<div id="btc">
-								<a href="#contents">Back to Contents</a>
-							</div>
-							<div id="suite_title">
-								Test Suite:
-								<xsl:value-of select="@name" />
-								<a>
-									<xsl:attribute name="name">
-                                                                     <xsl:value-of
-										select="@name" />
-                                                                  </xsl:attribute>
-								</a>
-							</div>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-													<xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
-														<td>
-															Not Run
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-				<div id="goTopBtn">
-					<img border="0" src="./back_top.png" />
-				</div>
-				<script type="text/javascript" src="application.js" />
-				<script language="javascript" type="text/javascript">
-					$(document).ready(function(){
-					goTopEx();
-					});
-				</script>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/usecase/usecase-wrt-tizen-tests/tests.css
+++ b/usecase/usecase-wrt-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-2dtransforms-css3-tests/testcase.xsl
+++ b/webapi/tct-2dtransforms-css3-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-2dtransforms-css3-tests/testresult.xsl
+++ b/webapi/tct-2dtransforms-css3-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-2dtransforms-css3-tests/tests.css
+++ b/webapi/tct-2dtransforms-css3-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-3dtransforms-css3-tests/testcase.xsl
+++ b/webapi/tct-3dtransforms-css3-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-3dtransforms-css3-tests/testresult.xsl
+++ b/webapi/tct-3dtransforms-css3-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-3dtransforms-css3-tests/tests.css
+++ b/webapi/tct-3dtransforms-css3-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-alarm-tizen-tests/testcase.xsl
+++ b/webapi/tct-alarm-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-alarm-tizen-tests/testresult.xsl
+++ b/webapi/tct-alarm-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-alarm-tizen-tests/tests.css
+++ b/webapi/tct-alarm-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-animations-css3-tests/testcase.xsl
+++ b/webapi/tct-animations-css3-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-animations-css3-tests/testresult.xsl
+++ b/webapi/tct-animations-css3-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-animations-css3-tests/tests.css
+++ b/webapi/tct-animations-css3-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-animationtiming-w3c-tests/testcase.xsl
+++ b/webapi/tct-animationtiming-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-animationtiming-w3c-tests/testresult.xsl
+++ b/webapi/tct-animationtiming-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-animationtiming-w3c-tests/tests.css
+++ b/webapi/tct-animationtiming-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-appcache-html5-tests/testcase.xsl
+++ b/webapi/tct-appcache-html5-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-appcache-html5-tests/testresult.xsl
+++ b/webapi/tct-appcache-html5-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-appcache-html5-tests/tests.css
+++ b/webapi/tct-appcache-html5-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-appcontrol-tizen-tests/testcase.xsl
+++ b/webapi/tct-appcontrol-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-appcontrol-tizen-tests/testresult.xsl
+++ b/webapi/tct-appcontrol-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-appcontrol-tizen-tests/tests.css
+++ b/webapi/tct-appcontrol-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-application-tizen-tests/testcase.xsl
+++ b/webapi/tct-application-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-application-tizen-tests/testresult.xsl
+++ b/webapi/tct-application-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-application-tizen-tests/tests.css
+++ b/webapi/tct-application-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-audio-html5-tests/testcase.xsl
+++ b/webapi/tct-audio-html5-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-audio-html5-tests/testresult.xsl
+++ b/webapi/tct-audio-html5-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-audio-html5-tests/tests.css
+++ b/webapi/tct-audio-html5-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-backgrounds-css3-tests/testcase.xsl
+++ b/webapi/tct-backgrounds-css3-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-backgrounds-css3-tests/testresult.xsl
+++ b/webapi/tct-backgrounds-css3-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-backgrounds-css3-tests/tests.css
+++ b/webapi/tct-backgrounds-css3-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-batterystatus-w3c-tests/testcase.xsl
+++ b/webapi/tct-batterystatus-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-batterystatus-w3c-tests/testresult.xsl
+++ b/webapi/tct-batterystatus-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-batterystatus-w3c-tests/tests.css
+++ b/webapi/tct-batterystatus-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-bluetooth-tizen-tests/testcase.xsl
+++ b/webapi/tct-bluetooth-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-bluetooth-tizen-tests/testresult.xsl
+++ b/webapi/tct-bluetooth-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-bluetooth-tizen-tests/tests.css
+++ b/webapi/tct-bluetooth-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-bookmark-tizen-tests/testcase.xsl
+++ b/webapi/tct-bookmark-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-bookmark-tizen-tests/testresult.xsl
+++ b/webapi/tct-bookmark-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-bookmark-tizen-tests/tests.css
+++ b/webapi/tct-bookmark-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-browserstate-html5-tests/testcase.xsl
+++ b/webapi/tct-browserstate-html5-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-browserstate-html5-tests/testresult.xsl
+++ b/webapi/tct-browserstate-html5-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-browserstate-html5-tests/tests.css
+++ b/webapi/tct-browserstate-html5-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-calendar-tizen-tests/testcase.xsl
+++ b/webapi/tct-calendar-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-calendar-tizen-tests/testresult.xsl
+++ b/webapi/tct-calendar-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-calendar-tizen-tests/tests.css
+++ b/webapi/tct-calendar-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-callhistory-tizen-tests/testcase.xsl
+++ b/webapi/tct-callhistory-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-callhistory-tizen-tests/testresult.xsl
+++ b/webapi/tct-callhistory-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-callhistory-tizen-tests/tests.css
+++ b/webapi/tct-callhistory-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-canvas-html5-tests/testcase.xsl
+++ b/webapi/tct-canvas-html5-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-canvas-html5-tests/testresult.xsl
+++ b/webapi/tct-canvas-html5-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-canvas-html5-tests/tests.css
+++ b/webapi/tct-canvas-html5-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-capability-tests/testcase.xsl
+++ b/webapi/tct-capability-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-capability-tests/testresult.xsl
+++ b/webapi/tct-capability-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-capability-tests/tests.css
+++ b/webapi/tct-capability-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-colors-css3-tests/testcase.xsl
+++ b/webapi/tct-colors-css3-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-colors-css3-tests/testresult.xsl
+++ b/webapi/tct-colors-css3-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-colors-css3-tests/tests.css
+++ b/webapi/tct-colors-css3-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-contact-tizen-tests/testcase.xsl
+++ b/webapi/tct-contact-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-contact-tizen-tests/testresult.xsl
+++ b/webapi/tct-contact-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-contact-tizen-tests/tests.css
+++ b/webapi/tct-contact-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-content-tizen-tests/testcase.xsl
+++ b/webapi/tct-content-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-content-tizen-tests/testresult.xsl
+++ b/webapi/tct-content-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-content-tizen-tests/tests.css
+++ b/webapi/tct-content-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-cors-w3c-tests/testcase.xsl
+++ b/webapi/tct-cors-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-cors-w3c-tests/testresult.xsl
+++ b/webapi/tct-cors-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-cors-w3c-tests/tests.css
+++ b/webapi/tct-cors-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-csp-w3c-tests/testcase.xsl
+++ b/webapi/tct-csp-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-csp-w3c-tests/testresult.xsl
+++ b/webapi/tct-csp-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-csp-w3c-tests/tests.css
+++ b/webapi/tct-csp-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-datacontrol-tizen-tests/testcase.xsl
+++ b/webapi/tct-datacontrol-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-datacontrol-tizen-tests/testresult.xsl
+++ b/webapi/tct-datacontrol-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-datacontrol-tizen-tests/tests.css
+++ b/webapi/tct-datacontrol-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-datasync-tizen-tests/testcase.xsl
+++ b/webapi/tct-datasync-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-datasync-tizen-tests/testresult.xsl
+++ b/webapi/tct-datasync-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-datasync-tizen-tests/tests.css
+++ b/webapi/tct-datasync-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-deviceorientation-w3c-tests/testcase.xsl
+++ b/webapi/tct-deviceorientation-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-deviceorientation-w3c-tests/testresult.xsl
+++ b/webapi/tct-deviceorientation-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-deviceorientation-w3c-tests/tests.css
+++ b/webapi/tct-deviceorientation-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-dnd-html5-tests/testcase.xsl
+++ b/webapi/tct-dnd-html5-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-dnd-html5-tests/testresult.xsl
+++ b/webapi/tct-dnd-html5-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-dnd-html5-tests/tests.css
+++ b/webapi/tct-dnd-html5-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-download-tizen-tests/testcase.xsl
+++ b/webapi/tct-download-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-download-tizen-tests/testresult.xsl
+++ b/webapi/tct-download-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-download-tizen-tests/tests.css
+++ b/webapi/tct-download-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-extra-html5-tests/testcase.xsl
+++ b/webapi/tct-extra-html5-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-extra-html5-tests/testresult.xsl
+++ b/webapi/tct-extra-html5-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-extra-html5-tests/tests.css
+++ b/webapi/tct-extra-html5-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-fileapi-w3c-tests/testcase.xsl
+++ b/webapi/tct-fileapi-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-fileapi-w3c-tests/testresult.xsl
+++ b/webapi/tct-fileapi-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-fileapi-w3c-tests/tests.css
+++ b/webapi/tct-fileapi-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-filesystem-tizen-tests/testcase.xsl
+++ b/webapi/tct-filesystem-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-filesystem-tizen-tests/testresult.xsl
+++ b/webapi/tct-filesystem-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-filesystem-tizen-tests/tests.css
+++ b/webapi/tct-filesystem-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-filesystemapi-w3c-tests/testcase.xsl
+++ b/webapi/tct-filesystemapi-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-filesystemapi-w3c-tests/testresult.xsl
+++ b/webapi/tct-filesystemapi-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-filesystemapi-w3c-tests/tests.css
+++ b/webapi/tct-filesystemapi-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-filewriterapi-w3c-tests/testcase.xsl
+++ b/webapi/tct-filewriterapi-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-filewriterapi-w3c-tests/testresult.xsl
+++ b/webapi/tct-filewriterapi-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-filewriterapi-w3c-tests/tests.css
+++ b/webapi/tct-filewriterapi-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-flexiblebox-css3-tests/testcase.xsl
+++ b/webapi/tct-flexiblebox-css3-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-flexiblebox-css3-tests/testresult.xsl
+++ b/webapi/tct-flexiblebox-css3-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-flexiblebox-css3-tests/tests.css
+++ b/webapi/tct-flexiblebox-css3-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-fonts-css3-tests/testcase.xsl
+++ b/webapi/tct-fonts-css3-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-fonts-css3-tests/testresult.xsl
+++ b/webapi/tct-fonts-css3-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-fonts-css3-tests/tests.css
+++ b/webapi/tct-fonts-css3-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-forms-html5-tests/testcase.xsl
+++ b/webapi/tct-forms-html5-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-forms-html5-tests/testresult.xsl
+++ b/webapi/tct-forms-html5-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-forms-html5-tests/tests.css
+++ b/webapi/tct-forms-html5-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-fullscreen-nonw3c-tests/testcase.xsl
+++ b/webapi/tct-fullscreen-nonw3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-fullscreen-nonw3c-tests/testresult.xsl
+++ b/webapi/tct-fullscreen-nonw3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-fullscreen-nonw3c-tests/tests.css
+++ b/webapi/tct-fullscreen-nonw3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-geoallow-w3c-tests/testcase.xsl
+++ b/webapi/tct-geoallow-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-geoallow-w3c-tests/testresult.xsl
+++ b/webapi/tct-geoallow-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-geoallow-w3c-tests/tests.css
+++ b/webapi/tct-geoallow-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-geodeny-w3c-tests/testcase.xsl
+++ b/webapi/tct-geodeny-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-geodeny-w3c-tests/testresult.xsl
+++ b/webapi/tct-geodeny-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-geodeny-w3c-tests/tests.css
+++ b/webapi/tct-geodeny-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-gumallow-w3c-tests/testcase.xsl
+++ b/webapi/tct-gumallow-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-gumallow-w3c-tests/testresult.xsl
+++ b/webapi/tct-gumallow-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-gumallow-w3c-tests/tests.css
+++ b/webapi/tct-gumallow-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-indexeddb-w3c-tests/testcase.xsl
+++ b/webapi/tct-indexeddb-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-indexeddb-w3c-tests/testresult.xsl
+++ b/webapi/tct-indexeddb-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-indexeddb-w3c-tests/tests.css
+++ b/webapi/tct-indexeddb-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-jsenhance-html5-tests/testcase.xsl
+++ b/webapi/tct-jsenhance-html5-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-jsenhance-html5-tests/testresult.xsl
+++ b/webapi/tct-jsenhance-html5-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-jsenhance-html5-tests/tests.css
+++ b/webapi/tct-jsenhance-html5-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-mediacapture-w3c-tests/testcase.xsl
+++ b/webapi/tct-mediacapture-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-mediacapture-w3c-tests/testresult.xsl
+++ b/webapi/tct-mediacapture-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-mediacapture-w3c-tests/tests.css
+++ b/webapi/tct-mediacapture-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-mediaqueries-css3-tests/testcase.xsl
+++ b/webapi/tct-mediaqueries-css3-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-mediaqueries-css3-tests/testresult.xsl
+++ b/webapi/tct-mediaqueries-css3-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-mediaqueries-css3-tests/tests.css
+++ b/webapi/tct-mediaqueries-css3-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-messageport-tizen-tests/testcase.xsl
+++ b/webapi/tct-messageport-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-messageport-tizen-tests/testresult.xsl
+++ b/webapi/tct-messageport-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-messageport-tizen-tests/tests.css
+++ b/webapi/tct-messageport-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-messaging-email-tizen-tests/testcase.xsl
+++ b/webapi/tct-messaging-email-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-messaging-email-tizen-tests/testresult.xsl
+++ b/webapi/tct-messaging-email-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-messaging-email-tizen-tests/tests.css
+++ b/webapi/tct-messaging-email-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-messaging-mms-tizen-tests/testcase.xsl
+++ b/webapi/tct-messaging-mms-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-messaging-mms-tizen-tests/testresult.xsl
+++ b/webapi/tct-messaging-mms-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-messaging-mms-tizen-tests/tests.css
+++ b/webapi/tct-messaging-mms-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-messaging-sms-tizen-tests/testcase.xsl
+++ b/webapi/tct-messaging-sms-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-messaging-sms-tizen-tests/testresult.xsl
+++ b/webapi/tct-messaging-sms-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-messaging-sms-tizen-tests/tests.css
+++ b/webapi/tct-messaging-sms-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-multicolumn-css3-tests/testcase.xsl
+++ b/webapi/tct-multicolumn-css3-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-multicolumn-css3-tests/testresult.xsl
+++ b/webapi/tct-multicolumn-css3-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-multicolumn-css3-tests/tests.css
+++ b/webapi/tct-multicolumn-css3-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-namespace-tizen-tests/testcase.xsl
+++ b/webapi/tct-namespace-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-namespace-tizen-tests/testresult.xsl
+++ b/webapi/tct-namespace-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-namespace-tizen-tests/tests.css
+++ b/webapi/tct-namespace-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-navigationtiming-w3c-tests/testcase.xsl
+++ b/webapi/tct-navigationtiming-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-navigationtiming-w3c-tests/testresult.xsl
+++ b/webapi/tct-navigationtiming-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-navigationtiming-w3c-tests/tests.css
+++ b/webapi/tct-navigationtiming-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-netinfo-w3c-tests/testcase.xsl
+++ b/webapi/tct-netinfo-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-netinfo-w3c-tests/testresult.xsl
+++ b/webapi/tct-netinfo-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-netinfo-w3c-tests/tests.css
+++ b/webapi/tct-netinfo-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-networkbearerselection-tizen-tests/testcase.xsl
+++ b/webapi/tct-networkbearerselection-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-networkbearerselection-tizen-tests/testresult.xsl
+++ b/webapi/tct-networkbearerselection-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-networkbearerselection-tizen-tests/tests.css
+++ b/webapi/tct-networkbearerselection-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-nfc-tizen-tests/testcase.xsl
+++ b/webapi/tct-nfc-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-nfc-tizen-tests/testresult.xsl
+++ b/webapi/tct-nfc-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-nfc-tizen-tests/tests.css
+++ b/webapi/tct-nfc-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-notification-tizen-tests/testcase.xsl
+++ b/webapi/tct-notification-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-notification-tizen-tests/testresult.xsl
+++ b/webapi/tct-notification-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-notification-tizen-tests/tests.css
+++ b/webapi/tct-notification-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-notification-w3c-tests/testcase.xsl
+++ b/webapi/tct-notification-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-notification-w3c-tests/testresult.xsl
+++ b/webapi/tct-notification-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-notification-w3c-tests/tests.css
+++ b/webapi/tct-notification-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-package-tizen-tests/testcase.xsl
+++ b/webapi/tct-package-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-package-tizen-tests/testresult.xsl
+++ b/webapi/tct-package-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-package-tizen-tests/tests.css
+++ b/webapi/tct-package-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-pagevisibility-w3c-tests/testcase.xsl
+++ b/webapi/tct-pagevisibility-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-pagevisibility-w3c-tests/testresult.xsl
+++ b/webapi/tct-pagevisibility-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-pagevisibility-w3c-tests/tests.css
+++ b/webapi/tct-pagevisibility-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-power-tizen-tests/testcase.xsl
+++ b/webapi/tct-power-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-power-tizen-tests/testresult.xsl
+++ b/webapi/tct-power-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-power-tizen-tests/tests.css
+++ b/webapi/tct-power-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-privilege-tizen-tests/testcase.xsl
+++ b/webapi/tct-privilege-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-privilege-tizen-tests/testresult.xsl
+++ b/webapi/tct-privilege-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-privilege-tizen-tests/tests.css
+++ b/webapi/tct-privilege-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-push-tizen-tests/testcase.xsl
+++ b/webapi/tct-push-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-push-tizen-tests/testresult.xsl
+++ b/webapi/tct-push-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-push-tizen-tests/tests.css
+++ b/webapi/tct-push-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-sandbox-html5-tests/testcase.xsl
+++ b/webapi/tct-sandbox-html5-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-sandbox-html5-tests/testresult.xsl
+++ b/webapi/tct-sandbox-html5-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-sandbox-html5-tests/tests.css
+++ b/webapi/tct-sandbox-html5-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-screenorientation-w3c-tests/testcase.xsl
+++ b/webapi/tct-screenorientation-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-screenorientation-w3c-tests/testresult.xsl
+++ b/webapi/tct-screenorientation-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-screenorientation-w3c-tests/tests.css
+++ b/webapi/tct-screenorientation-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-secureelement-tizen-tests/testcase.xsl
+++ b/webapi/tct-secureelement-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-secureelement-tizen-tests/testresult.xsl
+++ b/webapi/tct-secureelement-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-secureelement-tizen-tests/tests.css
+++ b/webapi/tct-secureelement-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-security-tcs-tests/testcase.xsl
+++ b/webapi/tct-security-tcs-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-security-tcs-tests/testresult.xsl
+++ b/webapi/tct-security-tcs-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-security-tcs-tests/tests.css
+++ b/webapi/tct-security-tcs-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-selectorslevel1-w3c-tests/testcase.xsl
+++ b/webapi/tct-selectorslevel1-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-selectorslevel1-w3c-tests/testresult.xsl
+++ b/webapi/tct-selectorslevel1-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-selectorslevel1-w3c-tests/tests.css
+++ b/webapi/tct-selectorslevel1-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-selectorslevel2-w3c-tests/testcase.xsl
+++ b/webapi/tct-selectorslevel2-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-selectorslevel2-w3c-tests/testresult.xsl
+++ b/webapi/tct-selectorslevel2-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-selectorslevel2-w3c-tests/tests.css
+++ b/webapi/tct-selectorslevel2-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-sessionhistory-html5-tests/testcase.xsl
+++ b/webapi/tct-sessionhistory-html5-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-sessionhistory-html5-tests/testresult.xsl
+++ b/webapi/tct-sessionhistory-html5-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-sessionhistory-html5-tests/tests.css
+++ b/webapi/tct-sessionhistory-html5-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-sse-w3c-tests/testcase.xsl
+++ b/webapi/tct-sse-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-sse-w3c-tests/testresult.xsl
+++ b/webapi/tct-sse-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-sse-w3c-tests/tests.css
+++ b/webapi/tct-sse-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-svg-html5-tests/testcase.xsl
+++ b/webapi/tct-svg-html5-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-svg-html5-tests/testresult.xsl
+++ b/webapi/tct-svg-html5-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-svg-html5-tests/tests.css
+++ b/webapi/tct-svg-html5-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-systeminfo-tizen-tests/testcase.xsl
+++ b/webapi/tct-systeminfo-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-systeminfo-tizen-tests/testresult.xsl
+++ b/webapi/tct-systeminfo-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-systeminfo-tizen-tests/tests.css
+++ b/webapi/tct-systeminfo-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-systemsetting-tizen-tests/testcase.xsl
+++ b/webapi/tct-systemsetting-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-systemsetting-tizen-tests/testresult.xsl
+++ b/webapi/tct-systemsetting-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-systemsetting-tizen-tests/tests.css
+++ b/webapi/tct-systemsetting-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-testconfig/testcase.xsl
+++ b/webapi/tct-testconfig/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-testconfig/testresult.xsl
+++ b/webapi/tct-testconfig/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-testconfig/tests.css
+++ b/webapi/tct-testconfig/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-text-css3-tests/testcase.xsl
+++ b/webapi/tct-text-css3-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-text-css3-tests/testresult.xsl
+++ b/webapi/tct-text-css3-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-text-css3-tests/tests.css
+++ b/webapi/tct-text-css3-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-time-tizen-tests/testcase.xsl
+++ b/webapi/tct-time-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-time-tizen-tests/testresult.xsl
+++ b/webapi/tct-time-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-time-tizen-tests/tests.css
+++ b/webapi/tct-time-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-tizen-tizen-tests/testcase.xsl
+++ b/webapi/tct-tizen-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-tizen-tizen-tests/testresult.xsl
+++ b/webapi/tct-tizen-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-tizen-tizen-tests/tests.css
+++ b/webapi/tct-tizen-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-touchevent-w3c-tests/testcase.xsl
+++ b/webapi/tct-touchevent-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-touchevent-w3c-tests/testresult.xsl
+++ b/webapi/tct-touchevent-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-touchevent-w3c-tests/tests.css
+++ b/webapi/tct-touchevent-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-transitions-css3-tests/testcase.xsl
+++ b/webapi/tct-transitions-css3-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-transitions-css3-tests/testresult.xsl
+++ b/webapi/tct-transitions-css3-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-transitions-css3-tests/tests.css
+++ b/webapi/tct-transitions-css3-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-typedarrays-nonw3c-tests/testcase.xsl
+++ b/webapi/tct-typedarrays-nonw3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-typedarrays-nonw3c-tests/testresult.xsl
+++ b/webapi/tct-typedarrays-nonw3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-typedarrays-nonw3c-tests/tests.css
+++ b/webapi/tct-typedarrays-nonw3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-ui-css3-tests/testcase.xsl
+++ b/webapi/tct-ui-css3-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-ui-css3-tests/testresult.xsl
+++ b/webapi/tct-ui-css3-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-ui-css3-tests/tests.css
+++ b/webapi/tct-ui-css3-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-vibration-w3c-tests/testcase.xsl
+++ b/webapi/tct-vibration-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-vibration-w3c-tests/testresult.xsl
+++ b/webapi/tct-vibration-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-vibration-w3c-tests/tests.css
+++ b/webapi/tct-vibration-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-video-html5-tests/testcase.xsl
+++ b/webapi/tct-video-html5-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-video-html5-tests/testresult.xsl
+++ b/webapi/tct-video-html5-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-video-html5-tests/tests.css
+++ b/webapi/tct-video-html5-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-webaudio-w3c-tests/testcase.xsl
+++ b/webapi/tct-webaudio-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-webaudio-w3c-tests/testresult.xsl
+++ b/webapi/tct-webaudio-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-webaudio-w3c-tests/tests.css
+++ b/webapi/tct-webaudio-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-webdatabase-w3c-tests/testcase.xsl
+++ b/webapi/tct-webdatabase-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-webdatabase-w3c-tests/testresult.xsl
+++ b/webapi/tct-webdatabase-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-webdatabase-w3c-tests/tests.css
+++ b/webapi/tct-webdatabase-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-webgl-nonw3c-tests/testcase.xsl
+++ b/webapi/tct-webgl-nonw3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-webgl-nonw3c-tests/testresult.xsl
+++ b/webapi/tct-webgl-nonw3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-webgl-nonw3c-tests/tests.css
+++ b/webapi/tct-webgl-nonw3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-webmessaging-w3c-tests/testcase.xsl
+++ b/webapi/tct-webmessaging-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-webmessaging-w3c-tests/testresult.xsl
+++ b/webapi/tct-webmessaging-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-webmessaging-w3c-tests/tests.css
+++ b/webapi/tct-webmessaging-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-websetting-tizen-tests/testcase.xsl
+++ b/webapi/tct-websetting-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-websetting-tizen-tests/testresult.xsl
+++ b/webapi/tct-websetting-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-websetting-tizen-tests/tests.css
+++ b/webapi/tct-websetting-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-websocket-w3c-tests/testcase.xsl
+++ b/webapi/tct-websocket-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-websocket-w3c-tests/testresult.xsl
+++ b/webapi/tct-websocket-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-websocket-w3c-tests/tests.css
+++ b/webapi/tct-websocket-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-webstorage-w3c-tests/testcase.xsl
+++ b/webapi/tct-webstorage-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-webstorage-w3c-tests/testresult.xsl
+++ b/webapi/tct-webstorage-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-webstorage-w3c-tests/tests.css
+++ b/webapi/tct-webstorage-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-wgtapi01-w3c-tests/testcase.xsl
+++ b/webapi/tct-wgtapi01-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-wgtapi01-w3c-tests/testresult.xsl
+++ b/webapi/tct-wgtapi01-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-wgtapi01-w3c-tests/tests.css
+++ b/webapi/tct-wgtapi01-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-wgtapi02-w3c-tests/testcase.xsl
+++ b/webapi/tct-wgtapi02-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-wgtapi02-w3c-tests/testresult.xsl
+++ b/webapi/tct-wgtapi02-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-wgtapi02-w3c-tests/tests.css
+++ b/webapi/tct-wgtapi02-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-widget01-w3c-tests/testcase.xsl
+++ b/webapi/tct-widget01-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-widget01-w3c-tests/testresult.xsl
+++ b/webapi/tct-widget01-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-widget01-w3c-tests/tests.css
+++ b/webapi/tct-widget01-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-widget02-w3c-tests/testcase.xsl
+++ b/webapi/tct-widget02-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-widget02-w3c-tests/testresult.xsl
+++ b/webapi/tct-widget02-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-widget02-w3c-tests/tests.css
+++ b/webapi/tct-widget02-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-widgetpolicy-w3c-tests/testcase.xsl
+++ b/webapi/tct-widgetpolicy-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-widgetpolicy-w3c-tests/testresult.xsl
+++ b/webapi/tct-widgetpolicy-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-widgetpolicy-w3c-tests/tests.css
+++ b/webapi/tct-widgetpolicy-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-workers-w3c-tests/testcase.xsl
+++ b/webapi/tct-workers-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-workers-w3c-tests/testresult.xsl
+++ b/webapi/tct-workers-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-workers-w3c-tests/tests.css
+++ b/webapi/tct-workers-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/tct-xmlhttprequest-w3c-tests/testcase.xsl
+++ b/webapi/tct-xmlhttprequest-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-xmlhttprequest-w3c-tests/testresult.xsl
+++ b/webapi/tct-xmlhttprequest-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/tct-xmlhttprequest-w3c-tests/tests.css
+++ b/webapi/tct-xmlhttprequest-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-ambientlight-w3c-tests/testcase.xsl
+++ b/webapi/webapi-ambientlight-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-ambientlight-w3c-tests/testresult.xsl
+++ b/webapi/webapi-ambientlight-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-ambientlight-w3c-tests/tests.css
+++ b/webapi/webapi-ambientlight-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-appuri-w3c-tests/testcase.xsl
+++ b/webapi/webapi-appuri-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-appuri-w3c-tests/testresult.xsl
+++ b/webapi/webapi-appuri-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-appuri-w3c-tests/tests.css
+++ b/webapi/webapi-appuri-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-audiosystem-tizen-tests/testcase.xsl
+++ b/webapi/webapi-audiosystem-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-audiosystem-tizen-tests/testresult.xsl
+++ b/webapi/webapi-audiosystem-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-audiosystem-tizen-tests/tests.css
+++ b/webapi/webapi-audiosystem-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-contactsmanager-w3c-tests/testcase.xsl
+++ b/webapi/webapi-contactsmanager-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-contactsmanager-w3c-tests/testresult.xsl
+++ b/webapi/webapi-contactsmanager-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-contactsmanager-w3c-tests/tests.css
+++ b/webapi/webapi-contactsmanager-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-deviceadaptation-css3-tests/testcase.xsl
+++ b/webapi/webapi-deviceadaptation-css3-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-deviceadaptation-css3-tests/testresult.xsl
+++ b/webapi/webapi-deviceadaptation-css3-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-deviceadaptation-css3-tests/tests.css
+++ b/webapi/webapi-deviceadaptation-css3-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-devicecapabilities-w3c-tests/testcase.xsl
+++ b/webapi/webapi-devicecapabilities-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-devicecapabilities-w3c-tests/testresult.xsl
+++ b/webapi/webapi-devicecapabilities-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-devicecapabilities-w3c-tests/tests.css
+++ b/webapi/webapi-devicecapabilities-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-gamepad-w3c-tests/testcase.xsl
+++ b/webapi/webapi-gamepad-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-gamepad-w3c-tests/testresult.xsl
+++ b/webapi/webapi-gamepad-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-gamepad-w3c-tests/tests.css
+++ b/webapi/webapi-gamepad-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-hrtime-w3c-tests/testcase.xsl
+++ b/webapi/webapi-hrtime-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-hrtime-w3c-tests/testresult.xsl
+++ b/webapi/webapi-hrtime-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-hrtime-w3c-tests/tests.css
+++ b/webapi/webapi-hrtime-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-iap-xwalk-tests/testcase.xsl
+++ b/webapi/webapi-iap-xwalk-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-iap-xwalk-tests/testresult.xsl
+++ b/webapi/webapi-iap-xwalk-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-iap-xwalk-tests/tests.css
+++ b/webapi/webapi-iap-xwalk-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-imports-w3c-tests/testcase.xsl
+++ b/webapi/webapi-imports-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-imports-w3c-tests/testresult.xsl
+++ b/webapi/webapi-imports-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-imports-w3c-tests/tests.css
+++ b/webapi/webapi-imports-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-input-html5-tests/testcase.xsl
+++ b/webapi/webapi-input-html5-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-input-html5-tests/testresult.xsl
+++ b/webapi/webapi-input-html5-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-input-html5-tests/tests.css
+++ b/webapi/webapi-input-html5-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-locale-tizen-tests/testcase.xsl
+++ b/webapi/webapi-locale-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-locale-tizen-tests/testresult.xsl
+++ b/webapi/webapi-locale-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-locale-tizen-tests/tests.css
+++ b/webapi/webapi-locale-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-mediarenderer-tizen-tests/testcase.xsl
+++ b/webapi/webapi-mediarenderer-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-mediarenderer-tizen-tests/testresult.xsl
+++ b/webapi/webapi-mediarenderer-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-mediarenderer-tizen-tests/tests.css
+++ b/webapi/webapi-mediarenderer-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-mediaserver-tizen-tests/testcase.xsl
+++ b/webapi/webapi-mediaserver-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-mediaserver-tizen-tests/testresult.xsl
+++ b/webapi/webapi-mediaserver-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-mediaserver-tizen-tests/tests.css
+++ b/webapi/webapi-mediaserver-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-messaging-w3c-tests/testcase.xsl
+++ b/webapi/webapi-messaging-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-messaging-w3c-tests/testresult.xsl
+++ b/webapi/webapi-messaging-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-messaging-w3c-tests/tests.css
+++ b/webapi/webapi-messaging-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-nacl-xwalk-tests/testcase.xsl
+++ b/webapi/webapi-nacl-xwalk-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-nacl-xwalk-tests/testresult.xsl
+++ b/webapi/webapi-nacl-xwalk-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-nacl-xwalk-tests/tests.css
+++ b/webapi/webapi-nacl-xwalk-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-nativefilesystem-xwalk-tests/testcase.xsl
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/testresult.xsl
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-nativefilesystem-xwalk-tests/tests.css
+++ b/webapi/webapi-nativefilesystem-xwalk-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-nfc-w3c-tests/testcase.xsl
+++ b/webapi/webapi-nfc-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-nfc-w3c-tests/testresult.xsl
+++ b/webapi/webapi-nfc-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-nfc-w3c-tests/tests.css
+++ b/webapi/webapi-nfc-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-performancetimeline-w3c-tests/testcase.xsl
+++ b/webapi/webapi-performancetimeline-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-performancetimeline-w3c-tests/testresult.xsl
+++ b/webapi/webapi-performancetimeline-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-performancetimeline-w3c-tests/tests.css
+++ b/webapi/webapi-performancetimeline-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-picture-html5-tests/testcase.xsl
+++ b/webapi/webapi-picture-html5-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-picture-html5-tests/testresult.xsl
+++ b/webapi/webapi-picture-html5-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-picture-html5-tests/tests.css
+++ b/webapi/webapi-picture-html5-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-presentation-xwalk-tests/testcase.xsl
+++ b/webapi/webapi-presentation-xwalk-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-presentation-xwalk-tests/testresult.xsl
+++ b/webapi/webapi-presentation-xwalk-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-presentation-xwalk-tests/tests.css
+++ b/webapi/webapi-presentation-xwalk-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-promises-nonw3c-tests/testcase.xsl
+++ b/webapi/webapi-promises-nonw3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-promises-nonw3c-tests/testresult.xsl
+++ b/webapi/webapi-promises-nonw3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-promises-nonw3c-tests/tests.css
+++ b/webapi/webapi-promises-nonw3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-rawsockets-w3c-tests/testcase.xsl
+++ b/webapi/webapi-rawsockets-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-rawsockets-w3c-tests/testresult.xsl
+++ b/webapi/webapi-rawsockets-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-rawsockets-w3c-tests/tests.css
+++ b/webapi/webapi-rawsockets-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-resourcetiming-w3c-tests/testcase.xsl
+++ b/webapi/webapi-resourcetiming-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-resourcetiming-w3c-tests/testresult.xsl
+++ b/webapi/webapi-resourcetiming-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-resourcetiming-w3c-tests/tests.css
+++ b/webapi/webapi-resourcetiming-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-shadowdom-w3c-tests/testcase.xsl
+++ b/webapi/webapi-shadowdom-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-shadowdom-w3c-tests/testresult.xsl
+++ b/webapi/webapi-shadowdom-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-shadowdom-w3c-tests/tests.css
+++ b/webapi/webapi-shadowdom-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-simd-nonw3c-tests/testcase.xsl
+++ b/webapi/webapi-simd-nonw3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-simd-nonw3c-tests/testresult.xsl
+++ b/webapi/webapi-simd-nonw3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-simd-nonw3c-tests/tests.css
+++ b/webapi/webapi-simd-nonw3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-speechapi-tizen-tests/testcase.xsl
+++ b/webapi/webapi-speechapi-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-speechapi-tizen-tests/testresult.xsl
+++ b/webapi/webapi-speechapi-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-speechapi-tizen-tests/tests.css
+++ b/webapi/webapi-speechapi-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-sso-tizen-tests/testcase.xsl
+++ b/webapi/webapi-sso-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-sso-tizen-tests/testresult.xsl
+++ b/webapi/webapi-sso-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-sso-tizen-tests/tests.css
+++ b/webapi/webapi-sso-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-taskscheduler-w3c-tests/testcase.xsl
+++ b/webapi/webapi-taskscheduler-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-taskscheduler-w3c-tests/testresult.xsl
+++ b/webapi/webapi-taskscheduler-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-taskscheduler-w3c-tests/tests.css
+++ b/webapi/webapi-taskscheduler-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-usertiming-w3c-tests/testcase.xsl
+++ b/webapi/webapi-usertiming-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-usertiming-w3c-tests/testresult.xsl
+++ b/webapi/webapi-usertiming-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-usertiming-w3c-tests/tests.css
+++ b/webapi/webapi-usertiming-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-vehicleinfo-ivi-tests/testcase.xsl
+++ b/webapi/webapi-vehicleinfo-ivi-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-vehicleinfo-ivi-tests/testresult.xsl
+++ b/webapi/webapi-vehicleinfo-ivi-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-vehicleinfo-ivi-tests/tests.css
+++ b/webapi/webapi-vehicleinfo-ivi-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-webcl-nonw3c-tests/testcase.xsl
+++ b/webapi/webapi-webcl-nonw3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-webcl-nonw3c-tests/testresult.xsl
+++ b/webapi/webapi-webcl-nonw3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-webcl-nonw3c-tests/tests.css
+++ b/webapi/webapi-webcl-nonw3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-webrtc-w3c-tests/testcase.xsl
+++ b/webapi/webapi-webrtc-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-webrtc-w3c-tests/testresult.xsl
+++ b/webapi/webapi-webrtc-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-webrtc-w3c-tests/tests.css
+++ b/webapi/webapi-webrtc-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/webapi/webapi-webspeech-w3c-tests/testcase.xsl
+++ b/webapi/webapi-webspeech-w3c-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-webspeech-w3c-tests/testresult.xsl
+++ b/webapi/webapi-webspeech-w3c-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/webapi/webapi-webspeech-w3c-tests/tests.css
+++ b/webapi/webapi-webspeech-w3c-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/tct-appwgt-wrt-tests/testcase.xsl
+++ b/wrt/tct-appwgt-wrt-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/tct-appwgt-wrt-tests/testresult.xsl
+++ b/wrt/tct-appwgt-wrt-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/tct-appwgt-wrt-tests/tests.css
+++ b/wrt/tct-appwgt-wrt-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/tct-ext01-wrt-tests/testcase.xsl
+++ b/wrt/tct-ext01-wrt-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/tct-ext01-wrt-tests/testresult.xsl
+++ b/wrt/tct-ext01-wrt-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/tct-ext01-wrt-tests/tests.css
+++ b/wrt/tct-ext01-wrt-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/tct-ext02-wrt-tests/testcase.xsl
+++ b/wrt/tct-ext02-wrt-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/tct-ext02-wrt-tests/testresult.xsl
+++ b/wrt/tct-ext02-wrt-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/tct-ext02-wrt-tests/tests.css
+++ b/wrt/tct-ext02-wrt-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/tct-pm-wrt-tests/testcase.xsl
+++ b/wrt/tct-pm-wrt-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/tct-pm-wrt-tests/testresult.xsl
+++ b/wrt/tct-pm-wrt-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/tct-pm-wrt-tests/tests.css
+++ b/wrt/tct-pm-wrt-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/tct-rt01-wrt-tests/testcase.xsl
+++ b/wrt/tct-rt01-wrt-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/tct-rt01-wrt-tests/testresult.xsl
+++ b/wrt/tct-rt01-wrt-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/tct-rt01-wrt-tests/tests.css
+++ b/wrt/tct-rt01-wrt-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/tct-rt02-wrt-tests/testcase.xsl
+++ b/wrt/tct-rt02-wrt-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/tct-rt02-wrt-tests/testresult.xsl
+++ b/wrt/tct-rt02-wrt-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/tct-rt02-wrt-tests/tests.css
+++ b/wrt/tct-rt02-wrt-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/tct-sp01-wrt-tests/testcase.xsl
+++ b/wrt/tct-sp01-wrt-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/tct-sp01-wrt-tests/testresult.xsl
+++ b/wrt/tct-sp01-wrt-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/tct-sp01-wrt-tests/tests.css
+++ b/wrt/tct-sp01-wrt-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/tct-sp02-wrt-tests/testcase.xsl
+++ b/wrt/tct-sp02-wrt-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/tct-sp02-wrt-tests/testresult.xsl
+++ b/wrt/tct-sp02-wrt-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/tct-sp02-wrt-tests/tests.css
+++ b/wrt/tct-sp02-wrt-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/tct-sp03-wrt-tests/testcase.xsl
+++ b/wrt/tct-sp03-wrt-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/tct-sp03-wrt-tests/testresult.xsl
+++ b/wrt/tct-sp03-wrt-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/tct-sp03-wrt-tests/tests.css
+++ b/wrt/tct-sp03-wrt-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/tct-stab-wrt-tests/testcase.xsl
+++ b/wrt/tct-stab-wrt-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/tct-stab-wrt-tests/testresult.xsl
+++ b/wrt/tct-stab-wrt-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/tct-stab-wrt-tests/tests.css
+++ b/wrt/tct-stab-wrt-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/tct-ui01-wrt-tests/testcase.xsl
+++ b/wrt/tct-ui01-wrt-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/tct-ui01-wrt-tests/testresult.xsl
+++ b/wrt/tct-ui01-wrt-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/tct-ui01-wrt-tests/tests.css
+++ b/wrt/tct-ui01-wrt-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/wrt-audiopolicymanu-tizen-tests/testcase.xsl
+++ b/wrt/wrt-audiopolicymanu-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/wrt-audiopolicymanu-tizen-tests/tests.css
+++ b/wrt/wrt-audiopolicymanu-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/wrt-commandline-tizen-tests/testcase.xsl
+++ b/wrt/wrt-commandline-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/wrt-commandline-tizen-tests/tests.css
+++ b/wrt/wrt-commandline-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/wrt-commandlinemanu-tizen-tests/testcase.xsl
+++ b/wrt/wrt-commandlinemanu-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/wrt-commandlinemanu-tizen-tests/tests.css
+++ b/wrt/wrt-commandlinemanu-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/wrt-coreshellmanu-android-tests/testcase.xsl
+++ b/wrt/wrt-coreshellmanu-android-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/wrt-coreshellmanu-android-tests/tests.css
+++ b/wrt/wrt-coreshellmanu-android-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/wrt-digitalsign-tizen-tests/testcase.xsl
+++ b/wrt/wrt-digitalsign-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/wrt-digitalsign-tizen-tests/tests.css
+++ b/wrt/wrt-digitalsign-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/wrt-extension-android-tests/testcase.xsl
+++ b/wrt/wrt-extension-android-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/wrt-extension-android-tests/tests.css
+++ b/wrt/wrt-extension-android-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/wrt-extensionmanu-android-tests/testcase.xsl
+++ b/wrt/wrt-extensionmanu-android-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/wrt-extensionmanu-android-tests/tests.css
+++ b/wrt/wrt-extensionmanu-android-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/wrt-googleplay-android-tests/testcase.xsl
+++ b/wrt/wrt-googleplay-android-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/wrt-googleplay-android-tests/tests.css
+++ b/wrt/wrt-googleplay-android-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/wrt-i18nmanu-tizen-tests/testcase.xsl
+++ b/wrt/wrt-i18nmanu-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/wrt-i18nmanu-tizen-tests/tests.css
+++ b/wrt/wrt-i18nmanu-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/wrt-internetstdmanu-android-tests/testcase.xsl
+++ b/wrt/wrt-internetstdmanu-android-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/wrt-internetstdmanu-android-tests/tests.css
+++ b/wrt/wrt-internetstdmanu-android-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/wrt-manifest-tizen-tests/testcase.xsl
+++ b/wrt/wrt-manifest-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/wrt-manifest-tizen-tests/testresult.xsl
+++ b/wrt/wrt-manifest-tizen-tests/testresult.xsl
@@ -1,273 +1,491 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Report</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="device">
-						<table>
-							<tr>
-								<th colspan="2">Device Information</th>
-							</tr>
-							<tr>
-								<td>Device Name</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device Model</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_model" />
-								</td>
-							</tr>
-							<tr>
-								<td>OS Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@os_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Device ID</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@device_id" />
-								</td>
-							</tr>
-							<tr>
-								<td>Firmware Version</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@firmware_version" />
-								</td>
-							</tr>
-							<tr>
-								<td>Screen Size</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@screen_size" />
-								</td>
-							</tr>
-							<tr>
-								<td>Resolution</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@resolution" />
-								</td>
-							</tr>
-							<tr>
-								<td>Host Info</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/@host" />
-								</td>
-							</tr>
-							<tr>
-								<td>Others</td>
-								<td>
-									<xsl:value-of select="test_definition/environment/other" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-					<div id="summary">
-						<table>
-							<tr>
-								<th colspan="2">Test Summary</th>
-							</tr>
-							<tr>
-								<td>Test Plan Name</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/@test_plan_name" />
-								</td>
-							</tr>
-							<tr>
-								<td>Tests Total</td>
-								<td>
-									<xsl:value-of select="count(test_definition//suite/set/testcase)" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Passed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'PASS'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Failed</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'FAIL'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test N/A</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Test Not Run</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])" />
-								</td>
-							</tr>
-							<tr>
-								<td>Start time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/start_at" />
-								</td>
-							</tr>
-							<tr>
-								<td>End time</td>
-								<td>
-									<xsl:value-of select="test_definition/summary/end_at" />
-								</td>
-							</tr>
-						</table>
-					</div>
-
-
-					<div id="suite_summary">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1>Test Summary by Suite</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<table>
-							<tr>
-								<th>Suite</th>
-								<th>Passed</th>
-								<th>Failed</th>
-								<th>N/A</th>
-								<th>Not Run</th>
-								<th>Total</th>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<xsl:sort select="@name" />
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'PASS'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'FAIL'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of
-											select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-
-					<div id="cases">
-						<div id="title">
-							<table>
-								<tr>
-									<td class="title">
-										<h1 align="center">Detailed Test Results</h1>
-									</td>
-								</tr>
-							</table>
-						</div>
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Result</th>
-									<th>Stdout</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="4">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-
-											<xsl:choose>
-												<xsl:when test="@result">
-													<xsl:if test="@result = 'FAIL'">
-														<td class="red_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'PASS'">
-														<td class="green_rate">
-															<xsl:value-of select="@result" />
-														</td>
-													</xsl:if>
-													<xsl:if test="@result = 'BLOCK' ">
-														<td>
-															BLOCK
-														</td>
-													</xsl:if>
-												</xsl:when>
-												<xsl:otherwise>
-													<td>
-
-													</td>
-												</xsl:otherwise>
-											</xsl:choose>
-											<td>
-												<xsl:value-of select=".//result_info/stdout" />
-												<xsl:if test=".//result_info/stdout = ''">
-													N/A
-												</xsl:if>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Report</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="device">
+            <table>
+              <tr>
+                <th colspan="2">Device Information</th>
+              </tr>
+              <tr>
+                <td>Device Name</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_name">
+                      <xsl:if test="test_definition/environment/@device_name = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_name"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device Model</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_model">
+                      <xsl:if test="test_definition/environment/@device_model = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_model"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>OS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@os_version">
+                      <xsl:if test="test_definition/environment/@os_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@os_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Device ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@device_id">
+                      <xsl:if test="test_definition/environment/@device_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@device_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Firmware Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@firmware_version">
+                      <xsl:if test="test_definition/environment/@firmware_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@firmware_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Build ID</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@build_id">
+                      <xsl:if test="test_definition/environment/@build_id = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@build_id"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Screen Size</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@screen_size">
+                      <xsl:if test="test_definition/environment/@screen_size = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@screen_size"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Resolution</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@resolution">
+                      <xsl:if test="test_definition/environment/@resolution = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@resolution"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Host Info</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@host">
+                      <xsl:if test="test_definition/environment/@host = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@host"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>CTS Version</td>
+                <td>
+                  <xsl:choose>
+                    <xsl:when test="test_definition/environment/@cts_version">
+                      <xsl:if test="test_definition/environment/@cts_version = ''">
+                        N/A
+                      </xsl:if>
+                      <xsl:value-of select="test_definition/environment/@cts_version"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      N/A
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </td>
+              </tr>
+              <tr>
+                <td>Others</td>
+                <td>
+                  <xsl:if test="test_definition/environment/other = ''">
+                    N/A
+                  </xsl:if>
+                  <xsl:call-template name="br-replace">
+                    <xsl:with-param name="word" select="test_definition/environment/other"/>
+                  </xsl:call-template>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="summary">
+            <table>
+              <tr>
+                <th colspan="2">Test Summary</th>
+              </tr>
+              <tr>
+                <td>Test Plan Name</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/@test_plan_name"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Tests Total</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase)"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Passed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'PASS'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Failed</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'FAIL'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Block</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Test Not Run</td>
+                <td>
+                  <xsl:value-of select="count(test_definition//suite/set/testcase) - count(test_definition//suite/set/testcase[@result = 'PASS']) - count(test_definition//suite/set/testcase[@result = 'FAIL']) - count(test_definition//suite/set/testcase[@result = 'BLOCK'])"/>
+                </td>
+              </tr>
+              <tr>
+                <td>Start time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/start_at"/>
+                </td>
+              </tr>
+              <tr>
+                <td>End time</td>
+                <td>
+                  <xsl:value-of select="test_definition/summary/end_at"/>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suite_summary">
+            <div id="title">
+              <a name="contents"/>
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1>Test Summary by Suite</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <table>
+              <tr>
+                <th>Suite</th>
+                <th>Passed</th>
+                <th>Failed</th>
+                <th>Blocked</th>
+                <th>Not Run</th>
+                <th>Total</th>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <xsl:sort select="@name"/>
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'PASS'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'FAIL'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase) - count(set//testcase[@result = 'PASS']) - count(set//testcase[@result = 'FAIL']) - count(set//testcase[@result = 'BLOCK'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="fail_cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">
+                      Test Failures (
+                        <xsl:value-of select="count(test_definition/suite/set//testcase[@result = 'FAIL'])"/>
+                      )
+                    </h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <xsl:choose>
+                      <xsl:when test="@result">
+                        <xsl:if test="@result = 'FAIL'">
+                          <tr>
+                            <td>
+                              <xsl:value-of select="@id"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select="@purpose"/>
+                            </td>
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                            <td>
+                              <xsl:value-of select=".//result_info/stdout"/>
+                              <xsl:if test=".//result_info/stdout = ''">
+                                N/A
+                              </xsl:if>
+                            </td>
+                          </tr>
+                        </xsl:if>
+                      </xsl:when>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+          <div id="cases">
+            <div id="title">
+              <table>
+                <tr>
+                  <td class="title">
+                    <h1 align="center">Detailed Test Results</h1>
+                  </td>
+                </tr>
+              </table>
+            </div>
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Result</th>
+                  <th>Stdout</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="4">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <xsl:sort select="@id"/>
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <xsl:choose>
+                        <xsl:when test="@result">
+                          <xsl:if test="@result = 'FAIL'">
+                            <td class="red_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'PASS'">
+                            <td class="green_rate">
+                              <xsl:value-of select="@result"/>
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result = 'BLOCK' ">
+                            <td>
+                              BLOCK
+                            </td>
+                          </xsl:if>
+                          <xsl:if test="@result != 'BLOCK' and @result != 'FAIL' and @result != 'PASS' ">
+                            <td>
+                              Not Run
+                            </td>
+                          </xsl:if>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <td>
+                          </td>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                      <td>
+                        <xsl:value-of select=".//result_info/stdout"/>
+                        <xsl:if test=".//result_info/stdout = ''">
+                          N/A
+                        </xsl:if>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
+  <xsl:template name="br-replace">
+    <xsl:param name="word"/>
+    <xsl:variable name="cr">
+      <xsl:text>
+      </xsl:text>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="contains($word,$cr)">
+        <xsl:value-of select="substring-before($word,$cr)"/>
+        <br/>
+        <xsl:call-template name="br-replace">
+          <xsl:with-param name="word" select="substring-after($word,$cr)"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$word"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/wrt-manifest-tizen-tests/tests.css
+++ b/wrt/wrt-manifest-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/wrt-manifestmanu-android-tests/testcase.xsl
+++ b/wrt/wrt-manifestmanu-android-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/wrt-manifestmanu-android-tests/tests.css
+++ b/wrt/wrt-manifestmanu-android-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/wrt-packagemgt-android-tests/testcase.xsl
+++ b/wrt/wrt-packagemgt-android-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/wrt-packagemgt-android-tests/tests.css
+++ b/wrt/wrt-packagemgt-android-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/wrt-packagemgt-tizen-tests/testcase.xsl
+++ b/wrt/wrt-packagemgt-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/wrt-packagemgt-tizen-tests/tests.css
+++ b/wrt/wrt-packagemgt-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/wrt-packagemgtmanu-android-tests/testcase.xsl
+++ b/wrt/wrt-packagemgtmanu-android-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/wrt-packagemgtmanu-android-tests/tests.css
+++ b/wrt/wrt-packagemgtmanu-android-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/wrt-packagemgtmanu-tizen-tests/testcase.xsl
+++ b/wrt/wrt-packagemgtmanu-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/wrt-packagemgtmanu-tizen-tests/tests.css
+++ b/wrt/wrt-packagemgtmanu-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/wrt-packertoolmanu-android-tests/testcase.xsl
+++ b/wrt/wrt-packertoolmanu-android-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/wrt-packertoolmanu-android-tests/tests.css
+++ b/wrt/wrt-packertoolmanu-android-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/wrt-rtbin-tizen-tests/testcase.xsl
+++ b/wrt/wrt-rtbin-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/wrt-rtbin-tizen-tests/tests.css
+++ b/wrt/wrt-rtbin-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/wrt-rtcoremanu-android-tests/testcase.xsl
+++ b/wrt/wrt-rtcoremanu-android-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/wrt-rtcoremanu-android-tests/tests.css
+++ b/wrt/wrt-rtcoremanu-android-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/wrt-securitymanu-android-tests/testcase.xsl
+++ b/wrt/wrt-securitymanu-android-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/wrt-securitymanu-android-tests/tests.css
+++ b/wrt/wrt-securitymanu-android-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/wrt-securitymanu-tizen-tests/testcase.xsl
+++ b/wrt/wrt-securitymanu-tizen-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/wrt-securitymanu-tizen-tests/tests.css
+++ b/wrt/wrt-securitymanu-tizen-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/wrt-sharedmodemanu-android-tests/testcase.xsl
+++ b/wrt/wrt-sharedmodemanu-android-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/wrt-sharedmodemanu-android-tests/tests.css
+++ b/wrt/wrt-sharedmodemanu-android-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }

--- a/wrt/wrt-uxmanu-android-tests/testcase.xsl
+++ b/wrt/wrt-uxmanu-android-tests/testcase.xsl
@@ -1,181 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:output method="html" version="1.0" encoding="UTF-8"
-		indent="yes" />
-	<xsl:template match="/">
-		<html>
-			<STYLE type="text/css">
-				@import "tests.css";
-			</STYLE>
-
-			<body>
-				<div id="testcasepage">
-					<div id="title">
-						<table>
-							<tr>
-								<td>
-									<h1>Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="suites">
-						<table>
-							<tr>
-								<th>Test Suite</th>
-								<th>Total</th>
-								<th>Auto</th>
-								<th>Manual</th>
-							</tr>
-							<tr>
-								<td>
-									Total
-								</td>
-								<td>
-									<xsl:value-of select="count(test_definition/suite/set//testcase)" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])" />
-								</td>
-								<td>
-									<xsl:value-of
-										select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])" />
-								</td>
-							</tr>
-							<xsl:for-each select="test_definition/suite">
-								<tr>
-									<td>
-										<xsl:value-of select="@name" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set//testcase)" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type = 'auto'])" />
-									</td>
-									<td>
-										<xsl:value-of select="count(set/testcase[@execution_type != 'auto'])" />
-									</td>
-								</tr>
-							</xsl:for-each>
-						</table>
-					</div>
-					<div id="title">
-						<table>
-							<tr>
-								<td class="title">
-									<h1>Detailed Test Cases</h1>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div id="cases">
-						<xsl:for-each select="test_definition/suite">
-							<xsl:sort select="@name" />
-							<p>
-								Test Suite:
-								<xsl:value-of select="@name" />
-							</p>
-							<table>
-								<tr>
-									<th>Case_ID</th>
-									<th>Purpose</th>
-									<th>Type</th>
-									<th>Component</th>
-									<th>Execution Type</th>
-									<th>Description</th>
-									<th>Specification</th>
-								</tr>
-								<xsl:for-each select=".//set">
-									<xsl:sort select="@name" />
-									<tr>
-										<td colspan="7">
-											Test Set:
-											<xsl:value-of select="@name" />
-										</td>
-									</tr>
-									<xsl:for-each select=".//testcase">
-										<xsl:sort select="@id" />
-										<tr>
-											<td>
-												<xsl:value-of select="@id" />
-											</td>
-											<td>
-												<xsl:value-of select="@purpose" />
-											</td>
-											<td>
-												<xsl:value-of select="@type" />
-											</td>
-											<td>
-												<xsl:value-of select="@component" />
-											</td>
-											<td>
-												<xsl:value-of select="@execution_type" />
-											</td>
-											<td>
-												<p>
-													Pre_condition:
-													<xsl:value-of select=".//description/pre_condition" />
-												</p>
-												<p>
-													Post_condition:
-													<xsl:value-of select=".//description/post_condition" />
-												</p>
-												<p>
-													Test Script Entry:
-													<xsl:value-of select=".//description/test_script_entry" />
-												</p>
-												<p>
-													Steps:
-													<p />
-													<xsl:for-each select=".//description/steps/step">
-														<xsl:sort select="@order" />
-														Step
-														<xsl:value-of select="@order" />
-														:
-														<xsl:value-of select="./step_desc" />
-														;
-														<p />
-														Expected Result:
-														<xsl:value-of select="./expected" />
-														<p />
-													</xsl:for-each>
-												</p>
-											</td>
-											<td>
-												<xsl:call-template name="br-replace">
-													<xsl:with-param name="word" select=".//spec" />
-												</xsl:call-template>
-											</td>
-										</tr>
-									</xsl:for-each>
-								</xsl:for-each>
-							</table>
-						</xsl:for-each>
-					</div>
-				</div>
-			</body>
-		</html>
-	</xsl:template>
-	<xsl:template name="br-replace">
-		<xsl:param name="word" />
-		<xsl:variable name="cr">
-			<xsl:text>
-</xsl:text>
-		</xsl:variable>
-		<xsl:choose>
-			<xsl:when test="contains($word,$cr)">
-				<xsl:value-of select="substring-before($word,$cr)" />
-				<br />
-				<xsl:call-template name="br-replace">
-					<xsl:with-param name="word" select="substring-after($word,$cr)" />
-				</xsl:call-template>
-			</xsl:when>
-			<xsl:otherwise>
-				<xsl:value-of select="$word" />
-			</xsl:otherwise>
-		</xsl:choose>
-	</xsl:template>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html>
+      <STYLE type="text/css">
+        @import "tests.css";
+      </STYLE>
+      <head>
+        <script type="text/javascript" src="jquery.min.js"/>
+      </head>
+      <body>
+        <div id="testcasepage">
+          <div id="title">
+            <table>
+              <tr>
+                <td>
+                  <h1>Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="suites">
+            <a name="contents"/>
+            <table>
+              <tr>
+                <th>Test Suite</th>
+                <th>Total</th>
+                <th>Auto</th>
+                <th>Manual</th>
+              </tr>
+              <tr>
+                <td>
+                  Total
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase)"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type = 'auto'])"/>
+                </td>
+                <td>
+                  <xsl:value-of select="count(test_definition/suite/set//testcase[@execution_type != 'auto'])"/>
+                </td>
+              </tr>
+              <xsl:for-each select="test_definition/suite">
+                <tr>
+                  <td>
+                    <a>
+                      <xsl:attribute name="href">
+                        #<xsl:value-of select="@name"/>
+                      </xsl:attribute>
+                      <xsl:value-of select="@name"/>
+                    </a>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set//testcase)"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type = 'auto'])"/>
+                  </td>
+                  <td>
+                    <xsl:value-of select="count(set/testcase[@execution_type != 'auto'])"/>
+                  </td>
+                </tr>
+              </xsl:for-each>
+            </table>
+          </div>
+          <div id="title">
+            <table>
+              <tr>
+                <td class="title">
+                  <h1>Detailed Test Cases</h1>
+                </td>
+              </tr>
+            </table>
+          </div>
+          <div id="cases">
+            <xsl:for-each select="test_definition/suite">
+              <xsl:sort select="@name"/>
+              <div id="btc">
+                <a href="#contents">Back to Contents</a>
+              </div>
+              <div id="suite_title">
+                Test Suite:
+                <xsl:value-of select="@name"/>
+                <a><xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute></a>
+              </div>
+              <table>
+                <tr>
+                  <th>Case_ID</th>
+                  <th>Purpose</th>
+                  <th>Type</th>
+                  <th>Component</th>
+                  <th>Execution Type</th>
+                  <th>Description</th>
+                  <th>Specification</th>
+                </tr>
+                <xsl:for-each select=".//set">
+                  <xsl:sort select="@name"/>
+                  <tr>
+                    <td colspan="7">
+                      Test Set:
+                      <xsl:value-of select="@name"/>
+                    </td>
+                  </tr>
+                  <xsl:for-each select=".//testcase">
+                    <!-- xsl:sort select="@id" /> -->
+                    <tr>
+                      <td>
+                        <xsl:value-of select="@id"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@purpose"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@type"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@component"/>
+                      </td>
+                      <td>
+                        <xsl:value-of select="@execution_type"/>
+                      </td>
+                      <td>
+                        <p>
+                          Pre_condition:
+                          <xsl:value-of select=".//description/pre_condition"/>
+                        </p>
+                        <p>
+                          Post_condition:
+                          <xsl:value-of select=".//description/post_condition"/>
+                        </p>
+                        <p>
+                          Test Script Entry:
+                          <xsl:value-of select=".//description/test_script_entry"/>
+                        </p>
+                        <p>
+                          Steps:
+                          <p/>
+                          <xsl:for-each select=".//description/steps/step"><xsl:sort select="@order"/>
+                            Step
+                            <xsl:value-of select="@order"/>
+                            :
+                            <xsl:value-of select="./step_desc"/>
+                            ;
+                            <p/>
+                            Expected Result:
+                            <xsl:value-of select="./expected"/>
+                            <p/>
+                          </xsl:for-each>
+                        </p>
+                      </td>
+                      <td>
+                        <xsl:for-each select=".//specs/spec"><b>[Spec_Assertion]:</b><br/>
+                          [Category]:
+                          <xsl:value-of select="./spec_assertion/@category"/>
+                          <br/>
+                          [Section]:
+                          <xsl:value-of select="./spec_assertion/@section"/>
+                          <br/>
+                          [Specification]:
+                          <xsl:value-of select="./spec_assertion/@specification"/>
+                          <br/>
+                          [Interface]:
+                          <xsl:value-of select="./spec_assertion/@interface"/>
+                          <br/>
+                          <xsl:choose><xsl:when test="./spec_assertion/@element_name">
+                              [<xsl:value-of select="./spec_assertion/@element_type"/>]:
+                              <xsl:value-of select="./spec_assertion/@element_name"/>
+                              <br/>
+                            </xsl:when></xsl:choose>
+                          [URL]:
+                          <xsl:value-of select="./spec_url"/>
+                          <br/>
+                          [Statement]:
+                          <xsl:value-of select="./spec_statement"/>
+                          <br/>
+                        </xsl:for-each>
+                      </td>
+                    </tr>
+                  </xsl:for-each>
+                </xsl:for-each>
+              </table>
+            </xsl:for-each>
+          </div>
+        </div>
+        <div id="goTopBtn">
+          <img border="0" src="./back_top.png"/>
+        </div>
+        <script type="text/javascript" src="application.js"/>
+        <script language="javascript" type="text/javascript">
+          $(document).ready(function(){
+            goTopEx();
+          });
+        </script>
+      </body>
+    </html>
+  </xsl:template>
 </xsl:stylesheet>

--- a/wrt/wrt-uxmanu-android-tests/tests.css
+++ b/wrt/wrt-uxmanu-android-tests/tests.css
@@ -1,103 +1,132 @@
 @charset "UTF-8";
 /* CSS Document */
-#testcasepage div,#testcasepage h1,#testcasepage p,#testcasepage table,#testcasepage tr,#testcasepage th,#testcasepage td
-	{
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-weight: inherit;
-	font-style: inherit;
-	font-size: 0.96em;
-	font-family: arial;
-	vertical-align: baseline;
+#testcasepage div,
+#testcasepage h1,
+#testcasepage p,
+#testcasepage table,
+#testcasepage tr,
+#testcasepage th,
+#testcasepage td {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-weight: inherit;
+  font-style: inherit;
+  font-size: 0.96em;
+  font-family: arial;
+  vertical-align: baseline;
 }
 
 #testcasepage p {
-	text-align: left;
+  text-align: left;
+}
+
+#suite_title {
+  text-align: left;
+}
+
+#btc {
+  text-align: right;
 }
 
 #testcasepage table {
-	border-collapse: separate;
-	border-spacing: 0;
-	margin-bottom: 1.4em;
-	vertical-align: middle;
+  border-collapse: separate;
+  border-spacing: 0;
+  margin-bottom: 1.4em;
+  vertical-align: middle;
 }
 
-#testcasepage th,#testcasepage td {
-	text-align: left;
-	font-weight: normal;
-	padding: 4px 10px 4px 5px;
-	vertical-align: middle;
+#testcasepage th,
+#testcasepage td {
+  text-align: left;
+  font-weight: normal;
+  padding: 4px 10px 4px 5px;
+  vertical-align: middle;
 }
 
 #cases table {
-	width: 101%;
+  width: 101%;
+}
+
+#fail_cases table {
+  width: 101%;
 }
 
 #title table {
-	width: 101%;
+  width: 101%;
 }
 
 #device table {
-	width: 50%;
+  width: 50%;
 }
 
 #summary table {
-	width: 50%;
+  width: 50%;
 }
 
 #testcasepage th {
-	border-bottom: 1px solid #000;
-	background-color: #AAAAAA;
-	border-left: 1px solid #000;
-	border-top: 1px solid #000;
-	color: #000;
-	font-weight: bold;
-	vertical-align: bottom;
+  border-bottom: 1px solid #000;
+  background-color: #AAAAAA;
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  color: #000;
+  font-weight: bold;
+  vertical-align: bottom;
 }
 
-#testcasepage th:last-child, #testcasepage td:last-child {
-	border-right: 1px solid #000;
+#testcasepage th:last-child,
+#testcasepage td:last-child {
+  border-right: 1px solid #000;
 }
 
 #testcasepage td {
-	border-left: 1px solid;
-	font-weight: normal;
-	border-bottom: 1px solid;
+  border-left: 1px solid;
+  font-weight: normal;
+  border-bottom: 1px solid;
 }
 
 #testcasepage td.yellow_rate {
-	background-color: #ffcc00;
+  background-color: #ffcc00;
 }
 
 #testcasepage td.green_rate {
-	background-color: #33cc33;
+  background-color: #33cc33;
 }
 
 #testcasepage td.dgreen_rate {
-	background-color: #339933;
+  background-color: #339933;
 }
 
 #testcasepage td.red_rate {
-	background-color: #FF3333;
+  background-color: #FF3333;
 }
 
-#title table, #title tr, #title td {
-	border-left: none;
-	border-bottom: none;
-	text-align: center;
+#title table,
+#title tr,
+#title td {
+  border-left: none;
+  border-bottom: none;
+  text-align: center;
 }
 
 #title td:last-child {
-	border-right: none;
+  border-right: none;
 }
 
 #testcasepage h1 {
-	font-size: 2em;
-	font-family: Arial, sans-serif; font-weight : bold;
-	line-height: 1;
-	color: #000;
-	margin-bottom: 0.75em;
-	padding-top: 0.25em;
-	font-weight: bold;
+  font-size: 2em;
+  font-family: Arial, sans-serif;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  margin-bottom: 0.75em;
+  padding-top: 0.25em;
+  font-weight: bold;
+}
+
+#goTopBtn {
+  right: 0px;
+  bottom: 0px;
+  position: fixed; +position: absolute;
+  top: expression(parseInt(document.body.scrollTop) + document.body.clientHeight - 40);
 }


### PR DESCRIPTION
https://github.com/testkit/testkit-lite/tree/master/xsd
(commit 1d845ee6ecc08204121cdf81c5a57758ebe13929)

Format tests.xml and result.xml by `xmllint --format`
- http://xmlsoft.org/xmllint.html

Format tests.css
- http://google-styleguide.googlecode.com/svn/trunk/htmlcssguide.xml
- Indent by 2 spaces at a time
- Separate selectors and declarations by new lines

Format application.js
- http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml
- Indent by 2 spaces at a time
- Remove trailing white spaces
