### PR TITLE
[webapi][XWALK-2955] Update background-size-30.html test

### DIFF
--- a/webapi/tct-backgrounds-css3-tests/backgrounds/csswg/background-size-030.html
+++ b/webapi/tct-backgrounds-css3-tests/backgrounds/csswg/background-size-030.html
@@ -27,7 +27,7 @@
     </style>
   </head>
   <body>
-    <p>Test passes if there is 4 rows of 4 blue-and-orange squares and if there is <strong>no partially</strong> displayed squares and <strong>no red</strong>.</p>
+    <p>Test passes if there is 4 rows of 4 blue-and-orange squares and if there is <strong>no partially</strong> displayed square and <strong>no red</strong>.</p>
 
     <div></div>
   </body>


### PR DESCRIPTION
- Change the word squares to square in this test so that it can share a same reftest with other tests. 

Impacted tests(approved): new 0, update 1, delete 0 
Unit test platform: [TizenIVI] 
Unit test result summary: pass 0, fail 1, block 0 