### PR TITLE
Deprecate /home/app for multiuser support

### DIFF
--- a/behavior/tests/ConfigurationExtension/res/setting-encrypt-disable.html
+++ b/behavior/tests/ConfigurationExtension/res/setting-encrypt-disable.html
@@ -73,7 +73,7 @@ Authors:
             <ol>
               <li>Click the "Install" button to install the widget.</li>
               <li>Use the command: "app_launcher -l" in "app" user to get the app id of setting-encrypt-disable.</li>
-              <li>Use the command: "vi /home/app/apps_rw/xwalk-service/applications/'app-id'/index.html" to show the content of index.html in terminal.</li>
+              <li>Use the command: "vi /home/TIZEN_USER/apps_rw/xwalk-service/applications/'app-id'/index.html" to show the content of index.html in terminal.</li>
               <li>Click the "Uninstall" button to uninstall the widget.</li>
             </ol>
             <p>Expected Result: </p>

--- a/behavior/tests/ConfigurationExtension/res/setting-encrypt-enable.html
+++ b/behavior/tests/ConfigurationExtension/res/setting-encrypt-enable.html
@@ -73,7 +73,7 @@ Authors:
             <ol>
               <li>Click the "Install" button to install the widget.</li>
               <li>Use the command: "app_launcher -l" in "app" user to get the app id of setting-encrypt-enable.</li>
-              <li>Use the command: "vi /home/app/apps_rw/xwalk-service/applications/'app-id'/index.html" to show the content of index.html in terminal.</li>
+              <li>Use the command: "vi /home/TIZEN_USER/apps_rw/xwalk-service/applications/'app-id'/index.html" to show the content of index.html in terminal.</li>
               <li>Click the "Uninstall" button to uninstall the widget.</li>
             </ol>
             <p>Expected Result: </p>

--- a/behavior/tests/PackageManagement/res/Sample-widget3.html
+++ b/behavior/tests/PackageManagement/res/Sample-widget3.html
@@ -70,7 +70,7 @@ Authors:
             <p>Test Step: </p>
             <ol>
               <li>Use the command: "app_launcher -l" in "app" user to get the app id of tct-behavior-tests.</li>
-              <li>Copy the "Sample-widget3.wgt" to "Downloads" folder. For example, use the command: "cp -a /home/app/apps_rw/xwalk-service/applications/'app-id'/tests/PackageManagement/res/Sample-widget3.wgt /home/app/content/Downloads".</li>
+              <li>Copy the "Sample-widget3.wgt" to "Downloads" folder. For example, use the command: "cp -a /home/TIZEN_USER/apps_rw/xwalk-service/applications/'app-id'/tests/PackageManagement/res/Sample-widget3.wgt /home/TIZEN_USER/content/Downloads".</li>
               <li>Open the file browser and select "Sample-widget3" webapp to install.</li>
               <li>Click the "Uninstall" button to uninstall the widget "Sample-widget3".</li>
             </ol>

--- a/behavior/tests/Security/index.html
+++ b/behavior/tests/Security/index.html
@@ -48,7 +48,7 @@ Authors:
         <div id="content">
             <ul data-role="listview">
                 <li data-role="list-divider">Shared Media Directory</li>
-                <li><div data-role="button" id="openMediaBtn">Open /home/app/content directory</div></li>
+                <li><div data-role="button" id="openMediaBtn">Open /home/TIZEN_USER/content directory</div></li>
                 <li><div data-role="button" id="createFileBtn">Create file</div></li>
                 <li data-role="list-divider">File List</li>
                 <ul data-role="listview" id="media" data-inset="true" hidden="true"></ul>

--- a/behavior/tests/Stability/res/test-half-memory.html
+++ b/behavior/tests/Stability/res/test-half-memory.html
@@ -77,7 +77,7 @@ Authors:
                 <li>Push a file that the size is larger than half memory into the folder and rename the file as "zipzip.png".</li>
                 <li>Use the command :"zip -rq ../test-half-memory.wgt *" to create a "test-half-memory.wgt".</li>
                 <li>Use the command: "app_launcher -l" in "app" user to get the app id of tct-behavior-tests.</li>
