### PR TITLE
[behavior][XWALK-3119] Remove 2 subcases for CSP in behavior

### DIFF
--- a/behavior/tests/CSP/index.html
+++ b/behavior/tests/CSP/index.html
@@ -61,16 +61,6 @@ Authors:
                         <h2>csp-self</h2>
                     </a>
                 </li>
-                <li id="csp-asterisk">
-                    <a href="javascript:runApp('res/csp-asterisk.html')" data-transition="slide" style="">
-                        <h2>csp-asterisk</h2>
-                    </a>
-                </li>
-                <li id="csp-cross-origin">
-                    <a href="javascript:runApp('res/csp-cross-origin.html')" data-transition="slide" style="">
-                        <h2>csp-cross-origin</h2>
-                    </a>
-                </li>
                 <li id="default-policy-by-directives-csp">
                     <a href="javascript:runApp('res/default-policy-by-directives-csp.html')" data-transition="slide" style="">
                         <h2>default-policy-by-directives-csp</h2>


### PR DESCRIPTION
- Due to tinyweb dose not support access origin now, remove related subcases firstly.

Impacted TCs num: New 0, Update 0, Delete 2
Unit test Platform: [Tizen-IVI]
Unit test result summary: Pass 0, Fail 0, Blocked 0
