### PR TITLE
[Crosswalk-10][webapi][XWALK-2593] Fix bug for webrtc

### DIFF
--- a/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection.html
+++ b/webapi/webapi-webrtc-w3c-tests/webrtc/RTCPeerConnection.html
@@ -65,7 +65,7 @@ Authors:
       });
 
       t.step(function () {
-        assert_throws("SyntaxError", function () {
+        assert_throws("TypeMismatchError", function () {
           pc1.addIceCandidate("", function () {}, function () {});
         },"the candidate parameter is malformed throw a exception");
         t.done();


### PR DESCRIPTION
- Fix bug for webrtc
- `addIceCandidate("", function () {}, function () {})` should throw `TypeError`

Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: [Tizen IVI]
Unit test result summary: pass 1, fail 0, block 0