-                <li>Push the created widget to device with the command "sdb push 'path'/test-half-memory.wgt /home/app/apps_rw/xwalk-service/applications/'app-id'/tests/Stability/res/".</li>
+                <li>Push the created widget to device with the command "sdb push 'path'/test-half-memory.wgt /home/TIZEN_USER/apps_rw/xwalk-service/applications/'app-id'/tests/Stability/res/".</li>
               </ol>
               <li>Click the "Install" button to install the widget.</li>
               <li>Click the "Uninstall" button to uninstall the widget.</li>

--- a/behavior/tests/WRTSupport/res/protection-encryption-check.html
+++ b/behavior/tests/WRTSupport/res/protection-encryption-check.html
@@ -70,7 +70,7 @@ Authors:
             <p>Pre-condition: </p>
             <p>Confirm the widget application is encrypted.The resources(js, CSS, HTML files) of protection-encryption-check application is encrypted.For example: </p>
             <li>Use the command: "app_launcher -l" in "app" user to get the app id of protection-encryption-check.</li>
-            <p>use the command: "vi /home/app/apps_rw/xwalk-service/applications/'app-id'/index.html" to show the content of "index.html" in terminal, the content of "index.html" is encrypted.</p>
+            <p>use the command: "vi /home/TIZEN_USER/apps_rw/xwalk-service/applications/'app-id'/index.html" to show the content of "index.html" in terminal, the content of "index.html" is encrypted.</p>
             <p>Test Step: </p>
             <ol>
               <li>Click the "Install" button to install the widget.</li>

--- a/doc/Web_Runtime_Crosswalk_Test_Suite_User_Guide.md
+++ b/doc/Web_Runtime_Crosswalk_Test_Suite_User_Guide.md
@@ -35,13 +35,13 @@ This document provides method to run WRT Crosswalk Test Suite on TIZEN. You can 
 
   - Deploy crosswalk to Tizen device
 
-        $ sdb push crosswalk-<version\>.i686.rpm /home/app/content/tct
+        $ sdb push crosswalk-<version\>.i686.rpm /home/TIZEN_USER/content/tct
 
-        $ sdb push tizen-extensions-crosswalk-<version\>.i686.rpm /home/app/content/tct
+        $ sdb push tizen-extensions-crosswalk-<version\>.i686.rpm /home/TIZEN_USER/content/tct
 
-        $ sdb shell "rpm -ivh /home/app/content/tct/crosswalk-<version\>.i686.rpm"
+        $ sdb shell "rpm -ivh /home/TIZEN_USER/content/tct/crosswalk-<version\>.i686.rpm"
 
-        $ sdb shell "rpm -ivh /home/app/content/tct/tizen-extensions-crosswalk-<version\>.i686.rpm"
+        $ sdb shell "rpm -ivh /home/TIZEN_USER/content/tct/tizen-extensions-crosswalk-<version\>.i686.rpm"
 
 
 ## 4 Installation Web Runtime Crosswalk Test Suite

--- a/tools/atip/tools/set_env.sh
+++ b/tools/atip/tools/set_env.sh
@@ -42,7 +42,7 @@ elif [[ $1 == "xw_tizen" ]]; then
     export TEST_PLATFORM="tizen"
     export DEVICE_ID=""
     export CONNECT_TYPE="sdb"
-    export WEBDRIVER_VARS="{\"webdriver_url\":\"http://127.0.0.1:9515\", \"desired_capabilities\": {\"xwalkOptions\": {\"tizenAppId\": \"TEST_APP_ID\", \"tizenDebuggerAddress\": \"10.239.14.111:9333\"}}, \"test_prefix\": \"file:///opt/home/app/.config/xwalk-service/applications/TEST_APP_ID/\"}"
+    export WEBDRIVER_VARS="{\"webdriver_url\":\"http://127.0.0.1:9515\", \"desired_capabilities\": {\"xwalkOptions\": {\"tizenAppId\": \"TEST_APP_ID\", \"tizenDebuggerAddress\": \"10.239.14.111:9333\"}}, \"test_prefix\": \"file:///optTESTER-HOME-DIR/.config/xwalk-service/applications/TEST_APP_ID/\"}"
 elif [[ $1 == "chrome_ubuntu" ]]; then
     export TEST_PLATFORM="chrome_ubuntu"
     export DEVICE_ID=""

