### PR TITLE
[webapi][XWALK-3518] Delete simd tests

### DIFF
--- a/webapi/webapi-simd-nonw3c-tests/tests.full.xml
+++ b/webapi/webapi-simd-nonw3c-tests/tests.full.xml
@@ -207,18 +207,6 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="Supplementary APIs/SIMD" execution_type="auto" id="float32x4_shuffleMix" priority="P1" purpose="Check float32x4 shuffleMix (0, 12, 12)" status="approved" subcase="12" type="compliance">
-        <description>
-          <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=18</test_script_entry>
-        </description>
-        <specs>
-          <spec>
-            <spec_assertion category="SIMD" element_name="float32x4" element_type="method" interface="SIMD" section="SIMD" specification="SIMD" />
-            <spec_url>https://github.com/johnmccutchan/ecmascript_simd/blob/master/README.md</spec_url>
-            <spec_statement />
-          </spec>
-        </specs>
-      </testcase>
       <testcase component="Supplementary APIs/SIMD" execution_type="auto" id="float32x4_withX" priority="P1" purpose="Check float32x4 withX (0, 4, 4)" status="approved" subcase="4" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=19</test_script_entry>

--- a/webapi/webapi-simd-nonw3c-tests/tests.xml
+++ b/webapi/webapi-simd-nonw3c-tests/tests.xml
@@ -88,11 +88,6 @@
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=17</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Supplementary APIs/SIMD" execution_type="auto" id="float32x4_shuffleMix" purpose="Check float32x4 shuffleMix (0, 12, 12)" subcase="12">
-        <description>
-          <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=18</test_script_entry>
-        </description>
-      </testcase>
       <testcase component="Supplementary APIs/SIMD" execution_type="auto" id="float32x4_withX" purpose="Check float32x4 withX (0, 4, 4)" subcase="4">
         <description>
           <test_script_entry>/opt/webapi-simd-nonw3c-tests/simd/ecmascript_simd/src/index.html?testNumber=19</test_script_entry>


### PR DESCRIPTION
- SIMD.float32x4.shuffleMix API has been replaced by SIMD.float32x4.swizzle, so delete related case

Impacted TCs num(approved): New 0, Update 0, Delete 1
Unit test Platform: Andriod
Unit test result summary: Pass 0, Fail 0, Blocked 0