### PR TITLE
[embeddingapi][XWalk-3318] Improve embeddingapi cases

### DIFF
--- a/embeddingapi/embedding-api-android-tests/embeddingapi/AndroidManifest.xml
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/AndroidManifest.xml
@@ -19,7 +19,7 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    
+    <uses-permission android:name="android.permission.DISABLE_KEYGUARD"/>
     
     
       <instrumentation

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/assets/echo.html
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/assets/echo.html
@@ -5,9 +5,15 @@
 <body>
 <script>
 try {
-    echo.echo("Pass", function() {
-            document.title = "Pass";
-        });
+  var d = new Date().toString();
+  echo.echo(d, function(msg) {
+    var expected = "From java:" + d;
+    if (msg === expected) {
+      document.title = "Pass";
+    } else {
+      document.title = "Fail";
+    }
+  });
 } catch(e) {
     console.log(e);
     document.title = "Fail";

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/assets/external.js
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/assets/external.js
@@ -1,0 +1,3 @@
+function functionInTest() {
+    document.title="testLoadExternalJs_ChangeTitle";
+}

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/assets/externalJs.html
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/assets/externalJs.html
@@ -1,0 +1,11 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>Crosswalk Sample Application</title>
+<Javascript src="external.js"></javascript>
+</script>
+</head>
+<body>
+  Hello World.
+</body>
+</html>

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/assets/framesEcho.html
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/assets/framesEcho.html
@@ -7,7 +7,6 @@
     <iframe id="subFrame"></iframe>
     <script>
       var iframe = document.getElementById("subFrame");
-
       iframe.contentDocument.write("<html>\n"
         + " <head>\n"
         + " <script>\n"

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/assets/innerJs.html
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/assets/innerJs.html
@@ -1,0 +1,15 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>Crosswalk Sample Application</title>
+<!--<Javascript src="external.js"></javascript>-->
+<script type="text/javascript">
+function functionInTest() {
+    document.title="testLoadExternalJs_ChangeTitle";
+}
+</script>
+</head>
+<body>
+  Hello World.
+</body>
+</html>

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/MainActivity.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/MainActivity.java
@@ -5,11 +5,18 @@
 package org.xwalk.embedding;
 
 
+import org.xwalk.core.XWalkPreferences;
 import org.xwalk.core.XWalkView;
 import org.xwalk.embedding.test.R;
 
 import android.app.Activity;
+import android.app.KeyguardManager;
+import android.app.KeyguardManager.KeyguardLock;
+import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
+import android.os.PowerManager;
+import android.os.PowerManager.WakeLock;
 
 public class MainActivity extends Activity {
 
@@ -25,5 +32,33 @@ public class MainActivity extends Activity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.xwview_layout);
         mXWalkView = (XWalkView) findViewById(R.id.xwalkview);
+        XWalkPreferences.setValue(XWalkPreferences.SUPPORT_MULTIPLE_WINDOWS, true);
+
+        PowerManager pm = (PowerManager)getSystemService(POWER_SERVICE);
+        WakeLock mWakelock = pm.newWakeLock(PowerManager.ACQUIRE_CAUSES_WAKEUP |PowerManager.SCREEN_DIM_WAKE_LOCK, "SimpleTimer");
+        mWakelock.acquire();
+        mWakelock.release();
+
+        KeyguardManager keyguardManager = (KeyguardManager)getSystemService(KEYGUARD_SERVICE);
+        KeyguardLock keyguardLock = keyguardManager.newKeyguardLock("");
+        keyguardLock.disableKeyguard();
+    }
+
+    public Context getContent() {
+        return MainActivity.this;
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if (mXWalkView != null) {
+            mXWalkView.onActivityResult(requestCode, resultCode, data);
+        }
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        if (mXWalkView != null) {
+            mXWalkView.onNewIntent(intent);
+        }
     }
 }

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/TestXWalkResourceClientBase.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/TestXWalkResourceClientBase.java
@@ -1,0 +1,54 @@
+package org.xwalk.embedding.base;
+
+import org.xwalk.core.XWalkResourceClient;
+import org.xwalk.core.XWalkView;
+
+import android.net.http.SslError;
+import android.webkit.ValueCallback;
+import android.webkit.WebResourceResponse;
+
+public class TestXWalkResourceClientBase extends XWalkResourceClient{
+    TestHelperBridge mInnerContentsClient;
+    public TestXWalkResourceClientBase(TestHelperBridge client, XWalkView mXWalkView) {
+        super(mXWalkView);
+        mInnerContentsClient = client;
+    }
+
+    @Override
+    public void onLoadStarted(XWalkView view, String url) {
+        mInnerContentsClient.onLoadStarted(url);
+    }
+
+    @Override
+    public void onLoadFinished(XWalkView view, String url) {
+        mInnerContentsClient.onLoadFinished(url);
+    }
+
+    @Override
+    public void onProgressChanged(XWalkView view, int progressInPercent) {
+        mInnerContentsClient.onProgressChanged(progressInPercent);
+    }
+
+    @Override
+    public void onReceivedLoadError(XWalkView view, int errorCode,
+            String description, String failingUrl) {
+        mInnerContentsClient.onReceivedLoadError(errorCode, description, failingUrl);
+    }
+
+    @Override
+    public WebResourceResponse shouldInterceptLoadRequest(XWalkView view,
+            String url) {
+        return mInnerContentsClient.shouldInterceptLoadRequest(url);
+    }
+
+    @Override
+    public boolean shouldOverrideUrlLoading(XWalkView view, String url) {
+        return mInnerContentsClient.shouldOverrideUrlLoading(url);
+    }
+
+    @Override
+    public void onReceivedSslError(XWalkView view,
+            ValueCallback<Boolean> callback, SslError error) {
+        mInnerContentsClient.onReceivedSsl();
+    }
+}

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/TestXWalkUIClientBase.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/TestXWalkUIClientBase.java
@@ -1,0 +1,124 @@
+package org.xwalk.embedding.base;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.chromium.content.browser.test.util.CallbackHelper;
+import org.xwalk.core.XWalkJavascriptResult;
+import org.xwalk.core.XWalkUIClient;
+import org.xwalk.core.XWalkView;
+
+import android.graphics.Bitmap;
+import android.net.Uri;
+import android.os.Message;
+import android.webkit.ValueCallback;
+
+public class TestXWalkUIClientBase extends XWalkUIClient {
+    TestHelperBridge mInnerContentsClient;
+    
+    protected final String ALERT_TEXT = "Hello World!";
+    final String CONFIRM_TEXT = "Would you like a cookie?";
+    boolean flagForConfirmCancelled = false;
+    protected final String PROMPT_TEXT = "How do you like your eggs in the morning?";
+    protected final String PROMPT_DEFAULT = "Scrambled";
+    protected final String PROMPT_RESULT = "I like mine with a kiss";
+    final CallbackHelper jsBeforeUnloadHelper = new CallbackHelper();
+    AtomicBoolean mInnerCallbackCalled;
+
+    public TestXWalkUIClientBase(TestHelperBridge client, XWalkView mXWalkView, AtomicBoolean callbackCalled) {
+        super(mXWalkView);
+        mInnerContentsClient = client;
+        mInnerCallbackCalled = callbackCalled;
+    }
+    
+    @Override
+    public void onPageLoadStarted(XWalkView view, String url) {
+        mInnerContentsClient.onPageStarted(url);
+    }
+
+    @Override
+    public void onPageLoadStopped(XWalkView view, String url, LoadStatus status) {
+        mInnerContentsClient.onPageFinished(url, status);
+    }
+
+    @Override
+    public void onReceivedTitle(XWalkView view, String title) {
+        mInnerContentsClient.onTitleChanged(title);
+    }
+
+    @Override
+    public void onJavascriptCloseWindow(XWalkView view) {
+        mInnerContentsClient.onJavascriptCloseWindow();
+    }
+
+    @Override
+    public void onScaleChanged(XWalkView view, float oldScale,
+            float newScale) {
+        mInnerContentsClient.onScaleChanged(newScale);
+    }
+
+    @Override
+    public void onRequestFocus(XWalkView view) {
+        mInnerContentsClient.onRequestFocus();
+    }
+
+    @Override
+    public boolean onCreateWindowRequested(XWalkView view,
+            InitiateBy initiator, ValueCallback<XWalkView> callback) {
+        mInnerContentsClient.onCreateWindowRequested();
+        return true;
+    }
+
+    @Override
+    public void onIconAvailable(XWalkView view, String url,
+            Message startDownload) {
+        startDownload.sendToTarget();
+        mInnerContentsClient.onIconAvailable();
+    }
+
+    @Override
+    public void onReceivedIcon(XWalkView view, String url, Bitmap icon) {
+        mInnerContentsClient.onReceivedIcon();
+    }
+
+    @Override
+    public void onFullscreenToggled(XWalkView view, boolean enterFullscreen) {
+        mInnerContentsClient.onFullscreenToggled(enterFullscreen);
+    }
+
+    @Override
+    public void openFileChooser(XWalkView view,
+            ValueCallback<Uri> uploadFile, String acceptType, String capture) {
+        mInnerContentsClient.openFileChooser(uploadFile);
+    }
+
+    @Override
+    public boolean onJavascriptModalDialog(XWalkView view, JavascriptMessageType type,
+            String url, String message, String defaultValue, XWalkJavascriptResult result) {
+        switch(type) {
+            case JAVASCRIPT_ALERT:
+                mInnerCallbackCalled.set(true);
+                result.confirm();
+                return false;
+            case JAVASCRIPT_CONFIRM:
+                if (flagForConfirmCancelled == true) {
+                    result.cancel();
+                } else {
+                    result.confirm();
+                }
+                mInnerCallbackCalled.set(true);
+                return false;
+            case JAVASCRIPT_PROMPT:
+                result.confirmWithResult(PROMPT_RESULT);
+                mInnerCallbackCalled.set(true);
+                return false;
+            case JAVASCRIPT_BEFOREUNLOAD:
+                result.cancel();
+                jsBeforeUnloadHelper.notifyCalled();
+                return false;
+            default:
+                break;
+            }
+        assert(false);
+        return false;
+    }
+}

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
@@ -23,11 +23,8 @@ import org.chromium.content.browser.test.util.Criteria;
 import org.chromium.content.browser.test.util.CriteriaHelper;
 import org.chromium.net.test.util.TestWebServer;
 import org.xwalk.core.JavascriptInterface;
