### PR TITLE
[wrt] Update inst.wgt.py to reflect pkgcmd -l change

### DIFF
--- a/wrt/tct-appwgt-wrt-tests/inst.wgt.py
+++ b/wrt/tct-appwgt-wrt-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/tct-appwgt-wrt-tests/inst.xpk.py
+++ b/wrt/tct-appwgt-wrt-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/tct-appwgt-wrt-tests/scripts/xwalk_common.sh
+++ b/wrt/tct-appwgt-wrt-tests/scripts/xwalk_common.sh
@@ -35,8 +35,7 @@ function install_app(){
 }
 
 function uninstall_app(){
-    pkgcmd -l >/tmp/apps.txt 2>&1
-    pkgids=`cat /tmp/apps.txt | grep $1 | awk '{print $4}'`
+    pkgids=`pkgcmd -l |grep $1 |awk -F "pkgid" '{print $2}' |awk -F '[' '{print $2}'|awk -F ']' '{print $1}'`
     pkgids=${pkgids:1:-1}
     for pkgid in $pkgids
     do
@@ -45,8 +44,7 @@ function uninstall_app(){
 }
 
 function find_app(){
-    pkgcmd -l >/tmp/apps.txt 2>&1
-    pkgids=`cat /tmp/apps.txt | grep $1 | head -n 1| awk -F '[],[]' '{print $4}'`
+    pkgids=`pkgcmd -l |grep $1 |awk -F "pkgid" '{print $2}' |awk -F '[' '{print $2}'|awk -F ']' '{print $1}'`
     appid=`app_launcher -l | grep $1 | head -n 1| awk  '{print $2}'`
     appid=${appid:1:-1}
 }

--- a/wrt/tct-ext01-wrt-tests/inst.wgt.py
+++ b/wrt/tct-ext01-wrt-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/tct-ext01-wrt-tests/inst.xpk.py
+++ b/wrt/tct-ext01-wrt-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/tct-ext02-wrt-tests/inst.wgt.py
+++ b/wrt/tct-ext02-wrt-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/tct-ext02-wrt-tests/inst.xpk.py
+++ b/wrt/tct-ext02-wrt-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/tct-ext02-wrt-tests/scripts/Common
+++ b/wrt/tct-ext02-wrt-tests/scripts/Common
@@ -99,8 +99,7 @@ function func_check()
 
 ##usage: uninstall_app $app_name(e.g. uninstall_app tct-sp02-wrt-tests)##
 function uninstall_app(){
-    pkgcmd -l >/tmp/apps.txt 2>&1
-    pkgids=`cat /tmp/apps.txt | grep $1 | awk -F '[],[]' '{print $4}'`
+    pkgids=`pkgcmd -l |grep $1 |awk -F "pkgid" '{print $2}' |awk -F '[' '{print $2}'|awk -F ']' '{print $1}'`
     for pkgid in $pkgids
     do
         pkgcmd -u -t wgt -q -n $pkgid
@@ -109,8 +108,7 @@ function uninstall_app(){
 
 ##usage: find_app $app_name(e.g. find_app tct-sp02-wrt-tests)##
 function find_app(){
-    pkgcmd -l >/tmp/apps.txt 2>&1
-    pkgids=`cat /tmp/apps.txt | grep $1 | awk -F '[],[]' '{print $4}'`
+    pkgids=`pkgcmd -l |grep $1 |awk -F "pkgid" '{print $2}' |awk -F '[' '{print $2}'|awk -F ']' '{print $1}'`
     appid=`app_launcher -l | grep $1 | head -n 1| awk  '{print $2}'`
     appid=${appid:1:-1}
 }

--- a/wrt/tct-pm-wrt-tests/inst.wgt.py
+++ b/wrt/tct-pm-wrt-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/tct-pm-wrt-tests/inst.xpk.py
+++ b/wrt/tct-pm-wrt-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/tct-pm-wrt-tests/scripts/xwalk_common.sh
+++ b/wrt/tct-pm-wrt-tests/scripts/xwalk_common.sh
@@ -37,7 +37,7 @@ function install_app(){
 
 ##usage: uninstall_app $app_name(e.g. uninstall_app tct-sp02-wrt-tests)##
 function uninstall_app(){
-    pkgids=`pkgcmd -l | grep $1 | awk -F '[],[]' '{print $4}'`
+    pkgids=`pkgcmd -l |grep $1 |awk -F "pkgid" '{print $2}' |awk -F '[' '{print $2}'|awk -F ']' '{print $1}'`
     for pkgid in $pkgids
     do
         pkgcmd -u -n $pkgid -q
@@ -51,7 +51,7 @@ function find_appid(){
 }
 
 function find_app(){
-    pkgids=`pkgcmd -l | grep $1 | awk -F '[],[]' '{print $4}'`
+    pkgids=`pkgcmd -l |grep $1 |awk -F "pkgid" '{print $2}' |awk -F '[' '{print $2}'|awk -F ']' '{print $1}'`
 }
 
 

--- a/wrt/tct-rt01-wrt-tests/inst.wgt.py
+++ b/wrt/tct-rt01-wrt-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/tct-rt01-wrt-tests/inst.xpk.py
+++ b/wrt/tct-rt01-wrt-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/tct-rt02-wrt-tests/inst.wgt.py
+++ b/wrt/tct-rt02-wrt-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/tct-rt02-wrt-tests/inst.xpk.py
+++ b/wrt/tct-rt02-wrt-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/tct-rt02-wrt-tests/scripts/xwalk_common.sh
+++ b/wrt/tct-rt02-wrt-tests/scripts/xwalk_common.sh
@@ -37,7 +37,7 @@ function install_app(){
 
 ##usage: uninstall_app $app_name(e.g. uninstall_app tct-sp02-wrt-tests)##
 function uninstall_app(){
-    pkgids=`pkgcmd -l | grep $1 | awk -F '[\],\[]' '{print $4}'`
+    pkgids=`pkgcmd -l |grep $1 |awk -F "pkgid" '{print $2}' |awk -F '[' '{print $2}'|awk -F ']' '{print $1}'`
     for pkgid in $pkgids
     do
         pkgcmd -u -n $pkgid -q
@@ -51,7 +51,7 @@ function find_appid(){
 }
 
 function find_app(){
-    pkgids=`pkgcmd -l | grep $1 | awk -F '[\],\[]' '{print $4}'`
+    pkgids=`pkgcmd -l |grep $1 |awk -F "pkgid" '{print $2}' |awk -F '[' '{print $2}'|awk -F ']' '{print $1}'`
 }
 
 

--- a/wrt/tct-sp01-wrt-tests/inst.wgt.py
+++ b/wrt/tct-sp01-wrt-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/tct-sp01-wrt-tests/inst.xpk.py
+++ b/wrt/tct-sp01-wrt-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/tct-sp02-wrt-tests/inst.wgt.py
+++ b/wrt/tct-sp02-wrt-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/tct-sp02-wrt-tests/inst.xpk.py
+++ b/wrt/tct-sp02-wrt-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/tct-sp02-wrt-tests/scripts/xwalk_common.sh
+++ b/wrt/tct-sp02-wrt-tests/scripts/xwalk_common.sh
@@ -37,7 +37,7 @@ function install_app(){
 
 ##usage: uninstall_app $app_name(e.g. uninstall_app tct-sp02-wrt-tests)##
 function uninstall_app(){
-    pkgids=`pkgcmd -l | grep $1 | awk -F '[],[]' '{print $4}'`
+    pkgids=`pkgcmd -l |grep $1 |awk -F "pkgid" '{print $2}' |awk -F '[' '{print $2}'|awk -F ']' '{print $1}'`
     for pkgid in $pkgids
     do
         pkgcmd -u -n $pkgid -q
@@ -51,7 +51,7 @@ function find_appid(){
 }
 
 function find_app(){
-    pkgids=`pkgcmd -l | grep $1 | awk -F '[],[]' '{print $4}'`
+    pkgids=`pkgcmd -l |grep $1 |awk -F "pkgid" '{print $2}' |awk -F '[' '{print $2}'|awk -F ']' '{print $1}'`
 }
 
 

--- a/wrt/tct-sp03-wrt-tests/inst.wgt.py
+++ b/wrt/tct-sp03-wrt-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/tct-sp03-wrt-tests/inst.xpk.py
+++ b/wrt/tct-sp03-wrt-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/tct-stab-wrt-tests/inst.wgt.py
+++ b/wrt/tct-stab-wrt-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/tct-stab-wrt-tests/inst.xpk.py
+++ b/wrt/tct-stab-wrt-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/tct-stab-wrt-tests/scripts/xwalk_common.sh
+++ b/wrt/tct-stab-wrt-tests/scripts/xwalk_common.sh
@@ -37,7 +37,7 @@ function install_app(){
 
 ##usage: uninstall_app $app_name(e.g. uninstall_app tct-sp02-wrt-tests)##
 function uninstall_app(){
-    pkgids=`pkgcmd -l | grep $1 | awk -F '[\],\[]' '{print $4}'`
+    pkgids=`pkgcmd -l |grep $1 |awk -F "pkgid" '{print $2}' |awk -F '[' '{print $2}'|awk -F ']' '{print $1}'`
     for pkgid in $pkgids
     do
         pkgcmd -u -n $pkgid -q
@@ -51,7 +51,7 @@ function find_appid(){
 }
 
 function find_app(){
-    pkgids=`pkgcmd -l | grep $1 | awk -F '[\],\[]' '{print $4}'`
+    pkgids=`pkgcmd -l |grep $1 |awk -F "pkgid" '{print $2}' |awk -F '[' '{print $2}'|awk -F ']' '{print $1}'`
 }
 
 

--- a/wrt/tct-ui01-wrt-tests/inst.wgt.py
+++ b/wrt/tct-ui01-wrt-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/tct-ui01-wrt-tests/inst.xpk.py
+++ b/wrt/tct-ui01-wrt-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-audiopolicymanu-tizen-tests/inst.wgt.py
+++ b/wrt/wrt-audiopolicymanu-tizen-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-audiopolicymanu-tizen-tests/inst.xpk.py
+++ b/wrt/wrt-audiopolicymanu-tizen-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-commandline-tizen-tests/inst.wgt.py
+++ b/wrt/wrt-commandline-tizen-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-commandline-tizen-tests/inst.xpk.py
+++ b/wrt/wrt-commandline-tizen-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-commandlinemanu-tizen-tests/inst.wgt.py
+++ b/wrt/wrt-commandlinemanu-tizen-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-commandlinemanu-tizen-tests/inst.xpk.py
+++ b/wrt/wrt-commandlinemanu-tizen-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-coreshellmanu-android-tests/inst.wgt.py
+++ b/wrt/wrt-coreshellmanu-android-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-coreshellmanu-android-tests/inst.xpk.py
+++ b/wrt/wrt-coreshellmanu-android-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-digitalsign-tizen-tests/inst.wgt.py
+++ b/wrt/wrt-digitalsign-tizen-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-digitalsign-tizen-tests/inst.xpk.py
+++ b/wrt/wrt-digitalsign-tizen-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-extension-android-tests/inst.wgt.py
+++ b/wrt/wrt-extension-android-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-extension-android-tests/inst.xpk.py
+++ b/wrt/wrt-extension-android-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-extensionmanu-android-tests/inst.wgt.py
+++ b/wrt/wrt-extensionmanu-android-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-extensionmanu-android-tests/inst.xpk.py
+++ b/wrt/wrt-extensionmanu-android-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-googleplay-android-tests/inst.wgt.py
+++ b/wrt/wrt-googleplay-android-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-googleplay-android-tests/inst.xpk.py
+++ b/wrt/wrt-googleplay-android-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-i18nmanu-tizen-tests/inst.wgt.py
+++ b/wrt/wrt-i18nmanu-tizen-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-i18nmanu-tizen-tests/inst.xpk.py
+++ b/wrt/wrt-i18nmanu-tizen-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-internetstdmanu-android-tests/inst.wgt.py
+++ b/wrt/wrt-internetstdmanu-android-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-internetstdmanu-android-tests/inst.xpk.py
+++ b/wrt/wrt-internetstdmanu-android-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-manifest-tizen-tests/inst.wgt.py
+++ b/wrt/wrt-manifest-tizen-tests/inst.wgt.py
@@ -45,10 +45,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -110,16 +110,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-manifest-tizen-tests/inst.xpk.py
+++ b/wrt/wrt-manifest-tizen-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-manifest-tizen-tests/script/appinstall.sh
+++ b/wrt/wrt-manifest-tizen-tests/script/appinstall.sh
@@ -12,8 +12,7 @@ exit 1
 else
 echo $back
 #get installed app id
-pkgids=`pkgcmd -l | grep $1 | awk '{print $4}'`
-pkgids=`echo $pkgids | awk '{print $1}'`
+pkgids=`pkgcmd -l |grep $1 |awk -F "pkgid" '{print $2}' |awk -F '[' '{print $2}'|awk -F ']' '{print $1}'`
 pkgids=${pkgids:1:-1}
 echo $pkgids
 pkgids=""

--- a/wrt/wrt-manifestmanu-android-tests/inst.wgt.py
+++ b/wrt/wrt-manifestmanu-android-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-manifestmanu-android-tests/inst.xpk.py
+++ b/wrt/wrt-manifestmanu-android-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-packagemgt-android-tests/inst.wgt.py
+++ b/wrt/wrt-packagemgt-android-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-packagemgt-android-tests/inst.xpk.py
+++ b/wrt/wrt-packagemgt-android-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-packagemgt-tizen-tests/inst.wgt.py
+++ b/wrt/wrt-packagemgt-tizen-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-packagemgt-tizen-tests/inst.xpk.py
+++ b/wrt/wrt-packagemgt-tizen-tests/inst.xpk.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-packagemgtmanu-android-tests/inst.wgt.py
+++ b/wrt/wrt-packagemgtmanu-android-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-packagemgtmanu-android-tests/inst.xpk.py
+++ b/wrt/wrt-packagemgtmanu-android-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-packagemgtmanu-tizen-tests/inst.wgt.py
+++ b/wrt/wrt-packagemgtmanu-tizen-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-packagemgtmanu-tizen-tests/inst.xpk.py
+++ b/wrt/wrt-packagemgtmanu-tizen-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-packertool-tizen-tests/inst.wgt.py
+++ b/wrt/wrt-packertool-tizen-tests/inst.wgt.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -109,16 +109,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-packertool-tizen-tests/inst.xpk.py
+++ b/wrt/wrt-packertool-tizen-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-packertoolmanu-android-tests/inst.wgt.py
+++ b/wrt/wrt-packertoolmanu-android-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-packertoolmanu-android-tests/inst.xpk.py
+++ b/wrt/wrt-packertoolmanu-android-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-rtbin-tizen-tests/inst.wgt.py
+++ b/wrt/wrt-rtbin-tizen-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-rtbin-tizen-tests/inst.xpk.py
+++ b/wrt/wrt-rtbin-tizen-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-rtcoremanu-android-tests/inst.wgt.py
+++ b/wrt/wrt-rtcoremanu-android-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-rtcoremanu-android-tests/inst.xpk.py
+++ b/wrt/wrt-rtcoremanu-android-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-securitymanu-android-tests/inst.wgt.py
+++ b/wrt/wrt-securitymanu-android-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-securitymanu-android-tests/inst.xpk.py
+++ b/wrt/wrt-securitymanu-android-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-securitymanu-tizen-tests/inst.wgt.py
+++ b/wrt/wrt-securitymanu-tizen-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-securitymanu-tizen-tests/inst.xpk.py
+++ b/wrt/wrt-securitymanu-tizen-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-sharedmode-android-tests/inst.wgt.py
+++ b/wrt/wrt-sharedmode-android-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-sharedmode-android-tests/inst.xpk.py
+++ b/wrt/wrt-sharedmode-android-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-sharedmodemanu-android-tests/inst.wgt.py
+++ b/wrt/wrt-sharedmodemanu-android-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-sharedmodemanu-android-tests/inst.xpk.py
+++ b/wrt/wrt-sharedmodemanu-android-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-uxmanu-android-tests/inst.wgt.py
+++ b/wrt/wrt-uxmanu-android-tests/inst.wgt.py
@@ -43,10 +43,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -65,16 +65,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 

--- a/wrt/wrt-uxmanu-android-tests/inst.xpk.py
+++ b/wrt/wrt-uxmanu-android-tests/inst.xpk.py
@@ -44,10 +44,10 @@ def updateCMD(cmd=None):
     return cmd
 def getUSERID():
     if PARAMETERS.mode == "SDB":
-        cmd = "sdb -s %s shell id -u %s" % ( 
+        cmd = "sdb -s %s shell id -u %s" % (
             PARAMETERS.device, PARAMETERS.user)
     else:
-        cmd = "ssh %s \"id -u %s\"" % ( 
+        cmd = "ssh %s \"id -u %s\"" % (
             PARAMETERS.device, PARAMETERS.user )
     return doCMD(cmd)
 
@@ -66,16 +66,9 @@ def getPKGID(pkg_name=None):
 
     test_pkg_id = None
     for line in output:
-        pkg_infos = line.split()
-        if len(pkg_infos) == 4:
-            continue
-        name = pkg_infos[5]
-        name = name.lstrip('[').rstrip(']')
-        print "name is: %s" % name
-        if pkg_name == name:
-            test_pkg_id = pkg_infos[3]
-            test_pkg_id = test_pkg_id.lstrip('[').rstrip(']')
-            print test_pkg_id
+        if line.find("[" + pkg_name + "]") != -1:
+            pkgidIndex = line.split().index("pkgid")
+            test_pkg_id = line.split()[pkgidIndex+1].strip("[]")
             break
     return test_pkg_id
 


### PR DESCRIPTION
- The latest IVI image changes the output of 'pkgcmd -l'
- Use key "pkg_name" and "pkgid" to get package id
- Removing trailing space from inst.wgt.py files