### PR TITLE
[webapi] Update tests from manual to auto for websocket

### DIFF
--- a/webapi/tct-websocket-w3c-tests/tests.full.xml
+++ b/webapi/tct-websocket-w3c-tests/tests.full.xml
@@ -171,7 +171,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="BinaryType_wrong_value" onload_delay="10" priority="P2" purpose="Check if Secure WebSocket created when the binaryType is set to something other than blob/arraybuffer" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="BinaryType_wrong_value" onload_delay="10" priority="P2" purpose="Check if Secure WebSocket created when the binaryType is set to something other than blob/arraybuffer" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/binaryType-wrong-value.htm</test_script_entry>
         </description>
@@ -363,7 +363,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Close_2999_reason" onload_delay="10" priority="P2" purpose="Check if the desired exception thrown when WebSocket.close has the arguments 2999 and reason" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Close_2999_reason" onload_delay="10" priority="P2" purpose="Check if the desired exception thrown when WebSocket.close has the arguments 2999 and reason" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-2999-reason.htm</test_script_entry>
         </description>
@@ -435,7 +435,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Close_null" onload_delay="10" priority="P2" purpose="Check if the desired exception thrown when the WebSocket.close secure has an argument null" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Close_null" onload_delay="10" priority="P2" purpose="Check if the desired exception thrown when the WebSocket.close secure has an argument null" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-null.htm</test_script_entry>
         </description>
@@ -447,7 +447,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Close_onlyReason" onload_delay="10" priority="P2" purpose="Check if the desired exception thrown when the WebSocket.close secure only has an argument by reason" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Close_onlyReason" onload_delay="10" priority="P2" purpose="Check if the desired exception thrown when the WebSocket.close secure only has an argument by reason" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-onlyReason.htm</test_script_entry>
         </description>
@@ -459,7 +459,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Close_undefined" onload_delay="10" priority="P2" purpose="Check if the desired exception thrown when the WebSocket.close secure has an argument undefined" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Close_undefined" onload_delay="10" priority="P2" purpose="Check if the desired exception thrown when the WebSocket.close secure has an argument undefined" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-undefined.htm</test_script_entry>
         </description>
@@ -1131,7 +1131,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Close_Reason_124Bytes" onload_delay="10" priority="P2" purpose="Check if the desired exception thrown when the WebSocket.close reason length is more than 123 bytes" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Close_Reason_124Bytes" onload_delay="10" priority="P2" purpose="Check if the desired exception thrown when the WebSocket.close reason length is more than 123 bytes" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-Reason-124Bytes.htm</test_script_entry>
         </description>
@@ -1143,7 +1143,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Close_0" onload_delay="10" priority="P2" purpose="Check if the desired exception thrown when the WebSocket.close secure has an argument 0" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Close_0" onload_delay="10" priority="P2" purpose="Check if the desired exception thrown when the WebSocket.close secure has an argument 0" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-0.htm</test_script_entry>
         </description>
@@ -1155,7 +1155,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Close_1005" onload_delay="10" priority="P2" purpose="Check if the desired exception thrown when the WebSocket.close secure has an argument 1005" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Close_1005" onload_delay="10" priority="P2" purpose="Check if the desired exception thrown when the WebSocket.close secure has an argument 1005" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-1005.htm</test_script_entry>
         </description>
@@ -1179,7 +1179,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Send_65K_data" onload_delay="10" priority="P2" purpose="Check if Secure WebSocket when Send 65K data" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_65K_data" onload_delay="10" priority="P2" purpose="Check if Secure WebSocket when Send 65K data" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-65K-data.htm</test_script_entry>
         </description>
@@ -1202,7 +1202,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="create_secure_valid_url_protocol_string" onload_delay="10" priority="P2" purpose="Check if connection can be opened or closed after open or close a secure WebSocket with a valid URL and protocol string" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="create_secure_valid_url_protocol_string" onload_delay="10" priority="P2" purpose="Check if connection can be opened or closed after open or close a secure WebSocket with a valid URL and protocol string" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-Secure-valid-url-protocol-string.htm</test_script_entry>
         </description>