-import org.xwalk.core.XWalkJavascriptResult;
 import org.xwalk.core.XWalkNavigationHistory;
 import org.xwalk.core.XWalkNavigationItem;
-import org.xwalk.core.XWalkResourceClient;
-import org.xwalk.core.XWalkUIClient;
 import org.xwalk.core.XWalkView;
 import org.xwalk.embedding.MainActivity;
 
@@ -35,14 +32,9 @@ import com.test.server.ActivityInstrumentationTestCase2;
 
 import android.content.Context;
 import android.content.res.AssetManager;
-import android.graphics.Bitmap;
-import android.net.Uri;
-import android.net.http.SslError;
 import android.os.Bundle;
-import android.os.Message;
 import android.util.Log;
 import android.util.Pair;
-import android.webkit.ValueCallback;
 import android.webkit.WebResourceResponse;
 
 public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActivity> {
@@ -541,166 +533,15 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
                                           "}");
     }
 
-    class TestXWalkUIClientBase extends XWalkUIClient {
-        TestHelperBridge mInnerContentsClient;
-        public TestXWalkUIClientBase(TestHelperBridge client) {
-            super(getXWalkView());
-            mInnerContentsClient = client;
-        }
-
-        @Override
-        public void onPageLoadStarted(XWalkView view, String url) {
-            mInnerContentsClient.onPageStarted(url);
-        }
-
-        @Override
-        public void onPageLoadStopped(XWalkView view, String url, LoadStatus status) {
-            mInnerContentsClient.onPageFinished(url, status);
-        }
-
-        @Override
-        public void onReceivedTitle(XWalkView view, String title) {
-            mInnerContentsClient.onTitleChanged(title);
-        }
-
-        @Override
-        public void onJavascriptCloseWindow(XWalkView view) {
-            mInnerContentsClient.onJavascriptCloseWindow();
-        }
-
-        @Override
-        public void onScaleChanged(XWalkView view, float oldScale,
-                float newScale) {
-            mInnerContentsClient.onScaleChanged(newScale);
-        }
-
-        @Override
-        public void onRequestFocus(XWalkView view) {
-            mInnerContentsClient.onRequestFocus();
-        }
-
-        @Override
-        public boolean onCreateWindowRequested(XWalkView view,
-                InitiateBy initiator, ValueCallback<XWalkView> callback) {
-            mInnerContentsClient.onCreateWindowRequested();
-            return true;
-        }
-
-        @Override
-        public void onIconAvailable(XWalkView view, String url,
-                Message startDownload) {
-            startDownload.sendToTarget();
-            mInnerContentsClient.onIconAvailable();
-        }
-
-        @Override
-        public void onReceivedIcon(XWalkView view, String url, Bitmap icon) {
-            mInnerContentsClient.onReceivedIcon();
-        }
-
-        @Override
-        public void onFullscreenToggled(XWalkView view, boolean enterFullscreen) {
-            System.out.println("test............111111");
-            mInnerContentsClient.onFullscreenToggled(enterFullscreen);
-        }
-
-        @Override
-        public void openFileChooser(XWalkView view,
-                ValueCallback<Uri> uploadFile, String acceptType, String capture) {
-            mInnerContentsClient.openFileChooser(uploadFile);
-        }
-
-        @Override
-        public boolean onJavascriptModalDialog(XWalkView view, JavascriptMessageType type,
-                String url, String message, String defaultValue, XWalkJavascriptResult result) {
-            switch(type) {
-                case JAVASCRIPT_ALERT:
-                    callbackCalled.set(true);
-                    result.confirm();
-                    assertEquals(ALERT_TEXT, message);
-                    return false;
-                case JAVASCRIPT_CONFIRM:
-                    assertEquals(CONFIRM_TEXT, message);
-                    if (flagForConfirmCancelled == true) {
-                        result.cancel();
-                    } else {
-                        result.confirm();
-                    }
-                    callbackCalled.set(true);
-                    return false;
-                case JAVASCRIPT_PROMPT:
-                    assertEquals(PROMPT_TEXT, message);
-                    assertEquals(PROMPT_DEFAULT, defaultValue);
-                    result.confirmWithResult(PROMPT_RESULT);
-                    callbackCalled.set(true);
-                    return false;
-                case JAVASCRIPT_BEFOREUNLOAD:
-                    result.cancel();
-                    jsBeforeUnloadHelper.notifyCalled();
-                    return false;
-                default:
-                    break;
-                }
-            assert(false);
-            return false;
-        }
-    }
-
     public class TestXWalkUIClient extends TestXWalkUIClientBase {
         public TestXWalkUIClient() {
-            super(mTestHelperBridge);
-        }
-    }
-
-    class TestXWalkResourceClientBase extends XWalkResourceClient {
-        TestHelperBridge mInnerContentsClient;
-        public TestXWalkResourceClientBase(TestHelperBridge client) {
-            super(mXWalkView);
-            mInnerContentsClient = client;
-        }
-
-        @Override
-        public void onLoadStarted(XWalkView view, String url) {
-            mInnerContentsClient.onLoadStarted(url);
-        }
-
-        @Override
-        public void onLoadFinished(XWalkView view, String url) {
-            mInnerContentsClient.onLoadFinished(url);
-        }
-
-        @Override
-        public void onProgressChanged(XWalkView view, int progressInPercent) {
-            mTestHelperBridge.onProgressChanged(progressInPercent);
-        }
-
-        @Override
-        public void onReceivedLoadError(XWalkView view, int errorCode,
-                String description, String failingUrl) {
-            mInnerContentsClient.onReceivedLoadError(errorCode, description, failingUrl);
-        }
-
-        @Override
-        public WebResourceResponse shouldInterceptLoadRequest(XWalkView view,
-                String url) {
-            return mInnerContentsClient.shouldInterceptLoadRequest(url);
-        }
-
-        @Override
-        public boolean shouldOverrideUrlLoading(XWalkView view, String url) {
-            return mTestHelperBridge.shouldOverrideUrlLoading(url);
-        }
-
-        @Override
-        public void onReceivedSslError(XWalkView view,
-                ValueCallback<Boolean> callback, SslError error) {
-            mInnerContentsClient.onReceivedSsl();
+            super(mTestHelperBridge, mXWalkView, callbackCalled);
         }
     }
 
     class TestXWalkResourceClient extends TestXWalkResourceClientBase {
         public TestXWalkResourceClient() {
-            super(mTestHelperBridge);
+            super(mTestHelperBridge,mXWalkView);
         }
     }
 

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v1/XWalkUIClientTest.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v1/XWalkUIClientTest.java
@@ -7,6 +7,7 @@ package org.xwalk.embedding.test.v1;
 import java.util.concurrent.TimeoutException;
 
 import org.xwalk.core.XWalkUIClient;
