### PR TITLE
[usecase] Fix bug result appears exception for usecase

### DIFF
--- a/tools/bootstrap-fw/js/list.js
+++ b/tools/bootstrap-fw/js/list.js
@@ -81,7 +81,7 @@ function listTest() {
     $('#mytest').append(testline);
   }
   if(passnum == 0 && failnum == 0)
-    passnum == failnum == "";
+    passnum = failnum = "";
   var setresarr = {totalnum:totalnum, passnum:passnum, failnum:failnum};
   lstorage.setItem(sid + "res", JSON.stringify(setresarr));
 }


### PR DESCRIPTION
- When first time launch usecase, enter 'Security' set then back, result of 'Security' appears. But when enter 'CSP' then back, result disappears. Fix this bug.