@@ -1213,7 +1213,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="secure_close_server_initiated_close" onload_delay="10" priority="P2" purpose="Check if the connnection works when open or close a secure WebSocket with server initiated close" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_close_server_initiated_close" onload_delay="10" priority="P2" purpose="Check if the connnection works when open or close a secure WebSocket with server initiated close" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-server-initiated-close.htm</test_script_entry>
         </description>
@@ -1224,7 +1224,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="secure_close_4999_reason" onload_delay="10" priority="P2" purpose="Check if the connection works when open or close a secure WebSocket with 4999 code and reason" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_close_4999_reason" onload_delay="10" priority="P2" purpose="Check if the connection works when open or close a secure WebSocket with 4999 code and reason" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-4999-reason.htm</test_script_entry>
         </description>
@@ -1246,7 +1246,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="create_secure_extensions_empty" onload_delay="10" priority="P2" purpose="Check if the websocket connection with an empty extension can be opened or closed successfully" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="create_secure_extensions_empty" onload_delay="10" priority="P2" purpose="Check if the websocket connection with an empty extension can be opened or closed successfully" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-Secure-extensions-empty.htm</test_script_entry>
         </description>
@@ -1257,7 +1257,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="secure_send_null" onload_delay="10" priority="P2" purpose="Check if null can be received when null data send on a Secure WebSocket" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_send_null" onload_delay="10" priority="P2" purpose="Check if null can be received when null data send on a Secure WebSocket" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-null.htm</test_script_entry>
         </description>
@@ -1268,7 +1268,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="create_secure_valid_url_binarytype_blob" onload_delay="10" priority="P2" purpose="Check if a open secure WebSocket which binaryType should be set to 'blob' after connection is established." status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="create_secure_valid_url_binarytype_blob" onload_delay="10" priority="P2" purpose="Check if a open secure WebSocket which binaryType should be set to 'blob' after connection is established." status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-Secure-valid-url-binaryType-blob.htm</test_script_entry>
         </description>
@@ -1301,7 +1301,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="secure_send_binary_blob" onload_delay="10" priority="P2" purpose="Check if binary data should be received in blob form when binary data in blob form send on a Secure Websocket" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_send_binary_blob" onload_delay="10" priority="P2" purpose="Check if binary data should be received in blob form when binary data in blob form send on a Secure Websocket" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-blob.htm</test_script_entry>
         </description>
@@ -1312,7 +1312,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="create_secure_valid_url_array_protocols" onload_delay="10" priority="P2" purpose="Check if connection works when open or close a secure WebSocket with a valid URL and array of protocol strings" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="create_secure_valid_url_array_protocols" onload_delay="10" priority="P2" purpose="Check if connection works when open or close a secure WebSocket with a valid URL and array of protocol strings" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-Secure-valid-url-array-protocols.htm</test_script_entry>
         </description>
@@ -1323,7 +1323,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Send_data" onload_delay="10" priority="P2" purpose="Check if data can be received after send data on a Secure WebSocket" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_data" onload_delay="10" priority="P2" purpose="Check if data can be received after send data on a Secure WebSocket" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-data.htm</test_script_entry>
         </description>
@@ -1334,7 +1334,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="secure_close_3000_reason" onload_delay="10" priority="P2" purpose="Check if the desired wsocket.readyState is equal to 3 and evt.wasClean is true if the websocket call the method close(3000)" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_close_3000_reason" onload_delay="10" priority="P2" purpose="Check if the desired wsocket.readyState is equal to 3 and evt.wasClean is true if the websocket call the method close(3000)" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-3000-reason.htm</test_script_entry>
         </description>
@@ -1345,7 +1345,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="secure_close_readystate_closing" onload_delay="10" priority="P2" purpose="Check if readyState is 2 before onclose is fired" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_close_readystate_closing" onload_delay="10" priority="P2" purpose="Check if readyState is 2 before onclose is fired" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-readyState-Closing.htm</test_script_entry>
         </description>
