### PR TITLE
[webapi][XWALK-3390] Improve tests for Storage quotaexceedederr

### DIFF
--- a/webapi/tct-webstorage-w3c-tests/webstorage/w3c/storage_local_setitem_quotaexceedederr.html
+++ b/webapi/tct-webstorage-w3c-tests/webstorage/w3c/storage_local_setitem_quotaexceedederr.html
@@ -2,6 +2,7 @@
 <html>
  <head>
   <title>Web Storage</title>
+  <meta name="timeout" content="long">
   <script src="../../resources/testharness.js"></script>
   <script src="../../resources/testharnessreport.js"></script>
  </head>

--- a/webapi/tct-webstorage-w3c-tests/webstorage/w3c/storage_session_setitem_quotaexceedederr.html
+++ b/webapi/tct-webstorage-w3c-tests/webstorage/w3c/storage_session_setitem_quotaexceedederr.html
@@ -2,6 +2,7 @@
 <html>
  <head>
   <title>Web Storage</title>
+  <meta name="timeout" content="long">
   <script src="../../resources/testharness.js"></script>
   <script src="../../resources/testharnessreport.js"></script>
  </head>


### PR DESCRIPTION
 - These tests need more time to waitting for result of storage_local_setitem_quotaexceedederr

Impacted tests(approved): new 0, update 2, delete 0
Unit test platform: [android]
Unit test result summary: pass 2, fail 0, block 0