### PR TITLE
[webapi][XWALK-3118] Delete the excess character '\'

### DIFF
--- a/webapi/tct-colors-css3-tests/colors/csswg/t422-rgba-func-int-a.htm
+++ b/webapi/tct-colors-css3-tests/colors/csswg/t422-rgba-func-int-a.htm
@@ -4,7 +4,7 @@
 		<title>CSS Test: rgba() colors</title>
 		<link title="L. David Baron" rel="author" href="http://dbaron.org/">
 		<link title="Mozilla Corporation" rel="author" href="http://mozilla.com/">
-		<link rel="help" href="http://www.w3.org/TR/css3-color/#rgba-color">        \
+		<link rel="help" href="http://www.w3.org/TR/css3-color/#rgba-color">
 		<link rel="match" href="reference/t422-rgba-func-int-a-ref.html"/>
 		<meta content="" name="flags">
 		<meta content="Test that rgba() values produce correct colors." name="assert">


### PR DESCRIPTION
Remove the invalid charcter '\' from test code.
Impacted tests(approved):new 0,update 1,delete 0
Unit test platform:[android]
Unit test result summary:pass 1,fail 0,block 0
