### PR TITLE
[behavior][XWALK-3251] Fix app exit button can not work on IVI

### DIFF
--- a/behavior/js/main.js
+++ b/behavior/js/main.js
@@ -176,9 +176,20 @@ $("#home_ui").live("pageshow", function () {
 });
 
 $("#exit").live("click", function () {
+  try {
+    var app = tizen.application.getCurrentApplication();
+    app.exit();
+  } catch(error) {
+    closeWindow();
+  } finally {
+    closeWindow();
+  }
+});
+
+function closeWindow() {
   window.open('', '_self');
   window.close();
-});
+}
 
 $("#reset").live("click", function (event) {
   sstorage.clear();


### PR DESCRIPTION
- On IVI app exit working must use tizen API, so improve exit method to support both IVI and android platform

Unit test on platforms IVI and android, the app can exit successfully.