### PR TITLE
[webapi][XWALK-2436] Update tests for rawsockets

### DIFF
--- a/webapi/webapi-rawsockets-w3c-tests/rawsockets/UDPSocket_interface_basic.html
+++ b/webapi/webapi-rawsockets-w3c-tests/rawsockets/UDPSocket_interface_basic.html
@@ -57,8 +57,8 @@ var udpsocket = new namespace.UDPSocket();
   ["function", "close", ""],
   ["function", "suspend", ""],
   ["function", "resume", ""],
-  ["function", "joinMulticastGroup", ""],
-  ["function", "leaveMulticastGroup", ""],
+  ["function", "joinMulticast", ""],
+  ["function", "leaveMulticast", ""],
   ["function", "send", ""],
 ].forEach(function(attr) {
   var type = attr[0];


### PR DESCRIPTION
- Because joinMulticastGroup and leaveMulticastGroup methods have been changed to joinMulticast and leaveMulticast by the new spec, so update tests.

- SPEC url:http://www.w3.org/TR/raw-sockets/#interface-udpsocket

Impacted TCs num(approved): New 0, Update 2, Delete 0
Unit test Platform: Android
Unit test result summary: Pass 2, Fail 0, Blocked 0