### PR TITLE
[webapi][xwalk-3179] Add onload_delay for Datachannel tests

### DIFF
--- a/webapi/webapi-webrtc-w3c-tests/tests.full.xml
+++ b/webapi/webapi-webrtc-w3c-tests/tests.full.xml
@@ -1457,7 +1457,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection-datachannel-1" priority="P1" purpose="Check that connecting is the initial state of a RTCDataChannel object created with createDataChannel()" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection-datachannel-1" priority="P1" purpose="Check that connecting is the initial state of a RTCDataChannel object created with createDataChannel()" status="approved" type="compliance" onload_delay="10">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-datachannel.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
@@ -1469,7 +1469,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection-datachannel-2" priority="P1" purpose="Check that RTCPeerConnection.createDataChannel('label1') creates an ordered datachannel" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection-datachannel-2" priority="P1" purpose="Check that RTCPeerConnection.createDataChannel('label1') creates an ordered datachannel" status="approved" type="compliance" onload_delay="10">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-datachannel.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
@@ -1481,7 +1481,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection-datachannel-3" priority="P1" purpose="Check that RTCPeerConnection.createDataChannel('label2', {}) creates an ordered datachannel" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection-datachannel-3" priority="P1" purpose="Check that RTCPeerConnection.createDataChannel('label2', {}) creates an ordered datachannel" status="approved" type="compliance" onload_delay="10">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-datachannel.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
         </description>
@@ -1493,7 +1493,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection-datachannel-4" priority="P1" purpose="Check that RTCPeerConnection.createDataChannel('label3', {ordered:true}) creates an ordered datachannel" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection-datachannel-4" priority="P1" purpose="Check that RTCPeerConnection.createDataChannel('label3', {ordered:true}) creates an ordered datachannel" status="approved" type="compliance" onload_delay="10">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-datachannel.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
         </description>
@@ -1505,7 +1505,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection-datachannel-5" priority="P1" purpose="Check that RTCPeerConnection.createDataChannel('label3', {ordered:false}) creates a non-ordered datachannel" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection-datachannel-5" priority="P1" purpose="Check that RTCPeerConnection.createDataChannel('label3', {ordered:false}) creates a non-ordered datachannel" status="approved" type="compliance" onload_delay="10">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-datachannel.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
         </description>
@@ -1517,7 +1517,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection-datachannel-6" priority="P1" purpose="Check that RTCPeerConnection.createDataChannel('label3', {maxRetransmits:0}) creates a non-ordered datachannel" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection-datachannel-6" priority="P1" purpose="Check that RTCPeerConnection.createDataChannel('label3', {maxRetransmits:0}) creates a non-ordered datachannel" status="approved" type="compliance" onload_delay="10">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-datachannel.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
         </description>
@@ -1529,7 +1529,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection-datachannel-7" priority="P1" purpose="Check that RTCPeerConnection.createDataChannel('label3', {maxRetransmitTime:0}) creates a non-ordered datachannel" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection-datachannel-7" priority="P1" purpose="Check that RTCPeerConnection.createDataChannel('label3', {maxRetransmitTime:0}) creates a non-ordered datachannel" status="approved" type="compliance" onload_delay="10">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-datachannel.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
         </description>

--- a/webapi/webapi-webrtc-w3c-tests/tests.xml
+++ b/webapi/webapi-webrtc-w3c-tests/tests.xml
@@ -605,37 +605,37 @@
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-createOffer.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection-datachannel-1" purpose="Check that connecting is the initial state of a RTCDataChannel object created with createDataChannel()">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection-datachannel-1" purpose="Check that connecting is the initial state of a RTCDataChannel object created with createDataChannel()" onload_delay="10">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-datachannel.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection-datachannel-2" purpose="Check that RTCPeerConnection.createDataChannel('label1') creates an ordered datachannel">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection-datachannel-2" purpose="Check that RTCPeerConnection.createDataChannel('label1') creates an ordered datachannel" onload_delay="10">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-datachannel.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection-datachannel-3" purpose="Check that RTCPeerConnection.createDataChannel('label2', {}) creates an ordered datachannel">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection-datachannel-3" purpose="Check that RTCPeerConnection.createDataChannel('label2', {}) creates an ordered datachannel" onload_delay="10">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-datachannel.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection-datachannel-4" purpose="Check that RTCPeerConnection.createDataChannel('label3', {ordered:true}) creates an ordered datachannel">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection-datachannel-4" purpose="Check that RTCPeerConnection.createDataChannel('label3', {ordered:true}) creates an ordered datachannel" onload_delay="10">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-datachannel.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection-datachannel-5" purpose="Check that RTCPeerConnection.createDataChannel('label3', {ordered:false}) creates a non-ordered datachannel">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection-datachannel-5" purpose="Check that RTCPeerConnection.createDataChannel('label3', {ordered:false}) creates a non-ordered datachannel" onload_delay="10">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-datachannel.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection-datachannel-6" purpose="Check that RTCPeerConnection.createDataChannel('label3', {maxRetransmits:0}) creates a non-ordered datachannel">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection-datachannel-6" purpose="Check that RTCPeerConnection.createDataChannel('label3', {maxRetransmits:0}) creates a non-ordered datachannel" onload_delay="10">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-datachannel.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection-datachannel-7" purpose="Check that RTCPeerConnection.createDataChannel('label3', {maxRetransmitTime:0}) creates a non-ordered datachannel">
+      <testcase component="W3C_HTML5 APIs/Communication/WebRTC" execution_type="auto" id="RTCPeerConnection-datachannel-7" purpose="Check that RTCPeerConnection.createDataChannel('label3', {maxRetransmitTime:0}) creates a non-ordered datachannel" onload_delay="10">
         <description>
           <test_script_entry>/opt/webapi-webrtc-w3c-tests/webrtc/blink/RTCPeerConnection-datachannel.html?total_num=7&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
         </description>


### PR DESCRIPTION
- The tests need more time to get result, set onload_delay with 10s
- Block: ondatachannel cannot be fired.

Impacted tests(approved): new 0, update 7, delete 0
Unit test platform: [IVI]
Unit test result summary: pass 6, fail 0, block 1
