### PR TITLE
[webapi][XWALK-3323] Fix improper tct-package-tizen-tests input values

### DIFF
--- a/webapi/tct-package-tizen-tests/package/support/unitcommon.js
+++ b/webapi/tct-package-tizen-tests/package/support/unitcommon.js
@@ -116,17 +116,18 @@ function getTypeConversionExceptions(conversionType, isOptional) {
     switch (conversionType) {
         case "enum":
             conversionTable = [
-                [undefined, exceptionName],
-                [null, exceptionName],
                 [0, exceptionName],
                 [true, exceptionName],
                 ["dummyInvalidEnumValue", exceptionName],
                 [{ }, exceptionName]
             ];
+            if (!isOptional) {
+                conversionTable.push([null, exceptionName]);
+                conversionTable.push([undefined, exceptionName]);
+            }
             break;
         case "double":
             conversionTable = [
-                [undefined, exceptionName],
                 [NaN, exceptionName],
                 [Number.POSITIVE_INFINITY, exceptionName],
                 [Number.NEGATIVE_INFINITY, exceptionName],
@@ -134,6 +135,9 @@ function getTypeConversionExceptions(conversionType, isOptional) {
                 [{ name : "TIZEN" }, exceptionName],
                 [function () { }, exceptionName]
             ];
+            if (!isOptional) {
+                conversionTable.push([undefined, exceptionName]);
+            }
             break;
         case "object":
             conversionTable = [
@@ -142,11 +146,11 @@ function getTypeConversionExceptions(conversionType, isOptional) {
                 [NaN, exceptionName],
                 [0, exceptionName],
                 ["", exceptionName],
-                ["TIZEN", exceptionName],
-                [undefined, exceptionName]
+                ["TIZEN", exceptionName]
             ];
             if (!isOptional) {
                 conversionTable.push([null, exceptionName]);
+                conversionTable.push([undefined, exceptionName]);
             }
             break;
         case "functionObject":
@@ -159,10 +163,10 @@ function getTypeConversionExceptions(conversionType, isOptional) {
                 ["TIZEN", exceptionName],
                 [[], exceptionName],
                 [{ }, exceptionName],
-                [undefined, exceptionName]
             ];
             if (!isOptional) {
                 conversionTable.push([null, exceptionName]);
+                conversionTable.push([undefined, exceptionName]);
             }
             break;
         case "array":
@@ -174,11 +178,11 @@ function getTypeConversionExceptions(conversionType, isOptional) {
                 ["", exceptionName],
                 ["TIZEN", exceptionName],
                 [{ }, exceptionName],
-                [function () { }, exceptionName],
-                [undefined, exceptionName]
+                [function () { }, exceptionName]
             ];
             if (!isOptional) {
                 conversionTable.push([null, exceptionName]);
+                conversionTable.push([undefined, exceptionName]);
             }
             break;
         case "dictionary":
@@ -188,11 +192,11 @@ function getTypeConversionExceptions(conversionType, isOptional) {
                 [NaN, exceptionName],
                 [0, exceptionName],
                 ["", exceptionName],
-                ["TIZEN", exceptionName],
-                [undefined, exceptionName]
+                ["TIZEN", exceptionName]
             ];
             if (!isOptional) {
                 conversionTable.push([null, exceptionName]);
+                conversionTable.push([undefined, exceptionName]);
             }
             break;
         default:


### PR DESCRIPTION
This patch fixes improper values in conversion table
which are used to validate conversion.