### PR TITLE
[webapi] Remove accelerometer capability in CSS MediaQueries

### DIFF
--- a/webapi/tct-mediaqueries-css3-tests/tests.full.xml
+++ b/webapi/tct-mediaqueries-css3-tests/tests.full.xml
@@ -3,9 +3,6 @@
 <test_definition>
   <suite category="W3C/HTML5 APIs" name="tct-mediaqueries-css3-tests">
     <set name="CSS3MediaQueries" type="js">
-      <capabilities>
-        <capability name="accelerometer" />
-      </capabilities>
       <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/Media Queries (Partial)" execution_type="auto" id="CSS3MQ_width_min-width_positive_max-width_positive" priority="P1" purpose="Set '(min-width:400px) and (max-width:700px)' on CSS3 Media Queries width attribute, when the browser width is between 400px and 700px, the text will displays in red" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_width_min-width_positive_max-width_positive.html</test_script_entry>

--- a/webapi/tct-mediaqueries-css3-tests/tests.xml
+++ b/webapi/tct-mediaqueries-css3-tests/tests.xml
@@ -3,9 +3,6 @@
 <test_definition>
   <suite category="W3C/HTML5 APIs" name="tct-mediaqueries-css3-tests">
     <set name="CSS3MediaQueries" type="js">
-      <capabilities>
-        <capability name="accelerometer" />
-      </capabilities>
       <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/Media Queries (Partial)" execution_type="auto" id="CSS3MQ_width_min-width_positive_max-width_positive" purpose="Set '(min-width:400px) and (max-width:700px)' on CSS3 Media Queries width attribute, when the browser width is between 400px and 700px, the text will displays in red">
         <description>
           <test_script_entry>/opt/tct-mediaqueries-css3-tests/mediaqueries/CSS3MQ_width_min-width_positive_max-width_positive.html</test_script_entry>


### PR DESCRIPTION
- CSS MediaQueries does not need depend on 'accelerometer' capability, remove it from tests xml

Impacted tests(approved): new 0, update 0, delete 0
Unit test platform:[Tizen]
Unit test result summary: pass 52, fail 0, block 0