### PR TITLE
[webapi][XWALK-3501] Lack of ')' to complete the test code for mediaserver

### DIFF
--- a/webapi/webapi-mediaserver-tizen-tests/mediaserver/MediaContainer_upload_basic.html
+++ b/webapi/webapi-mediaserver-tizen-tests/mediaserver/MediaContainer_upload_basic.html
@@ -64,5 +64,5 @@ Authors:
     var path = uploadInputField.value;
     var title = uploadInputField.id;
     mc.upload(title, path).then(onUploadedComplete, onUploadFailure);
-  };
+  });
 </script>


### PR DESCRIPTION
Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: [Tizen IVI]
Unit test result summary: pass 1, fail 0, block 0