### PR TITLE
[webapi][XWALK-3276] Fix tests from upstream getUserMedia missing webkit...

### DIFF
--- a/webapi/tct-gumallow-w3c-tests/tests.full.xml
+++ b/webapi/tct-gumallow-w3c-tests/tests.full.xml
@@ -77,7 +77,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="manual" id="video-assignment-manual" priority="P2" purpose="Test checks that the MediaStream object returned by the success callback in getUserMedia can be properly assigned to a video element via the srcObject attribute" status="ready" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/mediastreams-as-media-elements/video-assignment-manual.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/mediastreams-as-media-elements/video-assignment-manual.html?usePrefixes=1</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -89,7 +89,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="auto" id="api-present" priority="P2" purpose="Test checks for the presence of the navigator.getUserMedia method, taking vendor prefixes into account" status="ready" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/obtaining-local-multimedia-content/navigatorusermedia/api-present.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/obtaining-local-multimedia-content/navigatorusermedia/api-present.html?usePrefixes=1</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -101,7 +101,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="auto" id="empty-option-param" priority="P2" purpose="Test checks that getUserMedia with no value in the options parameter raises a NOT_SUPPORTED_ERR exception" status="ready" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/obtaining-local-multimedia-content/navigatorusermedia/empty-option-param.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/obtaining-local-multimedia-content/navigatorusermedia/empty-option-param.html?usePrefixes=1</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -113,7 +113,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="auto" id="getusermedia-impossible-constraint" priority="P2" purpose="Test checks that setting a trivial mandatory constraint (width &gt;=0) in getUserMedia works" status="ready" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/obtaining-local-multimedia-content/navigatorusermedia/getusermedia-impossible-constraint.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/obtaining-local-multimedia-content/navigatorusermedia/getusermedia-impossible-constraint.html?usePrefixes=1</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -125,7 +125,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="auto" id="getusermedia-optional-constraint" priority="P2" purpose="Test checks that setting an optional constraint in getUserMedia is handled as optional" status="ready" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/obtaining-local-multimedia-content/navigatorusermedia/getusermedia-optional-constraint.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/obtaining-local-multimedia-content/navigatorusermedia/getusermedia-optional-constraint.html?usePrefixes=1</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -137,7 +137,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="auto" id="getusermedia-trivial-constraint" priority="P2" purpose="Test checks that setting a trivial mandatory constraint (width &gt;=0) in getUserMedia works" status="ready" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/obtaining-local-multimedia-content/navigatorusermedia/getusermedia-trivial-constraint.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/obtaining-local-multimedia-content/navigatorusermedia/getusermedia-trivial-constraint.html?usePrefixes=1</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -149,7 +149,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="auto" id="unknownkey-option-param" priority="P2" purpose="Test checks that getUserMedia with an unknown value in the options parameter raises a NOT_SUPPORTED_ERR exception" status="ready" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/obtaining-local-multimedia-content/navigatorusermedia/unknownkey-option-param.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/obtaining-local-multimedia-content/navigatorusermedia/unknownkey-option-param.html?usePrefixes=1</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -161,7 +161,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="manual" id="disabled-audio-silence" priority="P2" purpose="Test checks that a disabled audio track in a MediaStream is rendered as silence" status="ready" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/introduction/disabled-audio-silence-manual.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/introduction/disabled-audio-silence-manual.html?usePrefixes=1</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -173,7 +173,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="manual" id="disabled-video-black" priority="P2" purpose="Test checks that a disabled video track in a MediaStream is rendered as blackness" status="ready" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/introduction/disabled-video-black-manual.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/introduction/disabled-video-black-manual.html?usePrefixes=1</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -185,7 +185,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="manual" id="audio" priority="P2" purpose="Test checks that the MediaStream object returned by the success callback in getUserMedia has exactly one audio track" status="ready" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/audio-manual.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/audio-manual.html?usePrefixes=1</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -197,7 +197,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="manual" id="mediastream-addtrack" priority="P2" purpose="Test checks that adding a track to a MediaStream works as expected" status="ready" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-addtrack-manual.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-addtrack-manual.html?usePrefixes=1</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -209,7 +209,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="manual" id="mediastream-finished-add" priority="P2" purpose="Test checks that adding a track to a finished MediaStream raises an INVALID_STATE_ERR exception" status="ready" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-finished-add-manual.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-finished-add-manual.html?usePrefixes=1</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -221,7 +221,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="manual" id="mediastream-gettrackid" priority="P2" purpose="Test checks that MediaStream.getTrackById behaves as expected" status="ready" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-gettrackid-manual.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-gettrackid-manual.html?usePrefixes=1</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -233,7 +233,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="manual" id="mediastream-idl" priority="P2" purpose="Test checks that the MediaStream constructor follows the algorithm set in the spec" status="ready" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-idl-manual.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-idl-manual.html?usePrefixes=1</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -245,7 +245,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="manual" id="mediastream-id-manual" priority="P2" purpose="Test checks that the MediaStream object returned by the success callback in getUserMedia has a correct id" status="ready" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-id-manual.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-id-manual.html?usePrefixes=1</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -257,7 +257,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="manual" id="mediastream-removetrack" priority="P2" purpose="Test checks that removinging a track from a MediaStream works as expected" status="ready" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-removetrack-manual.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-removetrack-manual.html?usePrefixes=1</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -269,7 +269,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="manual" id="stream-ended" priority="P2" purpose="Test checks that the MediaStream object returned by the success callback in getUserMedia has a ended set to false at start, and triggers 'onended' when it is set to true" status="ready" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/stream-ended-manual.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/stream-ended-manual.html?usePrefixes=1</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -281,7 +281,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="manual" id="video" priority="P2" purpose="Test checks that the MediaStream object returned by the success callback in getUserMedia has exactly one video track and no audio" status="ready" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/video-manual.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/video-manual.html?usePrefixes=1</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -293,7 +293,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="manual" id="mediastreamtrack-end" priority="P2" purpose="Test checks that the video and audio tracks of MediaStream object returned by the success callback in getUserMedia are correctly set into ended state when permission is revoked" status="ready" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastreamtrack/mediastreamtrack-end-manual.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastreamtrack/mediastreamtrack-end-manual.html?usePrefixes=1</test_script_entry>
         </description>
         <specs>
           <spec>
