### PR TITLE
[webapi][XWALK-3446] Update test logic for Rawsockets

### DIFF
--- a/webapi/webapi-rawsockets-w3c-tests/rawsockets/TCPServerSocket_method_close.html
+++ b/webapi/webapi-rawsockets-w3c-tests/rawsockets/TCPServerSocket_method_close.html
@@ -45,13 +45,9 @@ var t = async_test("Check if close the TCP server socket after calling close met
 t.step(function () {
   assert_true(!!namespace, "TCPServerSocket interface support");
   var TCPServersocket = new namespace.TCPServerSocket(socketOptions);
-  var TCPsocket = new namespace.TCPSocket(remoteAddress, remotePort);
-  TCPsocket.onopen = function () {
-    TCPServersocket.close();
-  };
-  TCPsocket.close = function () {
-    t.done();
-  };
+  TCPServersocket.close();
+  assert_equals(TCPServersocket.readyState, "closed", "Close TCPServerSocket failed");
+  t.done();
 });
 
 </script>


### PR DESCRIPTION
- The close method can not fire TCPSocket.close event, so update

Impacted TCs num(approved): New 0, Update 1, Delete 0
Unit test Platform: Andriod
Unit test result summary: Pass 1, Fail 0, Blocked 0