--- a/tools/atip/tools/set_env.sh
+++ b/tools/atip/tools/set_env.sh
@@ -42,7 +42,7 @@ elif [[ $1 == "xw_tizen" ]]; then
     export TEST_PLATFORM="tizen"
     export DEVICE_ID=""
     export CONNECT_TYPE="sdb"
-    export WEBDRIVER_VARS="{\"webdriver_url\":\"http://127.0.0.1:9515\", \"desired_capabilities\": {\"xwalkOptions\": {\"tizenAppId\": \"TEST_APP_ID\", \"tizenDebuggerAddress\": \"10.239.14.111:9333\"}}, \"test_prefix\": \"file:///optTESTER-HOME-DIR/.config/xwalk-service/applications/TEST_APP_ID/\"}"
+    export WEBDRIVER_VARS="{\"webdriver_url\":\"http://127.0.0.1:9515\", \"desired_capabilities\": {\"xwalkOptions\": {\"tizenAppId\": \"TEST_APP_ID\", \"tizenDebuggerAddress\": \"10.239.14.111:9333\"}}, \"test_prefix\": \"file:///optTESTER-HOME-DIR/apps_rw/xwalk-service/applications/TEST_APP_ID/\"}"
 elif [[ $1 == "chrome_ubuntu" ]]; then
     export TEST_PLATFORM="chrome_ubuntu"
     export DEVICE_ID=""

--- a/tools/atip/tools/set_env.sh
+++ b/tools/atip/tools/set_env.sh
@@ -42,7 +42,7 @@ elif [[ $1 == "xw_tizen" ]]; then
     export TEST_PLATFORM="tizen"
     export DEVICE_ID=""
     export CONNECT_TYPE="sdb"
-    export WEBDRIVER_VARS="{\"webdriver_url\":\"http://127.0.0.1:9515\", \"desired_capabilities\": {\"xwalkOptions\": {\"tizenAppId\": \"TEST_APP_ID\", \"tizenDebuggerAddress\": \"10.239.14.111:9333\"}}, \"test_prefix\": \"file:///optTESTER-HOME-DIR/apps_rw/xwalk-service/applications/TEST_APP_ID/\"}"
+    export WEBDRIVER_VARS="{\"webdriver_url\":\"http://127.0.0.1:9515\", \"desired_capabilities\": {\"xwalkOptions\": {\"tizenAppId\": \"TEST_APP_ID\", \"tizenDebuggerAddress\": \"10.239.14.111:9333\"}}, \"test_prefix\": \"file:///opt/TESTER-HOME-DIR/apps_rw/xwalk-service/applications/TEST_APP_ID/\"}"
 elif [[ $1 == "chrome_ubuntu" ]]; then
     export TEST_PLATFORM="chrome_ubuntu"
     export DEVICE_ID=""

--- a/tools/atip/tools/webdriver.xw_tizen.json
+++ b/tools/atip/tools/webdriver.xw_tizen.json
@@ -11,5 +11,5 @@
         "device": "", 
         "name": "xw_tizen"
     }, 
-    "url-prefix": "file:///optTESTER-HOME-DIR/.config/xwalk-service/applications/TEST_APP_ID/"
+    "url-prefix": "file:///optTESTER-HOME-DIR/apps_rw/xwalk-service/applications/TEST_APP_ID/"
 }

--- a/tools/atip/tools/webdriver.xw_tizen.json
+++ b/tools/atip/tools/webdriver.xw_tizen.json
@@ -11,5 +11,5 @@
         "device": "", 
         "name": "xw_tizen"
     }, 
-    "url-prefix": "file:///opt/home/app/.config/xwalk-service/applications/TEST_APP_ID/"
+    "url-prefix": "file:///optTESTER-HOME-DIR/.config/xwalk-service/applications/TEST_APP_ID/"
 }

