### PR TITLE
[ivi-tct][webapi][xwalk-3179] Decrease timeout of AlarmRelative_getRemainingSeconds_return_null

### DIFF
--- a/webapi/tct-alarm-tizen-tests/alarm/AlarmRelative_getRemainingSeconds_return_null.html
+++ b/webapi/tct-alarm-tizen-tests/alarm/AlarmRelative_getRemainingSeconds_return_null.html
@@ -59,7 +59,7 @@ t.step(function () {
         returnedValue = alarm.getRemainingSeconds();
         assert_equals(returnedValue, null, "getRemainingSeconds do not returns null");
         t.done();
-    }), 10000);
+    }), 500);
 });
 
 </script>


### PR DESCRIPTION
Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: [IVI]
Unit test result summary: pass 1, fail 0, block 0