@@ -1389,7 +1389,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="create_secure_valid_url" onload_delay="10" priority="P2" purpose="Check if the connection can be opened or closed after open or close a secure WebSocket with a valid URL" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="create_secure_valid_url" onload_delay="10" priority="P2" purpose="Check if the connection can be opened or closed after open or close a secure WebSocket with a valid URL" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-Secure-valid-url.htm</test_script_entry>
         </description>
@@ -1400,7 +1400,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="create_secure_valid_url_protocol_setcorrectly" onload_delay="10" priority="P2" purpose="Check if protocol is set correctly after connection" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="create_secure_valid_url_protocol_setcorrectly" onload_delay="10" priority="P2" purpose="Check if protocol is set correctly after connection" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-Secure-valid-url-protocol-setCorrectly.htm</test_script_entry>
         </description>
@@ -1422,7 +1422,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="secure_close_1000" onload_delay="10" priority="P2" purpose="Check if readystate can be in CLOSED state and wasClean is TRUE after close a secure WebSocket with 1000 code" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_close_1000" onload_delay="10" priority="P2" purpose="Check if readystate can be in CLOSED state and wasClean is TRUE after close a secure WebSocket with 1000 code" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-1000.htm</test_script_entry>
         </description>
@@ -1433,7 +1433,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="secure_close_readystate_closed" onload_delay="10" priority="P2" purpose="Check if readyState is in closed state when onclose is fired" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_close_readystate_closed" onload_delay="10" priority="P2" purpose="Check if readyState is in closed state when onclose is fired" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-readyState-Closed.htm</test_script_entry>
         </description>
@@ -1444,7 +1444,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="secure_close_1000_reason" onload_delay="10" priority="P2" purpose="Check if readystate should be in CLOSED state and wasClean is TRUE after close a secure WebSocket with 1000 code and reason" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_close_1000_reason" onload_delay="10" priority="P2" purpose="Check if readystate should be in CLOSED state and wasClean is TRUE after close a secure WebSocket with 1000 code and reason" status="approved" type="compliance">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-1000-reason.htm</test_script_entry>
         </description>
@@ -1514,7 +1514,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Close_1000_verify_code" onload_delay="10" priority="P2" purpose="Check if the return code is 1000 when close a secure WebSocket with 1000 code" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Close_1000_verify_code" onload_delay="10" priority="P2" purpose="Check if the return code is 1000 when close a secure WebSocket with 1000 code" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-1000-verify-code.htm</test_script_entry>
         </description>
@@ -1526,7 +1526,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Close_1005_verify_code" onload_delay="10" priority="P2" purpose="Check if the return code is 1005 when close a secure WebSocket with 1005 code" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Close_1005_verify_code" onload_delay="10" priority="P2" purpose="Check if the return code is 1005 when close a secure WebSocket with 1005 code" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-1005-verify-code.htm</test_script_entry>
         </description>
@@ -1538,7 +1538,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Close_3000_verify_code" onload_delay="10" priority="P2" purpose="Check if the return code is 3000 when close a secure WebSocket with 3000 code" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Close_3000_verify_code" onload_delay="10" priority="P2" purpose="Check if the return code is 3000 when close a secure WebSocket with 3000 code" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-3000-verify-code.htm</test_script_entry>
         </description>
@@ -1550,7 +1550,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Send_binary_65K_arraybuffer" onload_delay="10" priority="P2" purpose="Check if 65 byte data can be received after Send 65K binary data on a Secure Websocket" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_65K_arraybuffer" onload_delay="10" priority="P2" purpose="Check if 65 byte data can be received after Send 65K binary data on a Secure Websocket" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-65K-arraybuffer.htm</test_script_entry>
         </description>
@@ -1562,7 +1562,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Send_binary_arraybuffer" onload_delay="10" priority="P2" purpose="Check if binary data should be received when binary data send on a Secure Websocket" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_arraybuffer" onload_delay="10" priority="P2" purpose="Check if binary data should be received when binary data send on a Secure Websocket" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybuffer.htm</test_script_entry>
         </description>