--- a/tools/atip/tools/webdriver.xw_tizen.json
+++ b/tools/atip/tools/webdriver.xw_tizen.json
@@ -11,5 +11,5 @@
         "device": "", 
         "name": "xw_tizen"
     }, 
-    "url-prefix": "file:///optTESTER-HOME-DIR/apps_rw/xwalk-service/applications/TEST_APP_ID/"
+    "url-prefix": "file:///opt/TESTER-HOME-DIR/apps_rw/xwalk-service/applications/TEST_APP_ID/"
 }

--- a/usecase/usecase-wrt-tizen-tests/samples/ApplicationProtection/index.html
+++ b/usecase/usecase-wrt-tizen-tests/samples/ApplicationProtection/index.html
@@ -47,8 +47,8 @@ Authors:
   <ol>
     <li>Create /opt/share folder on device</li>
     <li>Install the webapp setting-encrypt-enable.wgt and setting-encrypt-disable.wgt in testapp folder.</li>
-    <li>"ls /home/app/.config/xwalk-service/applications/'enable_pkgid'" to list the webapp file</li>
-    <li>"cat /home/app/.config/xwalk-service/applications/'disable_pkgid'/index.html" to show the webapp index.html</li>
+    <li>"ls /home/TIZEN_USER/.config/xwalk-service/applications/'enable_pkgid'" to list the webapp file</li>
+    <li>"cat /home/TIZEN_USER/.config/xwalk-service/applications/'disable_pkgid'/index.html" to show the webapp index.html</li>
     <li>Uninstall the widget.</li>        
   </ol>
 </div>

--- a/usecase/usecase-wrt-tizen-tests/samples/ApplicationProtection/index.html
+++ b/usecase/usecase-wrt-tizen-tests/samples/ApplicationProtection/index.html
@@ -47,8 +47,8 @@ Authors:
   <ol>
     <li>Create /opt/share folder on device</li>
     <li>Install the webapp setting-encrypt-enable.wgt and setting-encrypt-disable.wgt in testapp folder.</li>
-    <li>"ls /home/TIZEN_USER/.config/xwalk-service/applications/'enable_pkgid'" to list the webapp file</li>
-    <li>"cat /home/TIZEN_USER/.config/xwalk-service/applications/'disable_pkgid'/index.html" to show the webapp index.html</li>
+    <li>"ls /home/TIZEN_USER/apps_rw/xwalk-service/applications/'enable_pkgid'" to list the webapp file</li>
+    <li>"cat /home/TIZEN_USER/apps_rw/xwalk-service/applications/'disable_pkgid'/index.html" to show the webapp index.html</li>
     <li>Uninstall the widget.</li>        
   </ol>
 </div>

--- a/webapi/tct-application-tizen-tests/README
+++ b/webapi/tct-application-tizen-tests/README
@@ -5,16 +5,16 @@ This test suite is for testing Tizen Application API, which covers the following
 
 ## Pre-conditions
 
-* The following tests require the existence (and ready to installation) the file /home/app/content/Others/TCTAppInfoEventTest1.wgt
-(this file exist in tct-application-tizen-tests-<version>-<release>.<arch>.rpm and will be copied to home/app/content/Others during installation of test - the ApplicationId this application must be defined in app_common.js):
+* The following tests require the existence (and ready to installation) the file /home/TIZEN_USER/content/Others/TCTAppInfoEventTest1.wgt
+(this file exist in tct-application-tizen-tests-<version>-<release>.<arch>.rpm and will be copied to /home/TIZEN_USER/content/Others during installation of test - the ApplicationId this application must be defined in app_common.js):
   ApplicationManager_addAppInfoEventListener_oninstalled
   ApplicationManager_addAppInfoEventListener_onuninstalled
   ApplicationManager_addAppInfoEventListener_onupdated
   ApplicationInformationEventCallback_oninstalled
   ApplicationInformationEventCallback_onuninstalled
   ApplicationInformationEventCallback_onupdated