@@ -305,7 +305,7 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="manual" id="mediastreamtrack-id" priority="P2" purpose="Test checks that distinct mediastream tracks have distinct ids" status="ready" type="compliance">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastreamtrack/mediastreamtrack-id-manual.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastreamtrack/mediastreamtrack-id-manual.html?usePrefixes=1</test_script_entry>
         </description>
         <specs>
           <spec>

--- a/webapi/tct-gumallow-w3c-tests/tests.xml
+++ b/webapi/tct-gumallow-w3c-tests/tests.xml
@@ -35,102 +35,102 @@
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="manual" id="video-assignment-manual" purpose="Test checks that the MediaStream object returned by the success callback in getUserMedia can be properly assigned to a video element via the srcObject attribute">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/mediastreams-as-media-elements/video-assignment-manual.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/mediastreams-as-media-elements/video-assignment-manual.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="auto" id="api-present" purpose="Test checks for the presence of the navigator.getUserMedia method, taking vendor prefixes into account">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/obtaining-local-multimedia-content/navigatorusermedia/api-present.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/obtaining-local-multimedia-content/navigatorusermedia/api-present.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="auto" id="empty-option-param" purpose="Test checks that getUserMedia with no value in the options parameter raises a NOT_SUPPORTED_ERR exception">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/obtaining-local-multimedia-content/navigatorusermedia/empty-option-param.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/obtaining-local-multimedia-content/navigatorusermedia/empty-option-param.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="auto" id="getusermedia-impossible-constraint" purpose="Test checks that setting a trivial mandatory constraint (width &gt;=0) in getUserMedia works">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/obtaining-local-multimedia-content/navigatorusermedia/getusermedia-impossible-constraint.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/obtaining-local-multimedia-content/navigatorusermedia/getusermedia-impossible-constraint.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="auto" id="getusermedia-optional-constraint" purpose="Test checks that setting an optional constraint in getUserMedia is handled as optional">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/obtaining-local-multimedia-content/navigatorusermedia/getusermedia-optional-constraint.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/obtaining-local-multimedia-content/navigatorusermedia/getusermedia-optional-constraint.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="auto" id="getusermedia-trivial-constraint" purpose="Test checks that setting a trivial mandatory constraint (width &gt;=0) in getUserMedia works">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/obtaining-local-multimedia-content/navigatorusermedia/getusermedia-trivial-constraint.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/obtaining-local-multimedia-content/navigatorusermedia/getusermedia-trivial-constraint.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="auto" id="unknownkey-option-param" purpose="Test checks that getUserMedia with an unknown value in the options parameter raises a NOT_SUPPORTED_ERR exception">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/obtaining-local-multimedia-content/navigatorusermedia/unknownkey-option-param.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/obtaining-local-multimedia-content/navigatorusermedia/unknownkey-option-param.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="manual" id="disabled-audio-silence" purpose="Test checks that a disabled audio track in a MediaStream is rendered as silence">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/introduction/disabled-audio-silence-manual.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/introduction/disabled-audio-silence-manual.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="manual" id="disabled-video-black" purpose="Test checks that a disabled video track in a MediaStream is rendered as blackness">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/introduction/disabled-video-black-manual.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/introduction/disabled-video-black-manual.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="manual" id="audio" purpose="Test checks that the MediaStream object returned by the success callback in getUserMedia has exactly one audio track">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/audio-manual.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/audio-manual.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="manual" id="mediastream-addtrack" purpose="Test checks that adding a track to a MediaStream works as expected">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-addtrack-manual.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-addtrack-manual.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="manual" id="mediastream-finished-add" purpose="Test checks that adding a track to a finished MediaStream raises an INVALID_STATE_ERR exception">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-finished-add-manual.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-finished-add-manual.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="manual" id="mediastream-gettrackid" purpose="Test checks that MediaStream.getTrackById behaves as expected">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-gettrackid-manual.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-gettrackid-manual.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="manual" id="mediastream-idl" purpose="Test checks that the MediaStream constructor follows the algorithm set in the spec">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-idl-manual.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-idl-manual.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="manual" id="mediastream-id-manual" purpose="Test checks that the MediaStream object returned by the success callback in getUserMedia has a correct id">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-id-manual.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-id-manual.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="manual" id="mediastream-removetrack" purpose="Test checks that removinging a track from a MediaStream works as expected">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-removetrack-manual.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/mediastream-removetrack-manual.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="manual" id="stream-ended" purpose="Test checks that the MediaStream object returned by the success callback in getUserMedia has a ended set to false at start, and triggers 'onended' when it is set to true">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/stream-ended-manual.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/stream-ended-manual.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="manual" id="video" purpose="Test checks that the MediaStream object returned by the success callback in getUserMedia has exactly one video track and no audio">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/video-manual.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastream/video-manual.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="manual" id="mediastreamtrack-end" purpose="Test checks that the video and audio tracks of MediaStream object returned by the success callback in getUserMedia are correctly set into ended state when permission is revoked">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastreamtrack/mediastreamtrack-end-manual.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastreamtrack/mediastreamtrack-end-manual.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/Media/getUserMedia (Partial)" execution_type="manual" id="mediastreamtrack-id" purpose="Test checks that distinct mediastream tracks have distinct ids">
         <description>
-          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastreamtrack/mediastreamtrack-id-manual.html</test_script_entry>
+          <test_script_entry>/opt/tct-gumallow-w3c-tests/gumallow/w3c/stream-api/mediastreamtrack/mediastreamtrack-id-manual.html?usePrefixes=1</test_script_entry>
         </description>
       </testcase>
     </set>


### PR DESCRIPTION
... prefix

- Tests from upstream,the vendor-prefix.js help to provide prefix of getUserMedia according to URL parameter,
  so modify tests.xml and tests.full.xml to add URL paramerter 'usePrefixes=1'.

Impacted tests(approved): new 0, update 20, delete 0
Unit test platform: [android] crosswalk-10.38.222
Unit test result summary: pass 10, fail 8, block 2