### PR TITLE
[webapi][XWALK-3201] Update the function setup parameter

### DIFF
--- a/webapi/tct-audio-html5-tests/audio/w3c/audio_loop_base.html
+++ b/webapi/tct-audio-html5-tests/audio/w3c/audio_loop_base.html
@@ -17,7 +17,7 @@
         var media = document.getElementById("m");
         var name = document.getElementsByName("assert")[0].content;
         var t = async_test(name);
-        setup({timeout:300000});
+        setup({explicit_timeout:true});
         
         var looped = false;
 


### PR DESCRIPTION
- The testharness.js have updated to the latest, and the function setup changed.
- Function setup accept "explicit_timeout:true", case run no time limit in these way.
- The default timeout time is 10s, if case run time more than 10s, it will lead to block.
- Unfortunately setup can't set timeout value by itself again, there are only 10s or no time limit.

Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: [android] crosswalk-10.38.222
Unit test result summary: pass 1, fail 0, block 0