### PR TITLE
[webapi][XWALK-3117] Add tests to SIMD

### DIFF
--- a/webapi/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/ecmascript_simd_tests.js
+++ b/webapi/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/ecmascript_simd_tests.js
@@ -873,3 +873,78 @@ test('View on Float32x4Array', function() {
   equal(a.getAt(3).z, 15);
   equal(a.getAt(3).w, 16);
 });
+
+test('int32x4 shiftLeftByScalar', function() {
+var a = SIMD.int32x4(0xffffffff, 0x7fffffff, 0x1, 0x0);
+var b;
+b = SIMD.int32x4.shiftLeftByScalar(a, 1);
+equal(b.x, 0xfffffffe|0);
+equal(b.y, 0xfffffffe|0);
+equal(b.z, 0x00000002);
+equal(b.w, 0x00000000);
+b = SIMD.int32x4.shiftLeftByScalar(a, 2);
+equal(b.x, 0xfffffffc|0);
+equal(b.y, 0xfffffffc|0);
+equal(b.z, 0x00000004);
+equal(b.w, 0x00000000);
+b = SIMD.int32x4.shiftLeftByScalar(a, 30);
+equal(b.x, 0xc0000000|0);
+equal(b.y, 0xc0000000|0);
+equal(b.z, 0x40000000);
+equal(b.w, 0x00000000);
+b = SIMD.int32x4.shiftLeftByScalar(a, 31);
+equal(b.x, 0x80000000|0);
+equal(b.y, 0x80000000|0);
+equal(b.z, 0x80000000|0);
+equal(b.w, 0x0);
+});
+
+test('int32x4 shiftRightLogicalByScalar', function() {
+var a = SIMD.int32x4(0xffffffff, 0x7fffffff, 0x1, 0x0);
+var b;
+b = SIMD.int32x4.shiftRightLogicalByScalar(a, 1);
+equal(b.x, 0x7fffffff);
+equal(b.y, 0x3fffffff);
+equal(b.z, 0x00000000);
+equal(b.w, 0x00000000);
+b = SIMD.int32x4.shiftRightLogicalByScalar(a, 2);
+equal(b.x, 0x3fffffff);
+equal(b.y, 0x1fffffff);
+equal(b.z, 0x00000000);
+equal(b.w, 0x00000000);
+b = SIMD.int32x4.shiftRightLogicalByScalar(a, 30);
+equal(b.x, 0x00000003);
+equal(b.y, 0x00000001);
+equal(b.z, 0x00000000);
+equal(b.w, 0x00000000);
+b = SIMD.int32x4.shiftRightLogicalByScalar(a, 31);
+equal(b.x, 0x00000001);
+equal(b.y, 0x00000000);
+equal(b.z, 0x00000000);
+equal(b.w, 0x00000000);
+});
+
+test('int32x4 shiftRightArithmeticByScalar', function() {
+var a = SIMD.int32x4(0xffffffff, 0x7fffffff, 0x1, 0x0);
+var b;
+b = SIMD.int32x4.shiftRightArithmeticByScalar(a, 1);
+equal(b.x, 0xffffffff|0);
+equal(b.y, 0x3fffffff);
+equal(b.z, 0x00000000);
+equal(b.w, 0x00000000);
+b = SIMD.int32x4.shiftRightArithmeticByScalar(a, 2);
+equal(b.x, 0xffffffff|0);
+equal(b.y, 0x1fffffff);
+equal(b.z, 0x00000000);
+equal(b.w, 0x00000000);
+b = SIMD.int32x4.shiftRightArithmeticByScalar(a, 30);
+equal(b.x, 0xffffffff|0);
+equal(b.y, 0x00000001);
+equal(b.z, 0x00000000);
+equal(b.w, 0x00000000);
+b = SIMD.int32x4.shiftRightArithmeticByScalar(a, 31);
+equal(b.x, 0xffffffff|0);
+equal(b.y, 0x00000000);
+equal(b.z, 0x00000000);
+equal(b.w, 0x00000000);
+});

--- a/webapi/webapi-simd-nonw3c-tests/tests.full.xml
+++ b/webapi/webapi-simd-nonw3c-tests/tests.full.xml
@@ -591,6 +591,42 @@
           </spec>
         </specs>
       </testcase>
+      <testcase component="Supplementary APIs/SIMD" execution_type="auto" id="int32x4_shiftLeftByScalar" priority="P1" purpose="Check shiftLeftByScalar method of int32x4 is valid" status="approved" subcase="16" type="compliance">
+        <description>
+          <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=50</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion category="SIMD" element_name="int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
+            <spec_statement />
+          </spec>
+        </specs>
+      </testcase>
+      <testcase component="Supplementary APIs/SIMD" execution_type="auto" id="int32x4_shiftRightLogicalByScalar" priority="P1" purpose="Check shiftRightLogicalByScalar method of int32x4 is valid" status="approved" subcase="16" type="compliance">
+        <description>
+          <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=51</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion category="SIMD" element_name="int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
+            <spec_statement />
+          </spec>
+        </specs>
+      </testcase>
+      <testcase component="Supplementary APIs/SIMD" execution_type="auto" id="int32x4_shiftRightArithmeticByScalar" priority="P1" purpose="Check shiftRightArithmeticByScalar method of int32x4 is valid" status="approved" subcase="16" type="compliance">
+        <description>
+          <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=52</test_script_entry>
+        </description>
+        <specs>
+          <spec>
+            <spec_assertion category="SIMD" element_name="int32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
+            <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
+            <spec_statement />
+          </spec>
+        </specs>
+      </testcase>
       <testcase component="Supplementary APIs/SIMD" execution_type="auto" id="Float32x4_zero" priority="P1" purpose="Check if the zero function of float32x4 can change the parameter to 0.0." status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float32x4.html?testNumber=1</test_script_entry>

--- a/webapi/webapi-simd-nonw3c-tests/tests.xml
+++ b/webapi/webapi-simd-nonw3c-tests/tests.xml
@@ -248,6 +248,21 @@
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=49</test_script_entry>
         </description>
       </testcase>
+      <testcase component="Supplementary APIs/SIMD" execution_type="auto" id="int32x4_shiftLeftByScalar" purpose="Check shiftLeftByScalar method of int32x4 is valid" subcase="16">
+        <description>
+          <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=50</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Supplementary APIs/SIMD" execution_type="auto" id="int32x4_shiftRightLogicalByScalar" purpose="Check shiftRightLogicalByScalar method of int32x4 is valid" subcase="16">
+        <description>
+          <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=51</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Supplementary APIs/SIMD" execution_type="auto" id="int32x4_shiftRightArithmeticByScalar" purpose="Check shiftRightArithmeticByScalar method of int32x4 is valid" subcase="16">
+        <description>
+          <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=52</test_script_entry>
+        </description>
+      </testcase>
       <testcase component="Supplementary APIs/SIMD" execution_type="auto" id="Float32x4_zero" purpose="Check if the zero function of float32x4 can change the parameter to 0.0." subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/float32x4.html?testNumber=1</test_script_entry>


### PR DESCRIPTION
- SIMD.js API spec adds "ByScalar" to shift operations, add tests to test the new feature.
- Fail Reasion: the new feature is not supported now.

Impacted TCs num: New 48, Update 0, Delete 0
Unit test Platform: Andriod
Unit test result summary: Pass 0, Fail 48, Blocked 0