@@ -1574,7 +1574,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Send_paired_surrogates" onload_delay="10" priority="P2" purpose="Check if paired surrogates data should be received when paired surrogates data send on a Secure Websocket" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_paired_surrogates" onload_delay="10" priority="P2" purpose="Check if paired surrogates data should be received when paired surrogates data send on a Secure Websocket" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-paired-surrogates.htm</test_script_entry>
         </description>
@@ -1586,7 +1586,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Send_unicode_data" onload_delay="10" priority="P2" purpose="Check if unicode data message should be received when unicode data send on a Secure Websocket" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_unicode_data" onload_delay="10" priority="P2" purpose="Check if unicode data message should be received when unicode data send on a Secure Websocket" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-unicode-data.htm</test_script_entry>
         </description>
@@ -1682,7 +1682,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Send_binary_arraybufferview_float64" onload_delay="5" priority="P2" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Float64Array type" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_arraybufferview_float64" onload_delay="5" priority="P2" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Float64Array type" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybufferview-float64.htm</test_script_entry>
         </description>
@@ -1694,7 +1694,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Send_binary_arraybufferview_int32" onload_delay="5" priority="P2" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Int32Array type " status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_arraybufferview_int32" onload_delay="5" priority="P2" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Int32Array type " status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybufferview-int32.htm</test_script_entry>
         </description>
@@ -1706,7 +1706,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Send_binary_arraybufferview_uint8_offset" onload_delay="5" priority="P2" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Uint8Array type with offset " status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_arraybufferview_uint8_offset" onload_delay="5" priority="P2" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Uint8Array type with offset " status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybufferview-uint8-offset.htm</test_script_entry>
         </description>
@@ -1718,7 +1718,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Send_binary_arraybufferview_uint8_offset_length" onload_delay="5" priority="P2" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Uint8Array type with offset and length " status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_arraybufferview_uint8_offset_length" onload_delay="5" priority="P2" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Uint8Array type with offset and length " status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybufferview-uint8-offset-length.htm</test_script_entry>
         </description>
@@ -1730,7 +1730,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Send_binary_arraybufferview_uint16_offset_length" onload_delay="5" priority="P2" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Uint16Array type with offset and length" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_arraybufferview_uint16_offset_length" onload_delay="5" priority="P2" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Uint16Array type with offset and length" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybufferview-uint16-offset-length.htm</test_script_entry>
         </description>
@@ -1742,7 +1742,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Send_binary_arraybufferview_uint32_offset" onload_delay="5" priority="P2" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Uint32Array type with offset" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_arraybufferview_uint32_offset" onload_delay="5" priority="P2" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Uint32Array type with offset" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybufferview-uint32-offset.htm</test_script_entry>
         </description>
@@ -2786,7 +2786,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Unload-a-document_001" priority="P1" purpose="Check if can navigate top-level browsing context" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Unload-a-document_001" priority="P1" purpose="Check if can navigate top-level browsing context" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/unload-a-document/001.html</test_script_entry>
         </description>

--- a/webapi/tct-websocket-w3c-tests/tests.xml
+++ b/webapi/tct-websocket-w3c-tests/tests.xml
@@ -73,7 +73,7 @@
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/websocket_WebSocket_binaryType_exists.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="BinaryType_wrong_value" onload_delay="10" purpose="Check if Secure WebSocket created when the binaryType is set to something other than blob/arraybuffer">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="BinaryType_wrong_value" onload_delay="10" purpose="Check if Secure WebSocket created when the binaryType is set to something other than blob/arraybuffer">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/binaryType-wrong-value.htm</test_script_entry>
         </description>
@@ -153,7 +153,7 @@
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Close-0.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Close_2999_reason" onload_delay="10" purpose="Check if the desired exception thrown when WebSocket.close has the arguments 2999 and reason">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Close_2999_reason" onload_delay="10" purpose="Check if the desired exception thrown when WebSocket.close has the arguments 2999 and reason">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-2999-reason.htm</test_script_entry>
         </description>
