### PR TITLE
[embedding][XWALK-3631] Add cases for load js write page

### DIFF
--- a/embeddingapi/embedding-api-android-tests/embeddingapi/assets/writeContent.html
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/assets/writeContent.html
@@ -1,0 +1,10 @@
+<html>
+  <head>
+    <title></title>
+  </head>
+  <body>
+    <script>
+      document.write("Hello World !");
+    </script>
+  </body>
+</html>

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/assets/writeIfrme.html
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/assets/writeIfrme.html
@@ -1,0 +1,17 @@
+<html>
+  <head>
+    <title></title>
+  </head>
+  <body>
+    <div id="result">show test result...</div>
+    <iframe id="subFrame"></iframe>
+    <script>
+      var iframe = document.getElementById("subFrame");
+      iframe.contentDocument.write("<html>\n"
+        + "  <body>\n"
+        + "    Hello World !"
+        + "  <\/body>\n"
+        + "</html>");
+    </script>
+  </body>
+</html>

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/base/XWalkViewTestBase.java
@@ -42,6 +42,9 @@ public class XWalkViewTestBase extends ActivityInstrumentationTestCase2<MainActi
     public XWalkViewTestBase(Class<MainActivity> activityClass) {
         super(activityClass);
     }
+
+    protected final static String PASS_STRING = "Pass";
+
     protected static final String EMPTY_PAGE =
             "<!doctype html>" +
             "<title>Set User Agent String Test</title><p>Set User Agent String Test.</p>";

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v1/FullScreenTest.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v1/FullScreenTest.java
@@ -20,9 +20,10 @@ public class FullScreenTest extends XWalkViewTestBase {
             assertFalse(hasEnteredFullScreenOnUiThread());
             OnFullscreenToggledHelper mOnFullscreenToggledHelper = mTestHelperBridge.getOnFullscreenToggledHelper();
             int count = mOnFullscreenToggledHelper.getCallCount();
+            assertFalse(hasEnteredFullScreenOnUiThread());
             clickOnElementId("enter_fullscreen",null);
             mOnFullscreenToggledHelper.waitForCallback(count);
-
+            Thread.sleep(2000);
             assertTrue(hasEnteredFullScreenOnUiThread());
         } catch (Exception e) {
             assertTrue(false);
@@ -44,21 +45,21 @@ public class FullScreenTest extends XWalkViewTestBase {
             int count = mOnFullscreenToggledHelper.getCallCount();
             clickOnElementId("enter_fullscreen",null);
             mOnFullscreenToggledHelper.waitForCallback(count);
+            Thread.sleep(2000);
             assertTrue(hasEnteredFullScreenOnUiThread());
-
             count = mOnFullscreenToggledHelper.getCallCount();
             leaveFullscreenOnUiThread();
             mOnFullscreenToggledHelper.waitForCallback(count);
-
+            Thread.sleep(2000);
             assertFalse(hasEnteredFullScreenOnUiThread());
-
             count = mOnFullscreenToggledHelper.getCallCount();
             clickOnElementId("enter_fullscreen",null);
             mOnFullscreenToggledHelper.waitForCallback(count);
-
+            Thread.sleep(2000);
             count = mOnFullscreenToggledHelper.getCallCount();
             clickOnElementId("exit_fullscreen",null);
             mOnFullscreenToggledHelper.waitForCallback(count);
+            Thread.sleep(2000);
             assertFalse(hasEnteredFullScreenOnUiThread());
         } catch (Exception e) {
             assertTrue(false);

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v2/XWalkExtensionTest.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v2/XWalkExtensionTest.java
@@ -5,19 +5,20 @@
 package org.xwalk.embedding.test.v2;
 
 
+import java.util.concurrent.TimeUnit;
+
 import org.chromium.base.test.util.Feature;
 import org.xwalk.core.XWalkExtension;
 import org.xwalk.embedding.base.ExtensionEcho;
 import org.xwalk.embedding.base.ExtensionEcho_broadcast;
+import org.xwalk.embedding.base.OnTitleUpdatedHelper;
 import org.xwalk.embedding.base.XWalkViewTestBase;
 
 import android.annotation.SuppressLint;
-import android.os.SystemClock;
 import android.test.suitebuilder.annotation.SmallTest;
 
 @SuppressLint("NewApi")
 public class XWalkExtensionTest extends XWalkViewTestBase {
-    private final static String PASS_STRING = "Pass";
 
     @SmallTest
     public void testXWalkExtension() {
@@ -275,7 +276,13 @@ public class XWalkExtensionTest extends XWalkViewTestBase {
     public void testOnSyncMessage_MultiFrames() {
         try {
             ExtensionEcho echo = new ExtensionEcho();
-            loadAssetFileAndWaitForTitle("framesEcho.html");
+            String fileName = "framesEcho.html";
+            OnTitleUpdatedHelper mOnTitleUpdatedHelper = mTestHelperBridge.getOnTitleUpdatedHelper();
+            int currentCallCount = mOnTitleUpdatedHelper.getCallCount();
+            String fileContent = getFileContent(fileName);
+            loadDataAsync(fileName, fileContent, "text/html", false);
+            mOnTitleUpdatedHelper.waitForCallback(currentCallCount, 1, WAIT_TIMEOUT_SECONDS,
+                    TimeUnit.SECONDS);
             assertEquals(PASS_STRING, getTitleOnUiThread());
         } catch (Exception e) {
             assertTrue(false);

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v2/XWalkUIClientTest.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v2/XWalkUIClientTest.java
@@ -46,6 +46,36 @@ public class XWalkUIClientTest extends XWalkViewTestBase {
         }
     }
 
+    @SmallTest
+    public void testOnReceivedTitleWithWriteContent() {
+        try {
+            String testUrl = "file:///android_asset/writeContent.html";
+            OnTitleUpdatedHelper mOnTitleUpdatedHelper = mTestHelperBridge.getOnTitleUpdatedHelper();
+            int onReceivedTitleCallCount = mOnTitleUpdatedHelper.getCallCount();
+            loadUrlAsync(testUrl);
+            mOnTitleUpdatedHelper.waitForCallback(onReceivedTitleCallCount);
+            assertEquals("Test", mOnTitleUpdatedHelper.getTitle());
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
+    @SmallTest
+    public void testOnReceivedTitleWithWithWriteIfrme() {
+        try {
+            String testUrl = "file:///android_asset/writeIfrme.html";
+            OnTitleUpdatedHelper mOnTitleUpdatedHelper = mTestHelperBridge.getOnTitleUpdatedHelper();
+            int onReceivedTitleCallCount = mOnTitleUpdatedHelper.getCallCount();
+            loadUrlAsync(testUrl);
+            mOnTitleUpdatedHelper.waitForCallback(onReceivedTitleCallCount);
+            assertEquals("Test", mOnTitleUpdatedHelper.getTitle());
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
     public void testOnReceivedTitle_Callback() {
         try {
             String path = "/test.html";
@@ -213,6 +243,36 @@ public class XWalkUIClientTest extends XWalkViewTestBase {
         }
     }
 
+    @SmallTest
+    public void testOnPageLoadStartedWithWriteContent() {
+        try {
+            String testUrl = "file:///android_asset/writeContent.html";
+            OnPageStartedHelper mOnPageStartedHelper = mTestHelperBridge.getOnPageStartedHelper();
+            int currentCallCount = mOnPageStartedHelper.getCallCount();
+            loadUrlAsync(testUrl);
+            mOnPageStartedHelper.waitForCallback(currentCallCount);
+            assertEquals(testUrl, mOnPageStartedHelper.getUrl());
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
+    @SmallTest
+    public void testOnPageLoadStartedWithWithWriteIfrme() {
+        try {
+            String testUrl = "file:///android_asset/writeIfrme.html";
+            OnPageStartedHelper mOnPageStartedHelper = mTestHelperBridge.getOnPageStartedHelper();
+            int currentCallCount = mOnPageStartedHelper.getCallCount();
+            loadUrlAsync(testUrl);
+            mOnPageStartedHelper.waitForCallback(currentCallCount);
+            assertEquals(testUrl, mOnPageStartedHelper.getUrl());
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
     public void testOnPageLoadStartedWithInvalidUrl() {
         try {
             String url = "http://this.url.is.invalid/";
@@ -275,6 +335,38 @@ public class XWalkUIClientTest extends XWalkViewTestBase {
         } catch (Exception e) {
             e.printStackTrace();
             assertTrue(false);
+        }
+    }
+
+    @SmallTest
+    public void testOnPageLoadStoppedWithWriteContent() {
+        try {
+            String url = "file:///android_asset/writeContent.html";
+            OnPageFinishedHelper mOnPageFinishedHelper = mTestHelperBridge.getOnPageFinishedHelper();
+            int currentCallCount = mOnPageFinishedHelper.getCallCount();
+            loadUrlAsync(url);
+            mOnPageFinishedHelper.waitForCallback(currentCallCount);
+            assertEquals(url, mOnPageFinishedHelper.getUrl());
+            assertEquals(LoadStatus.FINISHED, mTestHelperBridge.getLoadStatus());
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
+        }
+    }
+
+    @SmallTest
+    public void testOnPageLoadStoppedWithWriteIfrme() {
+        try {
+            String url = "file:///android_asset/writeIfrme.html";
+            OnPageFinishedHelper mOnPageFinishedHelper = mTestHelperBridge.getOnPageFinishedHelper();
+            int currentCallCount = mOnPageFinishedHelper.getCallCount();
+            loadUrlAsync(url);
+            mOnPageFinishedHelper.waitForCallback(currentCallCount);
+            assertEquals(url, mOnPageFinishedHelper.getUrl());
+            assertEquals(LoadStatus.FINISHED, mTestHelperBridge.getLoadStatus());
+        } catch (Exception e) {
+            assertTrue(false);
+            e.printStackTrace();
         }
     }
 

--- a/embeddingapi/embedding-api-android-tests/tests_v2.xml
+++ b/embeddingapi/embedding-api-android-tests/tests_v2.xml
@@ -3,7 +3,7 @@
 <test_definition>
   <suite name="webapi-embeddingapi-xwalk-tests" category="Android embedding APIs">
     <set name="EmbeddingApiTest" type="androidunit" location="device">
-      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v2.XWalkUIClientTest" purpose="Check if the methods of XWalkUIClient interface can be executed correctly." subcase="18">
+      <testcase component="Crosswalk APIs/Embedding API" execution_type="auto" id="v2.XWalkUIClientTest" purpose="Check if the methods of XWalkUIClient interface can be executed correctly." subcase="24">
         <description>
           <test_script_entry>org.xwalk.embedding.test.v2.XWalkUIClientTest</test_script_entry>
         </description>


### PR DESCRIPTION
- Add cases to check if OnReceivedTitle can be triggered when load js write page
- Add cases to check if OnPageLoadStarted can be triggered when load js write page
- Improve "testOnSyncMessage_MultiFrames" case
- Failure analysis: XWALK-3564

Impacted tests(approved): new 6, update 3, delete 0
Unit test platform: [Android]
Unit test result summary: pass 8, fail 1, block 0