### PR TITLE
[webapi] Add long timeout for video

### DIFF
--- a/webapi/tct-video-html5-tests/video/w3c/video_loop_base.html
+++ b/webapi/tct-video-html5-tests/video/w3c/video_loop_base.html
@@ -6,6 +6,7 @@
     <link rel="help" href="http://dev.w3.org/html5/spec/single-page.html#dom-media-loop" />
     <meta name="flags" content="" />
     <meta name="assert" content="Check if video.loop is set to true that expecting the seeking event is fired more than once" />
+    <meta name=timeout content=long>
     <script src="../../resources/testharness.js"></script>
     <script src="../../resources/testharnessreport.js"></script>
     <script src="../../common/media.js"></script>
@@ -17,10 +18,7 @@
         var media = document.getElementById("m");
         var name = document.getElementsByName("assert")[0].content;
         var t = async_test(name);
-        setup({timeout:300000});
-        
         var looped = false;
-
         function startTest() {
             if (looped) {
                 t.step(function() {
@@ -29,10 +27,8 @@
                 t.done();
                 media.pause();
             }
-            
             looped = true;
         }
-
         media.addEventListener("seeking", startTest, false);
         media.loop = true;
         media.src = getVideoURI("../media/movie_5") + "?" + new Date() + Math.random();


### PR DESCRIPTION
- Function setup can't set timeout value by itself again in the latest testharness.js
- Add 'meta name=timeout content=long', then test run time will be 60s.

Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: [android] crosswalk-12.40.281
Unit test result summary: pass 1, fail 0, block 0