@@ -183,17 +183,17 @@
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/websocket_WebSocket_close_reason_null.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Close_null" onload_delay="10" purpose="Check if the desired exception thrown when the WebSocket.close secure has an argument null">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Close_null" onload_delay="10" purpose="Check if the desired exception thrown when the WebSocket.close secure has an argument null">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-null.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Close_onlyReason" onload_delay="10" purpose="Check if the desired exception thrown when the WebSocket.close secure only has an argument by reason">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Close_onlyReason" onload_delay="10" purpose="Check if the desired exception thrown when the WebSocket.close secure only has an argument by reason">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-onlyReason.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Close_undefined" onload_delay="10" purpose="Check if the desired exception thrown when the WebSocket.close secure has an argument undefined">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Close_undefined" onload_delay="10" purpose="Check if the desired exception thrown when the WebSocket.close secure has an argument undefined">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-undefined.htm</test_script_entry>
         </description>
@@ -473,17 +473,17 @@
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Create-Secure-blocked-port.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Close_Reason_124Bytes" onload_delay="10" purpose="Check if the desired exception thrown when the WebSocket.close reason length is more than 123 bytes">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Close_Reason_124Bytes" onload_delay="10" purpose="Check if the desired exception thrown when the WebSocket.close reason length is more than 123 bytes">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-Reason-124Bytes.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Close_0" onload_delay="10" purpose="Check if the desired exception thrown when the WebSocket.close secure has an argument 0">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Close_0" onload_delay="10" purpose="Check if the desired exception thrown when the WebSocket.close secure has an argument 0">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-0.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Close_1005" onload_delay="10" purpose="Check if the desired exception thrown when the WebSocket.close secure has an argument 1005">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Close_1005" onload_delay="10" purpose="Check if the desired exception thrown when the WebSocket.close secure has an argument 1005">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-1005.htm</test_script_entry>
         </description>
@@ -493,7 +493,7 @@
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Send-before-open.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Send_65K_data" onload_delay="10" purpose="Check if Secure WebSocket when Send 65K data">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_65K_data" onload_delay="10" purpose="Check if Secure WebSocket when Send 65K data">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-65K-data.htm</test_script_entry>
         </description>
@@ -503,17 +503,17 @@
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Send-65K-data.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="create_secure_valid_url_protocol_string" onload_delay="10" purpose="Check if connection can be opened or closed after open or close a secure WebSocket with a valid URL and protocol string">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="create_secure_valid_url_protocol_string" onload_delay="10" purpose="Check if connection can be opened or closed after open or close a secure WebSocket with a valid URL and protocol string">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-Secure-valid-url-protocol-string.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="secure_close_server_initiated_close" onload_delay="10" purpose="Check if the connnection works when open or close a secure WebSocket with server initiated close">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_close_server_initiated_close" onload_delay="10" purpose="Check if the connnection works when open or close a secure WebSocket with server initiated close">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-server-initiated-close.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="secure_close_4999_reason" onload_delay="10" purpose="Check if the connection works when open or close a secure WebSocket with 4999 code and reason">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_close_4999_reason" onload_delay="10" purpose="Check if the connection works when open or close a secure WebSocket with 4999 code and reason">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-4999-reason.htm</test_script_entry>
         </description>
@@ -523,17 +523,17 @@
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-valid-url-protocol.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="create_secure_extensions_empty" onload_delay="10" purpose="Check if the websocket connection with an empty extension can be opened or closed successfully">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="create_secure_extensions_empty" onload_delay="10" purpose="Check if the websocket connection with an empty extension can be opened or closed successfully">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-Secure-extensions-empty.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="secure_send_null" onload_delay="10" purpose="Check if null can be received when null data send on a Secure WebSocket">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_send_null" onload_delay="10" purpose="Check if null can be received when null data send on a Secure WebSocket">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-null.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="create_secure_valid_url_binarytype_blob" onload_delay="10" purpose="Check if a open secure WebSocket which binaryType should be set to 'blob' after connection is established.">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="create_secure_valid_url_binarytype_blob" onload_delay="10" purpose="Check if a open secure WebSocket which binaryType should be set to 'blob' after connection is established.">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-Secure-valid-url-binaryType-blob.htm</test_script_entry>
         </description>
