### PR TITLE
[wrt][xwalk-3492] Update tests for packertool2

### DIFF
--- a/wrt/wrt-packertool2-android-tests/packertool2/comm.py
+++ b/wrt/wrt-packertool2-android-tests/packertool2/comm.py
@@ -271,18 +271,16 @@ def versionCode(cmd, flag, base, self):
                 print "Find"
                 l = lines[i].strip("\n\r").strip()
                 result = l.index("versionCode")
+                end = l.index("versionName")
                 if flag != "":
                     start = result
-                    end = result + 15
                     self.assertIn('11', l[start:end])
                 elif base != "":
                     start = result
-                    end = result + 21
                     self.assertIn('1234567', l[start:end])
                 else:
                     start = result
-                    end = result + 18
-                    self.assertIn('1.0.0', l[start:end])
+                    self.assertIn('10000', l[start:end])
                 break
             else:
                 print "Continue find"

--- a/wrt/wrt-packertool2-android-tests/packertool2/versionCodetest.py
+++ b/wrt/wrt-packertool2-android-tests/packertool2/versionCodetest.py
@@ -68,9 +68,25 @@ class TestPackertoolsFunctions(unittest.TestCase):
         versionCode = ""
         versionCodeBase = ""
         versionCodeBase = " --app-versionCodeBase=1234567"
-        cmd = "python %smake_apk.py --package=org.xwalk.example --arch=%s --mode=%s --manifest=%s --project-dir=test" % \
+        cmd = "python %smake_apk.py --package=org.xwalk.example --arch=%s --mode=%s --manifest=%s --project-dir=test --app-version=1.0.0" % \
         (comm.Pck_Tools, comm.ARCH, comm.MODE, manfiestPath)
         comm.versionCode(cmd, versionCode, versionCodeBase, self)
+        comm.clear_versionCode()
+
+    def test_manifest_version_versionCode(self):
+        comm.setUp()
+        comm.clear_versionCode()
+        targetDir = comm.ConstPath + "/../testapp/example/"
+        manfiestPath = targetDir + "manifest.json"
+        os.chdir(targetDir)
+        versionCode = ""
+        versionCodeBase = ""
+        cmd = "python %smake_apk.py --package=org.xwalk.example --arch=%s --mode=%s --manifest=%s --project-dir=test --app-version=1.0.0.0" % \
+        (comm.Pck_Tools, comm.ARCH, comm.MODE, manfiestPath)
+        packstatus = commands.getstatusoutput(cmd)
+        errorinfo = "please specify --app-versionCode or --app-versionCodeBase"
+        self.assertNotEquals(0, packstatus[0])
+        self.assertIn(errorinfo, packstatus[1])
         comm.clear_versionCode()
 
 if __name__ == '__main__':  

--- a/wrt/wrt-packertool2-android-tests/tests.full.xml
+++ b/wrt/wrt-packertool2-android-tests/tests.full.xml
@@ -58,7 +58,7 @@
           <test_script_entry>/opt/wrt-packertool2-android-tests/packertool2/projectdirtest.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk WRT/Packer Tool" execution_type="auto" id="Crosswalk_versionCode" priority="P1" purpose="Validate if packer tool can work well with app-versionCode and app-versionCodeBase option" status="approved" type="Functional" subcase="3">
+      <testcase component="Crosswalk WRT/Packer Tool" execution_type="auto" id="Crosswalk_versionCode" priority="P1" purpose="Validate if packer tool can work well with app-versionCode and app-versionCodeBase option" status="approved" type="Functional" subcase="4">
         <description>
           <test_script_entry>/opt/wrt-packertool2-android-tests/packertool2/versionCodetest.py</test_script_entry>
         </description>

--- a/wrt/wrt-packertool2-android-tests/tests.xml
+++ b/wrt/wrt-packertool2-android-tests/tests.xml
@@ -58,7 +58,7 @@
           <test_script_entry>/opt/wrt-packertool2-android-tests/packertool2/projectdirtest.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk WRT/Packer Tool" execution_type="auto" id="Crosswalk_versionCodetest" purpose="Validate if packer tool can work well with app-versionCode and app-versionCodeBase option" subcase="3">
+      <testcase component="Crosswalk WRT/Packer Tool" execution_type="auto" id="Crosswalk_versionCodetest" purpose="Validate if packer tool can work well with app-versionCode and app-versionCodeBase option" subcase="4">
         <description>
           <test_script_entry>/opt/wrt-packertool2-android-tests/packertool2/versionCodetest.py</test_script_entry>
         </description>


### PR DESCRIPTION
- Add test for version when the length of version in manifest file is greater than or equal to 4

Impacted TCs num(approved): New 1, Update 3, Delete 0
Unit test Platform: Android
Android test result summary: Pass 4, Fail 0, Block 0