### PR TITLE
[cordova] Update inst.wgt.py to reflect pkgcmd -l change

### DIFF
--- a/cordova/cordova-mobilespec-android-tests/inst.wgt.py
+++ b/cordova/cordova-mobilespec-android-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/cordova/cordova-mobilespec-android-tests/inst.xpk.py
+++ b/cordova/cordova-mobilespec-android-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/cordova/cordova-sampleapp-android-tests/inst.wgt.py
+++ b/cordova/cordova-sampleapp-android-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/cordova/cordova-sampleapp-android-tests/inst.xpk.py
+++ b/cordova/cordova-sampleapp-android-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,19 +66,11 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
-
 
 def doRemoteCMD(cmd=None):
     if PARAMETERS.mode == "SDB":

--- a/cordova/cordova-webapp-android-tests/inst.wgt.py
+++ b/cordova/cordova-webapp-android-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/cordova/cordova-webapp-android-tests/inst.xpk.py
+++ b/cordova/cordova-webapp-android-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 


### PR DESCRIPTION
- The latest IVI image changes the output of 'pkgcmd -l'
- Use key "pkg_name" and "pkgid" to get package id
- Removing trailing space from inst.wgt.py files