@@ -548,27 +548,27 @@
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-valid-url-protocol-empty.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="secure_send_binary_blob" onload_delay="10" purpose="Check if binary data should be received in blob form when binary data in blob form send on a Secure Websocket">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_send_binary_blob" onload_delay="10" purpose="Check if binary data should be received in blob form when binary data in blob form send on a Secure Websocket">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-blob.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="create_secure_valid_url_array_protocols" onload_delay="10" purpose="Check if connection works when open or close a secure WebSocket with a valid URL and array of protocol strings">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="create_secure_valid_url_array_protocols" onload_delay="10" purpose="Check if connection works when open or close a secure WebSocket with a valid URL and array of protocol strings">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-Secure-valid-url-array-protocols.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Send_data" onload_delay="10" purpose="Check if data can be received after send data on a Secure WebSocket">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_data" onload_delay="10" purpose="Check if data can be received after send data on a Secure WebSocket">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-data.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="secure_close_3000_reason" onload_delay="10" purpose="Check if the desired wsocket.readyState is equal to 3 and evt.wasClean is true if the websocket call the method close(3000)">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_close_3000_reason" onload_delay="10" purpose="Check if the desired wsocket.readyState is equal to 3 and evt.wasClean is true if the websocket call the method close(3000)">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-3000-reason.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="secure_close_readystate_closing" onload_delay="10" purpose="Check if readyState is 2 before onclose is fired">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_close_readystate_closing" onload_delay="10" purpose="Check if readyState is 2 before onclose is fired">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-readyState-Closing.htm</test_script_entry>
         </description>
@@ -588,12 +588,12 @@
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Send-null.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="create_secure_valid_url" onload_delay="10" purpose="Check if the connection can be opened or closed after open or close a secure WebSocket with a valid URL">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="create_secure_valid_url" onload_delay="10" purpose="Check if the connection can be opened or closed after open or close a secure WebSocket with a valid URL">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-Secure-valid-url.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="create_secure_valid_url_protocol_setcorrectly" onload_delay="10" purpose="Check if protocol is set correctly after connection">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="create_secure_valid_url_protocol_setcorrectly" onload_delay="10" purpose="Check if protocol is set correctly after connection">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Create-Secure-valid-url-protocol-setCorrectly.htm</test_script_entry>
         </description>
@@ -603,17 +603,17 @@
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Close-1000-reason.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="secure_close_1000" onload_delay="10" purpose="Check if readystate can be in CLOSED state and wasClean is TRUE after close a secure WebSocket with 1000 code">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_close_1000" onload_delay="10" purpose="Check if readystate can be in CLOSED state and wasClean is TRUE after close a secure WebSocket with 1000 code">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-1000.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="secure_close_readystate_closed" onload_delay="10" purpose="Check if readyState is in closed state when onclose is fired">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_close_readystate_closed" onload_delay="10" purpose="Check if readyState is in closed state when onclose is fired">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-readyState-Closed.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="secure_close_1000_reason" onload_delay="10" purpose="Check if readystate should be in CLOSED state and wasClean is TRUE after close a secure WebSocket with 1000 code and reason">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="secure_close_1000_reason" onload_delay="10" purpose="Check if readystate should be in CLOSED state and wasClean is TRUE after close a secure WebSocket with 1000 code and reason">
         <description>
           <test_script_entry test_script_expected_result="0">/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-1000-reason.htm</test_script_entry>
         </description>
