### PR TITLE
[webapi] Update locale timezone tests to designed in Tizen/Time

### DIFF
--- a/webapi/tct-time-tizen-tests/README
+++ b/webapi/tct-time-tizen-tests/README
@@ -3,35 +3,6 @@
 This test suite is for testing Tizen Time API, which covers the following specifications:
 * https://developer.tizen.org/help/topic/org.tizen.web.device.apireference/tizen/time.html
 
-## Pre-Conditions
-
-* Time zone should be set to Seoul
-    Launch 'Settings' application -> Select 'Date and time'
-    -> Turn off 'Automatic update' if it is enabled. It makes you change 'Time zone'
-    -> Select 'Time zone' -> Choose 'Seoul'
-    Tests: TimeUtil_getLocalTimezone
-
-* There are tests which check position between two dates. One of these dates is current date,
-   the other one is set to some specific date. These tests may fail if current Date is set
-   before 2013-3-4:
-    Test: TZDate_earlierThan
-
-* Display language should be set to English(United Kingdom).
-    Launch 'Settings' application -> Select 'Language and keyboard' -> Select 'Display language'
-    -> Select 'English(United Kingdom)'
-    Test: TimeUtil_getDateFormat
-
-* Region should be set to English(United Kingdom).
-    Launch 'Settings' application -> Select 'Language and keyboard' -> Select 'Region'
-    -> Select 'English(United Kingdom)'
-    Tests: TZDate_toLocaleString_for_specific_date
-           TZDate_toLocaleDateString_for_specific_date
-           TZDate_toDateString_for_specific_date
-
-* Time format should be set to AM/PM (12 hours) format.
-    Launch 'Settings' application -> Select 'Date and time'
-    -> Time format: Select AM/PM (12 hours)
-
 ## Authors:
 
 * Li, Cici <cici.x.li@intel.com>

--- a/webapi/tct-time-tizen-tests/tests.full.xml
+++ b/webapi/tct-time-tizen-tests/tests.full.xml
@@ -4107,7 +4107,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Tizen Device APIs/System/Time" execution_type="auto" id="TZDate_toLocaleDateString_for_specific_date" priority="P1" purpose="Check whether toLocaleDateString() method correctly returns the date portion of a TZDate object as a string" status="approved" type="compliance">
+      <testcase component="Tizen Device APIs/System/Time" execution_type="auto" id="TZDate_toLocaleDateString_for_specific_date" priority="P1" purpose="Check whether toLocaleDateString() method correctly returns the date portion of a TZDate object as a string" status="designed" type="compliance">
         <description>
           <test_script_entry>/opt/tct-time-tizen-tests/time/TZDate_toLocaleDateString_for_specific_date.html</test_script_entry>
         </description>
@@ -4155,7 +4155,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Tizen Device APIs/System/Time" execution_type="auto" id="TZDate_toLocaleString_for_specific_date" priority="P1" purpose="Check whether toLocaleString() method correctly converts a TZDate object to a string, using locale conventions" status="approved" type="compliance">
+      <testcase component="Tizen Device APIs/System/Time" execution_type="auto" id="TZDate_toLocaleString_for_specific_date" priority="P1" purpose="Check whether toLocaleString() method correctly converts a TZDate object to a string, using locale conventions" status="designed" type="compliance">
         <description>
           <test_script_entry>/opt/tct-time-tizen-tests/time/TZDate_toLocaleString_for_specific_date.html</test_script_entry>
         </description>
@@ -4827,7 +4827,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Tizen Device APIs/System/Time" execution_type="auto" id="TimeUtil_getLocalTimezone" priority="P1" purpose="Check if method getLocalTimezone of TimeUtil works properly." status="approved" type="compliance">
+      <testcase component="Tizen Device APIs/System/Time" execution_type="auto" id="TimeUtil_getLocalTimezone" priority="P1" purpose="Check if method getLocalTimezone of TimeUtil works properly." status="designed" type="compliance">
         <description>
           <test_script_entry>/opt/tct-time-tizen-tests/time/TimeUtil_getLocalTimezone.html</test_script_entry>
         </description>

--- a/webapi/tct-time-tizen-tests/tests.xml
+++ b/webapi/tct-time-tizen-tests/tests.xml
@@ -1713,11 +1713,6 @@
           <test_script_entry>/opt/tct-time-tizen-tests/time/TZDate_toLocaleDateString.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Tizen Device APIs/System/Time" execution_type="auto" id="TZDate_toLocaleDateString_for_specific_date" purpose="Check whether toLocaleDateString() method correctly returns the date portion of a TZDate object as a string">
-        <description>
-          <test_script_entry>/opt/tct-time-tizen-tests/time/TZDate_toLocaleDateString_for_specific_date.html</test_script_entry>
-        </description>
-      </testcase>
       <testcase component="Tizen Device APIs/System/Time" execution_type="auto" id="TZDate_toLocaleDateString_exist" purpose="Check if toLocaleDateString method exists in TimeManager.">
         <description>
           <test_script_entry>/opt/tct-time-tizen-tests/time/TZDate_toLocaleDateString_exist.html</test_script_entry>
@@ -1731,11 +1726,6 @@
       <testcase component="Tizen Device APIs/System/Time" execution_type="auto" id="TZDate_toLocaleString" purpose="Check if TZDate::ToLocaleString() method returns non-empty string">
         <description>
           <test_script_entry>/opt/tct-time-tizen-tests/time/TZDate_toLocaleString.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="Tizen Device APIs/System/Time" execution_type="auto" id="TZDate_toLocaleString_for_specific_date" purpose="Check whether toLocaleString() method correctly converts a TZDate object to a string, using locale conventions">
-        <description>
-          <test_script_entry>/opt/tct-time-tizen-tests/time/TZDate_toLocaleString_for_specific_date.html</test_script_entry>
         </description>
       </testcase>
       <testcase component="Tizen Device APIs/System/Time" execution_type="auto" id="TZDate_toLocaleString_exist" purpose="Check if toLocaleString method exists in TimeManager.">
@@ -2011,11 +2001,6 @@
       <testcase component="Tizen Device APIs/System/Time" execution_type="auto" id="TimeUtil_getDateFormat_exist" purpose="Check if getDateFormat method exists in TimeManager.">
         <description>
           <test_script_entry>/opt/tct-time-tizen-tests/time/TimeUtil_getDateFormat_exist.html</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="Tizen Device APIs/System/Time" execution_type="auto" id="TimeUtil_getLocalTimezone" purpose="Check if method getLocalTimezone of TimeUtil works properly.">
-        <description>
-          <test_script_entry>/opt/tct-time-tizen-tests/time/TimeUtil_getLocalTimezone.html</test_script_entry>
         </description>
       </testcase>
       <testcase component="Tizen Device APIs/System/Time" execution_type="auto" id="TimeUtil_getLocalTimezone_exist" purpose="Check if getLocalTimezone method exists in TimeManager.">


### PR DESCRIPTION
- On IVI, the locale can not be changed, and this issue is waiting for resovle
  https://bugs.tizen.org/jira/browse/TC-1813
  https://bugs.tizen.org/jira/browse/TC-2054
- Mark these tests against LOCALE to designed
