### PR TITLE
[behavior][XWALK-3173/3119/2243/3121] Drop 7 tests for CSP

### DIFF
--- a/behavior/subtestresult.xml
+++ b/behavior/subtestresult.xml
@@ -5,20 +5,13 @@
   <set name="CSP">
       <testcase id="csp-none" result="N/A"></testcase>
       <testcase id="csp-self" result="N/A"></testcase>
-      <testcase id="csp-asterisk" result="N/A"></testcase>
-      <testcase id="csp-cross-origin" result="N/A"></testcase>
-      <testcase id="default-policy-by-directives-csp" result="N/A"></testcase>
-      <testcase id="default-policy-by-directives-report-only" result="N/A"></testcase>
       <testcase id="default-src_none" result="N/A"></testcase>
-      <testcase id="default-src_self" result="N/A"></testcase>
       <testcase id="default-src_asterisk" result="N/A"></testcase>
-      <testcase id="default-src_cross_origin" result="N/A"></testcase>
       <testcase id="sandbox-empty-ext" result="N/A"></testcase>
       <testcase id="sandbox-empty-int" result="N/A"></testcase>
       <testcase id="sandbox-empty-inline" result="N/A"></testcase>
       <testcase id="sandbox-same-origin-allow-scripts" result="N/A"></testcase>
       <testcase id="script-src_none" result="N/A"></testcase>
-      <testcase id="script-src_inline_eval" result="N/A"></testcase>
       <testcase id="style-src_self" result="N/A"></testcase>
   </set>
   <set name="PackageManagement">

--- a/behavior/tests.full.xml
+++ b/behavior/tests.full.xml
@@ -115,7 +115,7 @@
       <testcase purpose="Dynamic Box Test" type="functional_positive" status="designed" component="TCT Behavior" execution_type="manual" platform="all" priority="P0" id="DynamicBox">
         <capability name="shellAppWidget"/>
       </testcase>
-      <testcase purpose="CSP Test" type="functional_positive" status="approved" component="TCT Behavior" execution_type="manual" platform="tizen" priority="P0" id="CSP" subcase="17">
+      <testcase purpose="CSP Test" type="functional_positive" status="approved" component="TCT Behavior" execution_type="manual" platform="tizen" priority="P0" id="CSP" subcase="10">
       </testcase>
       <testcase purpose="User Interface Test" type="functional_positive" status="approved" component="TCT Behavior" execution_type="manual" platform="tizen" priority="P0" id="WRTUI" subcase="4">
       </testcase>

--- a/behavior/tests.tizen.xml
+++ b/behavior/tests.tizen.xml
@@ -69,7 +69,7 @@
       </testcase>
     </set>
     <set name="Web Runtime">
-      <testcase component="TCT Behavior" execution_type="manual" id="CSP" purpose="CSP Test" subcase="17">
+      <testcase component="TCT Behavior" execution_type="manual" id="CSP" purpose="CSP Test" subcase="10">
       </testcase>
       <testcase component="TCT Behavior" execution_type="manual" id="WRTUI" purpose="User Interface Test" subcase="4">
       </testcase>

--- a/behavior/tests/CSP/index.html
+++ b/behavior/tests/CSP/index.html
@@ -61,45 +61,15 @@ Authors:
                         <h2>csp-self</h2>
                     </a>
                 </li>
-                <li id="csp-asterisk">
-                    <a href="javascript:runApp('res/csp-asterisk.html')" data-transition="slide" style="">
-                        <h2>csp-asterisk</h2>
-                    </a>
-                </li>
-                <li id="csp-cross-origin">
-                    <a href="javascript:runApp('res/csp-cross-origin.html')" data-transition="slide" style="">
-                        <h2>csp-cross-origin</h2>
-                    </a>
-                </li>
-                <li id="default-policy-by-directives-csp">
-                    <a href="javascript:runApp('res/default-policy-by-directives-csp.html')" data-transition="slide" style="">
-                        <h2>default-policy-by-directives-csp</h2>
-                    </a>
-                </li>
-                <li id="default-policy-by-directives-report-only">
-                    <a href="javascript:runApp('res/default-policy-by-directives-report-only.html')" data-transition="slide" style="">
-                        <h2>default-policy-by-directives-report-only</h2>
-                    </a>
-                </li>
                 <li data-role="list-divider" role="heading">Test default-src directive</li>
                 <li id="default-src_none">
                     <a href="javascript:runApp('res/default-src_none.html')" data-transition="slide" style="">
                         <h2>default-src_none</h2>
                     </a>
                 </li>
-                <li id="default-src_self">
-                    <a href="javascript:runApp('res/default-src_self.html')" data-transition="slide" style="">
-                        <h2>default-src_self</h2>
-                    </a>
-                </li>
                 <li id="default-src_asterisk">
                     <a href="javascript:runApp('res/default-src_asterisk.html')" data-transition="slide" style="">
                         <h2>default-src_asterisk</h2>
-                    </a>
-                </li>
-                <li id="default-src_cross_origin">
-                    <a href="javascript:runApp('res/default-src_cross_origin.html')" data-transition="slide" style="">
-                        <h2>default-src_cross_origin</h2>
                     </a>
                 </li>
                 <li data-role="list-divider" role="heading">Test sandbox directive</li>
@@ -127,11 +97,6 @@ Authors:
                 <li id="script-src_none">
                     <a href="javascript:runApp('res/script-src_none.html')" data-transition="slide" style="">
                         <h2>script-src_none</h2>
-                    </a>
-                </li>
-                <li id="script-src_inline_eval">
-                    <a href="javascript:runApp('res/script-src_inline_eval.html')" data-transition="slide" style="">
-                        <h2>script-src_inline_eval</h2>
                     </a>
                 </li>
                 <li data-role="list-divider" role="heading">Test style-src directive</li>


### PR DESCRIPTION
- Due to access origin is not supported now, so remove these tests firstly

Impacted TCs num(approved): New 0, Update 0, Delete 7
Unit test Platform: [Tizen-IVI]
Unit test result summary: Pass 0, Fail 0, Blocked 0
