### PR TITLE
[ivi-tct][webapi] Avoid add testharness repeatedly

### DIFF
--- a/webapi/tct-systeminfo-tizen-tests/systeminfo/support/systeminfo_common.js
+++ b/webapi/tct-systeminfo-tizen-tests/systeminfo/support/systeminfo_common.js
@@ -16,8 +16,15 @@ limitations under the License.
 
  */
 
-document.write("<script language=\"javascript\" src=\"..\/resources\/testharness.js\"><\/script>");
-document.write("<script language=\"javascript\" src=\"..\/resources\/testharnessreport.js\"><\/script>");
+(function () {
+   var head_src = document.head.innerHTML;
+   if (head_src.search(/\/testharness.js\W/) === -1) {
+       document.write('<script language="javascript" src="../resources/testharness.js"></script>\n');
+   }
+   if (head_src.search(/\/testharnessreport.js\W/) === -1) {
+       document.write('<script language="javascript" src="../resources/testharnessreport.js"></script>\n');
+   }
+})();
 
 var attribute = "";
 var status_value = "";


### PR DESCRIPTION
- In some tests, testharness.js has been added by unitcommon.js, add testharness.js repeatedly will create a timeout result, so update it following unitcommon.js

Impacted tests(approved): new 0, update 0, delete 0
Unit test platform: [IVI]
Unit test result summary: pass 188, fail 18, block 1
