### PR TITLE
[webapi][XWALK-2435] Remove tests for RawSockets

### DIFF
--- a/webapi/webapi-rawsockets-w3c-tests/tests.full.xml
+++ b/webapi/webapi-rawsockets-w3c-tests/tests.full.xml
@@ -255,7 +255,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/System Apps/Raw Sockets" execution_type="auto" id="TCPSocket_onhalfclose_basic" priority="P1" purpose="Check if TCPSocket.onhalfclose exists and type of event" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/System Apps/Raw Sockets" execution_type="auto" id="TCPSocket_onhalfclose_basic" priority="P1" purpose="Check if TCPSocket.onhalfclose exists and type of event" status="designed" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-rawsockets-w3c-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
         </description>
@@ -279,7 +279,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/System Apps/Raw Sockets" execution_type="auto" id="TCPSocket_onmessage_basic" priority="P1" purpose="Check if TCPSocket.onmessage exists and type of event" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/System Apps/Raw Sockets" execution_type="auto" id="TCPSocket_onmessage_basic" priority="P1" purpose="Check if TCPSocket.onmessage exists and type of event" status="designed" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-rawsockets-w3c-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
         </description>

--- a/webapi/webapi-rawsockets-w3c-tests/tests.xml
+++ b/webapi/webapi-rawsockets-w3c-tests/tests.xml
@@ -103,19 +103,9 @@
           <test_script_entry>/opt/webapi-rawsockets-w3c-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=9</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/System Apps/Raw Sockets" execution_type="auto" id="TCPSocket_onhalfclose_basic" purpose="Check if TCPSocket.onhalfclose exists and type of event">
-        <description>
-          <test_script_entry>/opt/webapi-rawsockets-w3c-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=10</test_script_entry>
-        </description>
-      </testcase>
       <testcase component="W3C_HTML5 APIs/System Apps/Raw Sockets" execution_type="auto" id="TCPSocket_onerror_basic" purpose="Check if TCPSocket.onerror exists and type of event">
         <description>
           <test_script_entry>/opt/webapi-rawsockets-w3c-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=11</test_script_entry>
-        </description>
-      </testcase>
-      <testcase component="W3C_HTML5 APIs/System Apps/Raw Sockets" execution_type="auto" id="TCPSocket_onmessage_basic" purpose="Check if TCPSocket.onmessage exists and type of event">
-        <description>
-          <test_script_entry>/opt/webapi-rawsockets-w3c-tests/rawsockets/TCPSocket_interface_basic.html?total_num=17&amp;amp;locator_key=id&amp;amp;value=12</test_script_entry>
         </description>
       </testcase>
       <testcase component="W3C_HTML5 APIs/System Apps/Raw Sockets" execution_type="auto" id="TCPSocket_close_basic" purpose="Check if TCPSocket.close exists and type of function">


### PR DESCRIPTION
- The onhalfclose and onmessage events haved been removed by new spec, so remove related tests
- SPEC url：http://www.w3.org/TR/raw-sockets/#interface-tcpsocket

Impacted TCs num(approved): New 0, Update 0, Delete 2
Unit test Platform: Android
Unit test result summary: Pass 0, Fail 0, Blocked 0