### PR TITLE
[ivi-tct][webapi][xwalk-3179] Revise timeout to 5000 from 500

### DIFF
--- a/webapi/tct-alarm-tizen-tests/alarm/AlarmRelative_getRemainingSeconds_return_null.html
+++ b/webapi/tct-alarm-tizen-tests/alarm/AlarmRelative_getRemainingSeconds_return_null.html
@@ -59,7 +59,7 @@ t.step(function () {
         returnedValue = alarm.getRemainingSeconds();
         assert_equals(returnedValue, null, "getRemainingSeconds do not returns null");
         t.done();
-    }), 500);
+    }), 5000);
 });
 
 </script>


### PR DESCRIPTION
- Change timeout to 5000, too short timeout will make test fail

Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: [IVI]
Unit test result summary: pass 1, fail 0, block 0
