### PR TITLE
[usecase][XWALK-3089] Update csp case for usecase

### DIFF
--- a/usecase/usecase-webapi-xwalk-tests/samples/CSP/res/default-src_self/index.html
+++ b/usecase/usecase-webapi-xwalk-tests/samples/CSP/res/default-src_self/index.html
@@ -79,9 +79,8 @@ Authors:
   <body>
     <div data-role="page" id="main">
     <input type="hidden" id="wgt_name" value="default-src-self"/>
-    <p>Test 1: passes if the first two lines are the same in font and different from line 3.</p>
+    <p>Test 1: passes if the first line is different from second line.</p>
     <div id="test1">1234 ABCD</div>
-    <div>1234 ABCD</div>
     <div id="test">1234 ABCD</div>
     <hr />
     <p>Test 2: passes if a blue filled square with a "PASS" plug in is displayed .</p>


### PR DESCRIPTION
- Because we not sure if this is a feature issue and  the case purpose is to check whether the CSP(default-src self) only allow  the local font source loaded, so remove the div log without any css style to avoid this issue.

Impacted TCs num(approved): New 0, Update 1, Delete 0
Unit test Platform: [Tizen-IVI]
Unit test result summary: Pass 1, Fail 0, Blocked 0
