### PR TITLE
[webapi][XWALK-3503] Change event object to event.id for mediaserver

### DIFF
--- a/webapi/webapi-mediaserver-tizen-tests/mediaserver/MediaServerIdEvent_id_exist.html
+++ b/webapi/webapi-mediaserver-tizen-tests/mediaserver/MediaServerIdEvent_id_exist.html
@@ -43,7 +43,7 @@ Authors:
   msga.scanNetwork();
   msga.onserverlost = t.step_func( function (event) {
     assert_true("id" in event, "the id attribute exists");
-    assert_equals(typeof event, "string", "the id type");
+    assert_equals(typeof event.id, "string", "the id type");
     assert_readonly(event, "id", "You cannot change id attribute");
     t.done();
   });


### PR DESCRIPTION
Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: [Tizen IVI]
Unit test result summary: pass 1, fail 0, block 0