@@ -643,37 +643,37 @@
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Create-verify-url-set-non-default-port.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Close_1000_verify_code" onload_delay="10" purpose="Check if the return code is 1000 when close a secure WebSocket with 1000 code">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Close_1000_verify_code" onload_delay="10" purpose="Check if the return code is 1000 when close a secure WebSocket with 1000 code">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-1000-verify-code.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Close_1005_verify_code" onload_delay="10" purpose="Check if the return code is 1005 when close a secure WebSocket with 1005 code">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Close_1005_verify_code" onload_delay="10" purpose="Check if the return code is 1005 when close a secure WebSocket with 1005 code">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-1005-verify-code.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Close_3000_verify_code" onload_delay="10" purpose="Check if the return code is 3000 when close a secure WebSocket with 3000 code">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Close_3000_verify_code" onload_delay="10" purpose="Check if the return code is 3000 when close a secure WebSocket with 3000 code">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Close-3000-verify-code.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Send_binary_65K_arraybuffer" onload_delay="10" purpose="Check if 65 byte data can be received after Send 65K binary data on a Secure Websocket">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_65K_arraybuffer" onload_delay="10" purpose="Check if 65 byte data can be received after Send 65K binary data on a Secure Websocket">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-65K-arraybuffer.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Send_binary_arraybuffer" onload_delay="10" purpose="Check if binary data should be received when binary data send on a Secure Websocket">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_arraybuffer" onload_delay="10" purpose="Check if binary data should be received when binary data send on a Secure Websocket">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybuffer.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Send_paired_surrogates" onload_delay="10" purpose="Check if paired surrogates data should be received when paired surrogates data send on a Secure Websocket">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_paired_surrogates" onload_delay="10" purpose="Check if paired surrogates data should be received when paired surrogates data send on a Secure Websocket">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-paired-surrogates.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Send_unicode_data" onload_delay="10" purpose="Check if unicode data message should be received when unicode data send on a Secure Websocket">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_unicode_data" onload_delay="10" purpose="Check if unicode data message should be received when unicode data send on a Secure Websocket">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-unicode-data.htm</test_script_entry>
         </description>
@@ -713,32 +713,32 @@
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybufferview-float32.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Send_binary_arraybufferview_float64" onload_delay="5" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Float64Array type">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_arraybufferview_float64" onload_delay="5" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Float64Array type">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybufferview-float64.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Send_binary_arraybufferview_int32" onload_delay="5" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Int32Array type ">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_arraybufferview_int32" onload_delay="5" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Int32Array type ">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybufferview-int32.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Send_binary_arraybufferview_uint8_offset" onload_delay="5" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Uint8Array type with offset ">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_arraybufferview_uint8_offset" onload_delay="5" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Uint8Array type with offset ">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybufferview-uint8-offset.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Send_binary_arraybufferview_uint8_offset_length" onload_delay="5" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Uint8Array type with offset and length ">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_arraybufferview_uint8_offset_length" onload_delay="5" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Uint8Array type with offset and length ">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybufferview-uint8-offset-length.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Send_binary_arraybufferview_uint16_offset_length" onload_delay="5" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Uint16Array type with offset and length">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_arraybufferview_uint16_offset_length" onload_delay="5" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Uint16Array type with offset and length">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybufferview-uint16-offset-length.htm</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Secure_Send_binary_arraybufferview_uint32_offset" onload_delay="5" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Uint32Array type with offset">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Secure_Send_binary_arraybufferview_uint32_offset" onload_delay="5" purpose="Check if the connection can be opened, closed and the message can be received if send binary data on a WebSocket with ArrayBufferView of Uint32Array type with offset">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/Secure-Send-binary-arraybufferview-uint32-offset.htm</test_script_entry>
         </description>
@@ -1173,7 +1173,7 @@
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/interfaces/WebSocket/send/009.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="manual" id="Unload-a-document_001" purpose="Check if can navigate top-level browsing context">
+      <testcase component="W3C_HTML5 APIs/Communication/The WebSocket API" execution_type="auto" id="Unload-a-document_001" purpose="Check if can navigate top-level browsing context">
         <description>
           <test_script_entry>/opt/tct-websocket-w3c-tests/websocket/w3c/unload-a-document/001.html</test_script_entry>
         </description>


### PR DESCRIPTION
- Change 'execution_type' from 'manual' to 'auto'
- Failure analysis: https://crosswalk-project.org/jira/browse/XWALK-1791

Impacted tests(approved): new 0, update 39, delete 0
Unit test platform: [Android]
Unit test result summary: pass 37, fail 1, block 1