+import org.xwalk.embedding.base.ExtensionEcho;
 import org.xwalk.embedding.base.OnFullscreenToggledHelper;
 import org.xwalk.embedding.base.OnJavascriptCloseWindowHelper;
 import org.xwalk.embedding.base.OnRequestFocusHelper;
@@ -223,6 +224,17 @@ public class XWalkUIClientTest extends XWalkViewTestBase {
             loadDataSync(null, EMPTY_PAGE, "text/html", false);
             executeJavaScriptAndWaitForResult("alert('" + ALERT_TEXT + "')");
             assertTrue(callbackCalled.get());
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
+    @SmallTest
+    public void testOnPageFinished_write() {
+        try {
+            ExtensionEcho echo = new ExtensionEcho();
+            loadUrlSync("file:///android_asset/framesEcho.html");
         } catch (Exception e) {
             assertTrue(false);
             e.printStackTrace();

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v2/XWalkExtensionTest.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v2/XWalkExtensionTest.java
@@ -12,6 +12,7 @@ import org.xwalk.embedding.base.ExtensionEcho_broadcast;
 import org.xwalk.embedding.base.XWalkViewTestBase;
 
 import android.annotation.SuppressLint;
+import android.os.SystemClock;
 import android.test.suitebuilder.annotation.SmallTest;
 
 @SuppressLint("NewApi")
@@ -166,7 +167,7 @@ public class XWalkExtensionTest extends XWalkViewTestBase {
         try {
             ExtensionEcho echo = new ExtensionEcho();
             loadAssetFileAndWaitForTitle("echo.html");
-            assertEquals("From java:" + PASS_STRING, getTitleOnUiThread());
+            assertEquals(PASS_STRING, getTitleOnUiThread());
         } catch (Exception e) {
             e.printStackTrace();
             assertTrue(false);
@@ -249,7 +250,7 @@ public class XWalkExtensionTest extends XWalkViewTestBase {
         try {
             ExtensionEcho echo = new ExtensionEcho();
             loadAssetFileAndWaitForTitle("echo.html");
-            assertEquals("From java:" + PASS_STRING, getTitleOnUiThread());
+            assertEquals(PASS_STRING, getTitleOnUiThread());
         } catch (Exception e) {
             assertTrue(false);
             e.printStackTrace();
@@ -281,5 +282,5 @@ public class XWalkExtensionTest extends XWalkViewTestBase {
             e.printStackTrace();
         }
     }
-
 }
+

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v4/XWalkResourceClientTest.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v4/XWalkResourceClientTest.java
@@ -13,7 +13,7 @@ public class XWalkResourceClientTest extends XWalkViewTestBase {
     @SmallTest
     public void testOnReceivedSslError() {
         try {
-            String url = "https://webmail.archermind.com/";
+            String url = "https://kyfw.12306.cn/otn/regist/init";
             OnReceivedSslHelper mOnReceivedSslHelper = mTestHelperBridge.getOnReceivedSslHelper();
             int count = mOnReceivedSslHelper.getCallCount();
             loadUrlAsync(url);


### PR DESCRIPTION
- Failure analysis: When the html file useing the write js method to make page content, the onPageLoadStopped of XWalkUIClient can't be triggered

Impacted tests(approved): new 3, update 5, delete 0
Unit test platform: [Android]
Unit test result summary: pass 7, fail 1, block 0