### PR TITLE
[xwalk-3558] Update /home/app code by multi-user in wrt scripts

### DIFF
--- a/wrt/tct-appwgt-wrt-tests/scripts/wrt_appwgt_install.sh
+++ b/wrt/tct-appwgt-wrt-tests/scripts/wrt_appwgt_install.sh
@@ -33,6 +33,7 @@
 path=$(dirname $(dirname $0))
 source $path/scripts/xwalk_common.sh
 APP_NAME="app-widget-sample"
+get_currentuser
 function existbh()
 {
   echo $1

--- a/wrt/tct-appwgt-wrt-tests/scripts/wrt_appwgt_install_no_signature.sh
+++ b/wrt/tct-appwgt-wrt-tests/scripts/wrt_appwgt_install_no_signature.sh
@@ -33,6 +33,7 @@
 path=$(dirname $(dirname $0))
 source $path/scripts/xwalk_common.sh
 APP_NAME="sp-widget-no-signature"
+get_currentuser
 function existbh()
 {
   echo $1

--- a/wrt/tct-appwgt-wrt-tests/scripts/wrt_appwgt_install_only_author_signature.sh
+++ b/wrt/tct-appwgt-wrt-tests/scripts/wrt_appwgt_install_only_author_signature.sh
@@ -33,6 +33,7 @@
 path=$(dirname $(dirname $0))
 source $path/scripts/xwalk_common.sh
 APP_NAME="sp-widget-only-author-signature"
+get_currentuser
 function existbh()
 {
   echo $1

--- a/wrt/tct-appwgt-wrt-tests/scripts/wrt_appwgt_install_valid_signature.sh
+++ b/wrt/tct-appwgt-wrt-tests/scripts/wrt_appwgt_install_valid_signature.sh
@@ -33,6 +33,7 @@
 path=$(dirname $(dirname $0))
 source $path/scripts/xwalk_common.sh
 APP_NAME="sp-widget-valid-signature"
+get_currentuser
 function existbh()
 {
   echo $1

--- a/wrt/tct-appwgt-wrt-tests/scripts/wrt_appwgt_uninstall.sh
+++ b/wrt/tct-appwgt-wrt-tests/scripts/wrt_appwgt_uninstall.sh
@@ -29,10 +29,10 @@
 #        Zhang Ge <gex.zhang@intel.com>
 #        Yin,Haichao <haichaox.yin@intel.com>
 
-
 path=$(dirname $(dirname $0))
 source $path/scripts/xwalk_common.sh
 APP_NAME="app-widget-sample"
+get_currentuser
 function existbh()
 {
   echo $1

--- a/wrt/tct-appwgt-wrt-tests/scripts/xwalk_common.sh
+++ b/wrt/tct-appwgt-wrt-tests/scripts/xwalk_common.sh
@@ -30,6 +30,10 @@
 
 ###below functions just for crosswalk ivi testing###
 
+function get_currentuser(){
+    TIZEN_USER=`whoami`
+}
+
 function install_app(){
     nohup pkgcmd -i -t wgt -p $1 -q &>/dev/null &
     sleep 5

--- a/wrt/tct-ext02-wrt-tests/scripts/Common
+++ b/wrt/tct-ext02-wrt-tests/scripts/Common
@@ -28,6 +28,10 @@
 # Authors:
 #        Yue, jianhui <jianhuix.a.yue@intel.com>
 
+function get_currentuser(){
+    TIZEN_USER=`whoami`
+}
+
 function func_install()
 {
     if [ $# != 1 ];then

--- a/wrt/tct-pm-wrt-tests/scripts/Common
+++ b/wrt/tct-pm-wrt-tests/scripts/Common
@@ -31,6 +31,10 @@
 path=$(dirname $(dirname $0))
 source $path/scripts/xwalk_common.sh
 
+function get_currentuser(){
+    TIZEN_USER=`whoami`
+}
+
 function func_install()
 {
     PACKAGENAME="$path/$1"

--- a/wrt/tct-pm-wrt-tests/scripts/wrt_pm_Install_EXE.sh
+++ b/wrt/tct-pm-wrt-tests/scripts/wrt_pm_Install_EXE.sh
@@ -29,6 +29,7 @@
 #        Yue, jianhui <jianhuix.a.yue@intel.com>
 
 source $(dirname $0)/Common
+get_currentuser
 RESOURCE_DIR=/home/$TIZEN_USER/content
 origin_name=$RESOURCE_DIR/tct/opt/tct-pm-wrt-tests/Sample-widget.wgt
 change_name=$RESOURCE_DIR/tct/opt/tct-pm-wrt-tests/Sample-widget.EXE

--- a/wrt/tct-pm-wrt-tests/scripts/wrt_pm_dataStored_Update.sh
+++ b/wrt/tct-pm-wrt-tests/scripts/wrt_pm_dataStored_Update.sh
@@ -29,6 +29,7 @@
 #        Yue, jianhui <jianhuix.a.yue@intel.com>
 
 source $(dirname $0)/Common
+get_currentuser
 uninstall_app widget-version-1
 func_install_changename widget-version-1.wgt
 if [ $? -eq 1 ];then

--- a/wrt/tct-pm-wrt-tests/scripts/wrt_pm_uninstallation_application_erased.sh
+++ b/wrt/tct-pm-wrt-tests/scripts/wrt_pm_uninstallation_application_erased.sh
@@ -29,7 +29,7 @@
 #        Yue, jianhui <jianhuix.a.yue@intel.com>
 
 source $(dirname $0)/Common
-
+get_currentuser
 func_install uninstallation-application-erased.wgt
 if [ $? -eq 1 ];then
   echo "The installation is failed"

--- a/wrt/tct-sp02-wrt-tests/scripts/wrt_sp02_localstorage_check.sh
+++ b/wrt/tct-sp02-wrt-tests/scripts/wrt_sp02_localstorage_check.sh
@@ -31,6 +31,7 @@
 path=$(dirname $(dirname $0))
 source $path/scripts/xwalk_common.sh
 APP_NAME="private_localstorage_check"
+get_currentuser
 function existbh()
 {
   echo $1

--- a/wrt/tct-sp02-wrt-tests/scripts/xwalk_common.sh
+++ b/wrt/tct-sp02-wrt-tests/scripts/xwalk_common.sh
@@ -31,6 +31,11 @@
 ###below functions just for crosswalk ivi testing###
 
 ##usage: install_app $app_path(e.g. uninstall_app /home/tizen_user/content/tct/opt/tct-sp02-wrt-tests/tct-sp02-wrt-tests.wgt, note:tizen_user is the current device normal user, "app" user on ivi, "guest" user on tizen commom)##
+
+function get_currentuser(){
+    TIZEN_USER=`whoami`
+}
+
 function install_app(){
     pkgcmd -i -t wgt -q -p $1
 }

--- a/wrt/wrt-digitalsign-tizen-tests/digitalsign/Common
+++ b/wrt/wrt-digitalsign-tizen-tests/digitalsign/Common
@@ -28,6 +28,10 @@
 #Authors:
 #       IVAN CHEN <yufeix.chen@intel.com>
 
+function get_currentuser(){
+    TIZEN_USER=`whoami`
+}
+
 function func_xwalkservice(){
   export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/5000/dbus/user_bus_socket
   systemctl --user status xwalk.service > /dev/null
@@ -53,6 +57,7 @@ function get_app_id(){
 }
 
 function check_db(){
+  get_currentuser
   sqlite3 /home/$TIZEN_USER/.applications/dbspace/.app_info.db "select * from app_info;" | grep $1 | grep $2
   if [ $? -ne 0  ];then
     echo "cannot found $2 in applications.db"

--- a/wrt/wrt-digitalsign-tizen-tests/digitalsign/Crosswalk_Digital_Signature_Error.sh
+++ b/wrt/wrt-digitalsign-tizen-tests/digitalsign/Crosswalk_Digital_Signature_Error.sh
@@ -30,7 +30,7 @@
 
 local_path=$(cd $(dirname $0);pwd)
 source $local_path/Common
-
+get_currentuser
 func_check_xwalkservice
 
 pkgcmd -i -t xpk -p $local_path/../source/bad_signature.xpk -q > /tmp/install

--- a/wrt/wrt-digitalsign-tizen-tests/digitalsign/Crosswalk_Digital_Signature_Package.sh
+++ b/wrt/wrt-digitalsign-tizen-tests/digitalsign/Crosswalk_Digital_Signature_Package.sh
@@ -30,7 +30,7 @@
 
 local_path=$(cd $(dirname $0);pwd)
 source $local_path/Common
-
+get_currentuser
 func_check_xwalkservice
 
 pkgcmd -i -t xpk -p $local_path/../source/signature.xpk -q

--- a/wrt/wrt-manifest-tizen-tests/script/Common
+++ b/wrt/wrt-manifest-tizen-tests/script/Common
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2013 Intel Corporation
+# Copyright (C) 2015 Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without modification,
 # are permitted provided that the following conditions are met:
@@ -26,31 +26,8 @@
 # EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 # Authors:
-#        Cao, Jenny <jenny.q.cao@intel.com>
-#        Yue, jianhui <jianhuix.a.yue@intel.com>
+#        Yin, Haichao <haichaox.yin@intel.com>
 
-source $(dirname $0)/Common
-get_currentuser
-if [ $# != 1 ];then
-    echo "usage $0 + packagename"
-fi
-RESOURCE_DIR=/home/$TIZEN_USER/content
-PACKAGENAME="$RESOURCE_DIR/tct/opt/tct-ext02-wrt-tests/$1"
-p_name=$1
-APP_NAME=${p_name%.*}
-find_app $APP_NAME
-
-if [ -n $pkgids ];then
-  uninstall_app $APP_NAME
-  sleep 5
-fi
-func_install $1
-if [ $? -eq 0 ];then
-  echo -e  " pkgcmd install widget successfully!"
-  find_app $APP_NAME
-  uninstall_app $APP_NAME
-  exit 0
-else
-  echo -e  "pkgcmd install widget failed!"
-  exit 1
-fi
+function get_currentuser(){
+    TIZEN_USER=`whoami`
+}

--- a/wrt/wrt-manifest-tizen-tests/script/checkdb.sh
+++ b/wrt/wrt-manifest-tizen-tests/script/checkdb.sh
@@ -26,9 +26,10 @@
 #EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+source $(dirname $0)/Common
 path=$(dirname $(dirname $0))
 xpksuite_name=wrt-manifest-tizen-tests
 PACKAGENAME="$path/$1"
 Result="Pass"
-
+get_currentuser
 sqlite3 /home/$TIZEN_USER/.applications/dbspace/.app_info.db "select count(*) from app_info;"

--- a/wrt/wrt-manifest-tizen-tests/script/checkdb_new.sh
+++ b/wrt/wrt-manifest-tizen-tests/script/checkdb_new.sh
@@ -26,9 +26,10 @@
 #EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+source $(dirname $0)/Common
 path=$(dirname $(dirname $0))
 xpksuite_name=wrt-manifest-tizen-tests
 PACKAGENAME="$path/$1"
 Result="Pass"
-
+get_currentuser
 sqlite3 /home/$TIZEN_USER/.applications/dbspace/.app_info.db "select * from app_info limit $1,1;"

--- a/wrt/wrt-manifest-tizen-tests/script/checktct_folder.sh
+++ b/wrt/wrt-manifest-tizen-tests/script/checktct_folder.sh
@@ -26,10 +26,11 @@
 #EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+source $(dirname $0)/Common
 path=$(dirname $(dirname $0))
 xpksuite_name=wrt-manifest-tizen-tests
 PACKAGENAME="$path/$1"
-
+get_currentuser
 [ -d /home/$TIZEN_USER/content/tct/ ] ||  mkdir -p /home/$TIZEN_USER/content/tct/
 if [ -e /home/$TIZEN_USER/content/tct/ ];then
     echo "pass"

--- a/wrt/wrt-packagemgt-tizen-tests/packagemgt/Common
+++ b/wrt/wrt-packagemgt-tizen-tests/packagemgt/Common
@@ -28,6 +28,10 @@
 #Authors:
 #       IVAN CHEN <yufeix.chen@intel.com>
 
+function get_currentuser(){
+    TIZEN_USER=`whoami`
+}
+
 function func_xwalkservice()
 {
         export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/5000/dbus/user_bus_socket

--- a/wrt/wrt-packagemgt-tizen-tests/packagemgt/Crosswalk_WebApp_Install_Resource.sh
+++ b/wrt/wrt-packagemgt-tizen-tests/packagemgt/Crosswalk_WebApp_Install_Resource.sh
@@ -35,7 +35,7 @@ local_path=$(cd $(dirname $0);pwd)
 source $local_path/Common
 xpk_path=$local_path/../testapp
 webAppTest="web_app_test"
-
+get_currentuser
 getPkgid $webAppTest
 get_uninstall=`pkgcmd -u -n  $pkg_id -q`
 

--- a/wrt/wrt-packagemgt-tizen-tests/packagemgt/Crosswalk_WebApp_Launcher_Cache.sh
+++ b/wrt/wrt-packagemgt-tizen-tests/packagemgt/Crosswalk_WebApp_Launcher_Cache.sh
@@ -36,7 +36,7 @@ local_path=$(cd $(dirname $0);pwd)
 source $local_path/Common
 xpk_path=$local_path/../testapp
 webAppTest="web_app_test"
-
+get_currentuser
 # uninstall app first, and then install app
 getPkgid $webAppTest
 get_uninstall=`pkgcmd -u -n  $pkg_id -q`

--- a/wrt/wrt-rtbin-tizen-tests/rtbinauto/Common
+++ b/wrt/wrt-rtbin-tizen-tests/rtbinauto/Common
@@ -28,6 +28,10 @@
 #Authors:
 #       IVAN CHEN <yufeix.chen@intel.com>
 
+function get_currentuser(){
+    TIZEN_USER=`whoami`
+}
+
 function func_xwalkservice()
 {
             systemctl --user status xwalk.service > /dev/null

--- a/wrt/wrt-rtbin-tizen-tests/rtbinauto/Crosswalk_Run_As_Service_CheckDB.sh
+++ b/wrt/wrt-rtbin-tizen-tests/rtbinauto/Crosswalk_Run_As_Service_CheckDB.sh
@@ -30,7 +30,7 @@
 
 local_path=$(dirname $0)
 source $local_path/Common
-
+get_currentuser
 func_check_xwalkservice
 if [[ $? -eq 1 ]]; then
                  func_xwalkservice

--- a/wrt/wrt-rtbin-tizen-tests/rtbinauto/Crosswalk_Run_As_Service_Install.sh
+++ b/wrt/wrt-rtbin-tizen-tests/rtbinauto/Crosswalk_Run_As_Service_Install.sh
@@ -30,6 +30,7 @@
 
 local_path=$(dirname $0)
 source $local_path/Common
+get_currentuser
 
 func_check_xwalkservice
 if [[ $? -eq 1 ]]; then

--- a/wrt/wrt-rtbin-tizen-tests/rtbinauto/Crosswalk_Run_As_Service_Uninstall.sh
+++ b/wrt/wrt-rtbin-tizen-tests/rtbinauto/Crosswalk_Run_As_Service_Uninstall.sh
@@ -30,7 +30,7 @@
 
 local_path=$(dirname $0)
 source $local_path/Common
-
+get_currentuser
 func_check_xwalkservice
 if [[ $? -eq 1 ]]; then
                  func_xwalkservice


### PR DESCRIPTION
- Because of can not get the value of 'TIZEN_USER' when
  execute shell script on ivi device, update the script
  by new way in batch at here
- Talk with the testkit-lite developer, set the 'TIZEN_USER'
  environment variable value on ivi device will not be achieved