### PR TITLE
Fix unitcommon for application tests

### DIFF
--- a/webapi/tct-application-tizen-tests/application/support/TCTAppControl/resources/unitcommon.js
+++ b/webapi/tct-application-tizen-tests/application/support/TCTAppControl/resources/unitcommon.js
@@ -116,17 +116,18 @@ function getTypeConversionExceptions(conversionType, isOptional) {
     switch (conversionType) {
         case "enum":
             conversionTable = [
-                [undefined, exceptionName],
-                [null, exceptionName],
                 [0, exceptionName],
                 [true, exceptionName],
                 ["dummyInvalidEnumValue", exceptionName],
                 [{ }, exceptionName]
             ];
+            if (!isOptional) {
+                conversionTable.push([null, exceptionName]);
+                conversionTable.push([undefined, exceptionName]);
+            }
             break;
         case "double":
             conversionTable = [
-                [undefined, exceptionName],
                 [NaN, exceptionName],
                 [Number.POSITIVE_INFINITY, exceptionName],
                 [Number.NEGATIVE_INFINITY, exceptionName],
@@ -134,6 +135,10 @@ function getTypeConversionExceptions(conversionType, isOptional) {
                 [{ name : "TIZEN" }, exceptionName],
                 [function () { }, exceptionName]
             ];
+            if (!isOptional) {
+                conversionTable.push([null, exceptionName]);
+                conversionTable.push([undefined, exceptionName]);
+            }
             break;
         case "object":
             conversionTable = [
@@ -142,11 +147,11 @@ function getTypeConversionExceptions(conversionType, isOptional) {
                 [NaN, exceptionName],
                 [0, exceptionName],
                 ["", exceptionName],
-                ["TIZEN", exceptionName],
-                [undefined, exceptionName]
+                ["TIZEN", exceptionName]
             ];
             if (!isOptional) {
                 conversionTable.push([null, exceptionName]);
+                conversionTable.push([undefined, exceptionName]);
             }
             break;
         case "functionObject":
@@ -158,11 +163,11 @@ function getTypeConversionExceptions(conversionType, isOptional) {
                 ["", exceptionName],
                 ["TIZEN", exceptionName],
                 [[], exceptionName],
-                [{ }, exceptionName],
-                [undefined, exceptionName]
+                [{ }, exceptionName]
             ];
             if (!isOptional) {
                 conversionTable.push([null, exceptionName]);
+                conversionTable.push([undefined, exceptionName]);
             }
             break;
         case "array":
@@ -174,11 +179,11 @@ function getTypeConversionExceptions(conversionType, isOptional) {
                 ["", exceptionName],
                 ["TIZEN", exceptionName],
                 [{ }, exceptionName],
-                [function () { }, exceptionName],
-                [undefined, exceptionName]
+                [function () { }, exceptionName]
             ];
             if (!isOptional) {
                 conversionTable.push([null, exceptionName]);
+                conversionTable.push([undefined, exceptionName]);
             }
             break;
         case "dictionary":
@@ -188,11 +193,11 @@ function getTypeConversionExceptions(conversionType, isOptional) {
                 [NaN, exceptionName],
                 [0, exceptionName],
                 ["", exceptionName],
-                ["TIZEN", exceptionName],
-                [undefined, exceptionName]
+                ["TIZEN", exceptionName]
             ];
             if (!isOptional) {
                 conversionTable.push([null, exceptionName]);
+                conversionTable.push([undefined, exceptionName]);
             }
             break;
         default:

--- a/webapi/tct-application-tizen-tests/application/support/unitcommon.js
+++ b/webapi/tct-application-tizen-tests/application/support/unitcommon.js
@@ -116,17 +116,18 @@ function getTypeConversionExceptions(conversionType, isOptional) {
     switch (conversionType) {
         case "enum":
             conversionTable = [
-                [undefined, exceptionName],
-                [null, exceptionName],
                 [0, exceptionName],
                 [true, exceptionName],
                 ["dummyInvalidEnumValue", exceptionName],
                 [{ }, exceptionName]
             ];
+            if (!isOptional) {
+                conversionTable.push([null, exceptionName]);
+                conversionTable.push([undefined, exceptionName]);
+            }
             break;
         case "double":
             conversionTable = [
-                [undefined, exceptionName],
                 [NaN, exceptionName],
                 [Number.POSITIVE_INFINITY, exceptionName],
                 [Number.NEGATIVE_INFINITY, exceptionName],
@@ -134,6 +135,10 @@ function getTypeConversionExceptions(conversionType, isOptional) {
                 [{ name : "TIZEN" }, exceptionName],
                 [function () { }, exceptionName]
             ];
+            if (!isOptional) {
+                conversionTable.push([null, exceptionName]);
+                conversionTable.push([undefined, exceptionName]);
+            }
             break;
         case "object":
             conversionTable = [
@@ -142,11 +147,11 @@ function getTypeConversionExceptions(conversionType, isOptional) {
                 [NaN, exceptionName],
                 [0, exceptionName],
                 ["", exceptionName],
-                ["TIZEN", exceptionName],
-                [undefined, exceptionName]
+                ["TIZEN", exceptionName]
             ];
             if (!isOptional) {
                 conversionTable.push([null, exceptionName]);
+                conversionTable.push([undefined, exceptionName]);
             }
             break;
         case "functionObject":
@@ -158,11 +163,11 @@ function getTypeConversionExceptions(conversionType, isOptional) {
                 ["", exceptionName],
                 ["TIZEN", exceptionName],
                 [[], exceptionName],
-                [{ }, exceptionName],
-                [undefined, exceptionName]
+                [{ }, exceptionName]
             ];
             if (!isOptional) {
                 conversionTable.push([null, exceptionName]);
+                conversionTable.push([undefined, exceptionName]);
             }
             break;
         case "array":
@@ -174,11 +179,11 @@ function getTypeConversionExceptions(conversionType, isOptional) {
                 ["", exceptionName],
                 ["TIZEN", exceptionName],
                 [{ }, exceptionName],
-                [function () { }, exceptionName],
-                [undefined, exceptionName]
+                [function () { }, exceptionName]
             ];
             if (!isOptional) {
                 conversionTable.push([null, exceptionName]);
+                conversionTable.push([undefined, exceptionName]);
             }
             break;
         case "dictionary":
@@ -188,11 +193,11 @@ function getTypeConversionExceptions(conversionType, isOptional) {
                 [NaN, exceptionName],
                 [0, exceptionName],
                 ["", exceptionName],
-                ["TIZEN", exceptionName],
-                [undefined, exceptionName]
+                ["TIZEN", exceptionName]
             ];
             if (!isOptional) {
                 conversionTable.push([null, exceptionName]);
+                conversionTable.push([undefined, exceptionName]);
             }
             break;
         default:


### PR DESCRIPTION
Passing explicitly undefined to function should not throw.
Therefore test should accept passing undefined.

Follow:
https://lists.w3.org/Archives/Public/public-script-coord/2015JanMar/0012.html

This is same case as in PR:
https://github.com/crosswalk-project/crosswalk-test-suite/pull/1610

BUG=XWALK-3395