### PR TITLE
[webapi][XWALK-2955] Update background-001-ref.xht reftest file

### DIFF
--- a/webapi/tct-backgrounds-css3-tests/backgrounds/csswg/background-001-ref.xht
+++ b/webapi/tct-backgrounds-css3-tests/backgrounds/csswg/background-001-ref.xht
@@ -1,20 +1,14 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-
-<html xmlns="http://www.w3.org/1999/xhtml">
-
- <head>
-
-  <title>CSS Reftest Reference</title>
-
-  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
-
- </head>
-
- <body>
-
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reftest Reference</title>
+<link rel="author" title="Intel" href="http://www.intel.com">
+<style type="text/css">
+  div {
+    background: url(support/60x60-green.png);
+    height: 50px;
+  }
+</style>
+<body>
   <p>Test passes if there is a filled green rectangle across the page.</p>
-
-  <div><img src="support/1x1-green.png" width="100%" height="50" alt="Image download support must be enabled" /></div>
-
- </body>
-</html>
+  <div></div>
+</body>


### PR DESCRIPTION
- Because the previous picture used in reftest file is inconsistent with origin tests.

Impacted tests(approved):new 0,update 9,delete 0 
Unit test platform:[android] 
Unit test result summary:pass 0,fail 9,block 0