### PR TITLE
[ivi-tct][webapi][XWALK-2343] Add default value for NDEFRecord.id

### DIFF
--- a/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecord_id_attribute.html
+++ b/webapi/webapi-nfc-w3c-tests/nfc/NDEFRecord_id_attribute.html
@@ -54,7 +54,7 @@ t.step(function () {
     });
 
     onSuccess = t.step_func(function (payload) {
-        record = new NDEFRecord(recordText.tnf, recordText.type, payload, recordText.id);
+        record = new NDEFRecord(recordText.tnf, recordText.type, payload, "1");
         assert_true("id" in record, "NDEFRecord.id exists");
         assert_equals(typeof record.id, "string", "NDEFRecord.id attribute of type");
         check_readonly(record, "id", record.id, "string", "dummy");


### PR DESCRIPTION
Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: [Tizen IVI]
Unit test result summary: pass 1, fail 0, block 0