-* The following tests require the existence (and ready to installation) the file /home/app/content/Others/TCTAppInfoEventTest2.wgt (the newer version of TCTAppInfoEventTest1.wgt)
-(this file exist in tct-application-tizen-tests-<version>-<release>.<arch>.rpm and will be copied to home/app/content/Others during installation of test - the ApplicationId this application must be defined in app_common.js):
+* The following tests require the existence (and ready to installation) the file /home/TIZEN_USER/content/Others/TCTAppInfoEventTest2.wgt (the newer version of TCTAppInfoEventTest1.wgt)
+(this file exist in tct-application-tizen-tests-<version>-<release>.<arch>.rpm and will be copied to /home/TIZEN_USER/content/Others during installation of test - the ApplicationId this application must be defined in app_common.js):
   ApplicationManager_addAppInfoEventListener_onupdated
   ApplicationInformationEventCallback_onupdated
 

--- a/webapi/tct-notification-tizen-tests/notification/StatusNotification_appControl_attribute.html
+++ b/webapi/tct-notification-tizen-tests/notification/StatusNotification_appControl_attribute.html
@@ -44,13 +44,13 @@ test(function () {
         initialValue, newValue;
 
     initialValue = new tizen.ApplicationControl("http://tizen.org/appcontrol/operation/default",
-        "file:///home/app/content/Images/" + iconPathToSet.replace(/^.*\//, ""),
+        "file://TESTER-HOME-DIR/content/Images/" + iconPathToSet.replace(/^.*\//, ""),
         "image/jpg",
         null,
         [new tizen.ApplicationControlData("k1", ["v1"])]
     );
     newValue = new tizen.ApplicationControl(newOperation,
-        "file:///home/app/content/Images/" + thumbnailToSet.replace(/^.*\//, ""),
+        "file://TESTER-HOME-DIR/content/Images/" + thumbnailToSet.replace(/^.*\//, ""),
         "image/jpeg",
         "category",
         [new tizen.ApplicationControlData("new-k1", ["new-v1"])]

--- a/webapi/tct-privilege-tizen-tests/privilege/ContentManager_scanFile.html
+++ b/webapi/tct-privilege-tizen-tests/privilege/ContentManager_scanFile.html
@@ -39,7 +39,7 @@ test(function () {
     assert_throws({
         name: "SecurityError"
     }, function () {
-        tizen.content.scanFile("/home/app/content");
+        tizen.content.scanFile("TESTER-HOME-DIR/content");
     });
 }, document.title);
 

--- a/webapi/webapi-mediarenderer-tizen-tests/README
+++ b/webapi/webapi-mediarenderer-tizen-tests/README
@@ -7,16 +7,16 @@ This test suite is for testing Media Renderer Interface (Partial) specification:
 
 * Set up dlna media server follow the steps:
 1. Modify rygel.conf on IVI device.
-$ cp /etc/rygel.conf /home/app/apps_rw/
+$ cp /etc/rygel.conf TESTER-HOME-DIR/apps_rw/
 
 - video-upload-folder=@VIDEOS@
-+ video-upload-folder=/home/app/Videos
++ video-upload-folder=TESTER-HOME-DIR/Videos
 
 - music-upload-folder=@MUSIC@
-+ music-upload-folder=/home/app/Sounds
++ music-upload-folder=TESTER-HOME-DIR/Sounds
 
 - picture-upload-folder=@PICTURES@
-+ picture-upload-folder=/home/app/Images
++ picture-upload-folder=TESTER-HOME-DIR/Images
 
 # Allow upload of media files?
 - allow-upload=false
@@ -37,7 +37,7 @@ strict-sharing=false
 + title=iMediaExport
 
 - uris=@MUSIC@;@VIDEOS@;@PICTURES@
-+ uris=/home/app/Videos;/home/app/Sounds;/home/app/Images;
++ uris=TESTER-HOME-DIR/Videos;TESTER-HOME-DIR/Sounds;TESTER-HOME-DIR/Images;
  
 enabled=true
 - title=My Media
@@ -47,10 +47,10 @@ enabled=true
 - title=Audio/Video playback on @HOSTNAME@
 + title=iPlaybin
 
-2. Create Videos, Sounds and Images directories in /home/app/ on IVI device.
+2. Create Videos, Sounds and Images directories in TESTER-HOME-DIR/ on IVI device.
 
 3. Add some media content to IVI device.
-* Copy media files to /home/app/Videos, /home/app/Sounds and /home/app/Images.
+* Copy media files to TESTER-HOME-DIR/Videos, TESTER-HOME-DIR/Sounds and TESTER-HOME-DIR/Images.
 
 4. Launch of services on IVI device.
 $ su - app
@@ -65,3 +65,4 @@ $ rygel
 Copyright (c) 2014 Intel Corporation.
 Except as noted, this software is licensed under BSD-3-Clause License.
 Please see the COPYING file for the BSD-3-Clause License.
+

--- a/webapi/webapi-mediaserver-tizen-tests/README
+++ b/webapi/webapi-mediaserver-tizen-tests/README
@@ -7,16 +7,16 @@ This test suite is for testing CSS3 User Interface (Partial) specification:
 
 * Set up dlna media server follow the steps:
 1. Modify rygel.conf on IVI device.
-$ cp /etc/rygel.conf /home/app/apps_rw/
+$ cp /etc/rygel.conf TESTER-HOME-DIR/apps_rw/
 
 - video-upload-folder=@VIDEOS@
-+ video-upload-folder=/home/app/Videos
++ video-upload-folder=TESTER-HOME-DIR/Videos
 
 - music-upload-folder=@MUSIC@
-+ music-upload-folder=/home/app/Sounds
++ music-upload-folder=TESTER-HOME-DIR/Sounds
 
 - picture-upload-folder=@PICTURES@
-+ picture-upload-folder=/home/app/Images
++ picture-upload-folder=TESTER-HOME-DIR/Images
 
 # Allow upload of media files?
 - allow-upload=false
@@ -37,7 +37,7 @@ strict-sharing=false
 + title=iMediaExport
 
 - uris=@MUSIC@;@VIDEOS@;@PICTURES@
-+ uris=/home/app/Videos;/home/app/Sounds;/home/app/Images;
++ uris=TESTER-HOME-DIR/Videos;TESTER-HOME-DIR/Sounds;TESTER-HOME-DIR/Images;
  
 enabled=true
 - title=My Media
@@ -47,10 +47,10 @@ enabled=true
 - title=Audio/Video playback on @HOSTNAME@
 + title=iPlaybin
 
-2. Create Videos, Sounds and Images directories in /home/app/ on IVI device.
+2. Create Videos, Sounds and Images directories in TESTER-HOME-DIR/ on IVI device.
 
 3. Add some media content to IVI device.
-* Copy media files to /home/app/Videos, /home/app/Sounds and /home/app/Images.
+* Copy media files to TESTER-HOME-DIR/Videos, TESTER-HOME-DIR/Sounds and TESTER-HOME-DIR/Images.
 
 4. Launch of services on IVI device.
 $ su - app
@@ -65,3 +65,4 @@ $ rygel
 Copyright (c) 2014 Intel Corporation.
 Except as noted, this software is licensed under BSD-3-Clause License.
 Please see the COPYING file for the BSD-3-Clause License.
+

--- a/wrt/wrt-packertool-tizen-tests/inst.wgt.py
+++ b/wrt/wrt-packertool-tizen-tests/inst.wgt.py
@@ -198,7 +198,7 @@ def instPKGs():
             item_name = os.path.basename(item)
             if not doCopy(item, "%s/%s" % (PKG_SRC_DIR, item_name)):
                 action_status = False
-    print "Package push to host /home/<user>/content/tct/ successfully!"
+    print "Package push to host %s/tct/ successfully!" % SRC_DIR
     return action_status"""
 
 


### PR DESCRIPTION
- TESTER-HOME_DIR is used to replace static source code
  /home/app during test suite packaging.
- TIZEN_USER is used for dynamic replacement by testkit.
  It can also be used for manually cases which don't
  need update.
- SRC_DIR is a variable used by installation scripts.