### PR TITLE
[embeddingapi] Support to pack multi apks to one pkg

### DIFF
--- a/embeddingapi/embedding-api-android-tests/inst.apk.py
+++ b/embeddingapi/embedding-api-android-tests/inst.apk.py
@@ -35,14 +35,20 @@ def doCMD(cmd):
 
 
 def uninstPKGs():
-    cmd = "%s -s %s uninstall org.xwalk.embedding.test" % (
-        ADB_CMD, PARAMETERS.device)
-    (return_code, output) = doCMD(cmd)
-    for line in output:
-        if "Failure" in line:
-            return False
-            break
-    return True
+    action_status = True
+    for root, dirs, files in os.walk(SCRIPT_DIR):
+        for file in files:
+            if file.endswith(".apk"):
+                index_start = str(file).index("_")
+                index_end = str(file).index(".")
+                cmd = "%s -s %s uninstall org.xwalk.embedding.test.%s" % (
+                    ADB_CMD, PARAMETERS.device, str(file)[index_start + 1 : index_end])
+                (return_code, output) = doCMD(cmd)
+                for line in output:
+                    if "Failure" in line:
+                        action_status = False
+                        break
+    return action_status
 
 
 def instPKGs():

--- a/embeddingapi/embedding-api-android-tests/suite.json
+++ b/embeddingapi/embedding-api-android-tests/suite.json
@@ -6,17 +6,330 @@
         "inst.*.py"
     ], 
     "pkg-list": {
-        "embeddingapi": {
+        "embeddingapiv1": {
             "blacklist": [
                 "*"
             ], 
             "copylist": {
-                "inst.apk.py": "inst.py", 
-                "tests.xml": "tests.xml"
+                "inst.apk.py": "inst.py",
+                "tests_v1.xml": "tests_v1.xml"
             }, 
             "subapp-list": {
-                "embeddingapi": {
-                    "app-name": "embeddingapi", 
+                "embeddingapiv1": {
+                    "blacklist": [
+                        "src/org/xwalk/embedding/test/v2",
+                        "src/org/xwalk/embedding/test/v3",
+                        "src/org/xwalk/embedding/test/v4",
+                        "src/org/xwalk/embedding/test/v5"
+                    ],
+                    "app-dir": "embeddingapi",
+                    "app-name": "embeddingapi_v1",
+                    "app-type": "EMBEDDINGAPI",
+                    "embeddingapi-library-name": "crosswalk-webview",
+                    "copylist": {
+                        "libs/chromium/base_java_test_support.jar": "libs/base_java_test_support.jar",
+                        "libs/chromium/content_java_test_support.jar": "libs/content_java_test_support.jar",
+                        "libs/chromium/net_java_test_support.jar": "libs/net_java_test_support.jar",
+                        "libs/testkit/testkit-junit.jar": "libs/testkit-junit.jar"
+                    }
+                }
+            }
+        },
+        "embeddingapiv2": {
+            "blacklist": [
+                "*"
+            ], 
+            "copylist": {
+                "inst.apk.py": "inst.py",
+                "tests_v1.xml": "tests_v1.xml",
+                "tests_v2.xml": "tests_v2.xml"
+            }, 
+            "subapp-list": {
+                "embeddingapiv1": {
+                    "blacklist": [
+                        "src/org/xwalk/embedding/test/v2",
+                        "src/org/xwalk/embedding/test/v3",
+                        "src/org/xwalk/embedding/test/v4",
+                        "src/org/xwalk/embedding/test/v5"
+                    ],
+                    "app-dir": "embeddingapi",
+                    "app-name": "embeddingapi_v1", 
+                    "app-type": "EMBEDDINGAPI", 
+                    "embeddingapi-library-name": "crosswalk-webview",
+                    "copylist": {
+                        "libs/chromium/base_java_test_support.jar": "libs/base_java_test_support.jar",
+                        "libs/chromium/content_java_test_support.jar": "libs/content_java_test_support.jar",
+                        "libs/chromium/net_java_test_support.jar": "libs/net_java_test_support.jar",
+                        "libs/testkit/testkit-junit.jar": "libs/testkit-junit.jar"
+                    }
+                },
+                "embeddingapiv2": {
+                    "blacklist": [
+                        "src/org/xwalk/embedding/test/v1",
+                        "src/org/xwalk/embedding/test/v3",
+                        "src/org/xwalk/embedding/test/v4",
+                        "src/org/xwalk/embedding/test/v5"
+                    ],
+                    "app-dir": "embeddingapi",
+                    "app-name": "embeddingapi_v2", 
+                    "app-type": "EMBEDDINGAPI", 
+                    "embeddingapi-library-name": "crosswalk-webview",
+                    "copylist": {
+                        "libs/chromium/base_java_test_support.jar": "libs/base_java_test_support.jar",
+                        "libs/chromium/content_java_test_support.jar": "libs/content_java_test_support.jar",
+                        "libs/chromium/net_java_test_support.jar": "libs/net_java_test_support.jar",
+                        "libs/testkit/testkit-junit.jar": "libs/testkit-junit.jar"
+                    }
+                }
+            }
+        },
+        "embeddingapiv3": {
+            "blacklist": [
+                "*"
+            ], 
+            "copylist": {
+                "inst.apk.py": "inst.py",
+                "tests_v1.xml": "tests_v1.xml",
+                "tests_v2.xml": "tests_v2.xml",
+                "tests_v3.xml": "tests_v3.xml"
+            }, 
+            "subapp-list": {
+                "embeddingapiv1": {
+                    "blacklist": [
+                        "src/org/xwalk/embedding/test/v2",
+                        "src/org/xwalk/embedding/test/v3",
+                        "src/org/xwalk/embedding/test/v4",
+                        "src/org/xwalk/embedding/test/v5"
+                    ],
+                    "app-dir": "embeddingapi",
+                    "app-name": "embeddingapi_v1", 
+                    "app-type": "EMBEDDINGAPI", 
+                    "embeddingapi-library-name": "crosswalk-webview",
+                    "copylist": {
+                        "libs/chromium/base_java_test_support.jar": "libs/base_java_test_support.jar",
+                        "libs/chromium/content_java_test_support.jar": "libs/content_java_test_support.jar",
+                        "libs/chromium/net_java_test_support.jar": "libs/net_java_test_support.jar",
+                        "libs/testkit/testkit-junit.jar": "libs/testkit-junit.jar"
+                    }
+                },
+                "embeddingapiv2": {
+                    "blacklist": [
+                        "src/org/xwalk/embedding/test/v1",
+                        "src/org/xwalk/embedding/test/v3",
+                        "src/org/xwalk/embedding/test/v4",
+                        "src/org/xwalk/embedding/test/v5"
+                    ],
+                    "app-dir": "embeddingapi",
+                    "app-name": "embeddingapi_v2", 
+                    "app-type": "EMBEDDINGAPI", 
+                    "embeddingapi-library-name": "crosswalk-webview",
+                    "copylist": {
+                        "libs/chromium/base_java_test_support.jar": "libs/base_java_test_support.jar",
+                        "libs/chromium/content_java_test_support.jar": "libs/content_java_test_support.jar",
+                        "libs/chromium/net_java_test_support.jar": "libs/net_java_test_support.jar",
+                        "libs/testkit/testkit-junit.jar": "libs/testkit-junit.jar"
+                    }
+                },
+                "embeddingapiv3": {
+                    "blacklist": [
+                        "src/org/xwalk/embedding/test/v1",
+                        "src/org/xwalk/embedding/test/v2",
+                        "src/org/xwalk/embedding/test/v4",
+                        "src/org/xwalk/embedding/test/v5"
+                    ],
+                    "app-dir": "embeddingapi",
+                    "app-name": "embeddingapi_v3", 
+                    "app-type": "EMBEDDINGAPI", 
+                    "embeddingapi-library-name": "crosswalk-webview",
+                    "copylist": {
+                        "libs/chromium/base_java_test_support.jar": "libs/base_java_test_support.jar",
+                        "libs/chromium/content_java_test_support.jar": "libs/content_java_test_support.jar",
+                        "libs/chromium/net_java_test_support.jar": "libs/net_java_test_support.jar",
+                        "libs/testkit/testkit-junit.jar": "libs/testkit-junit.jar"
+                    }
+                }
+            }
+        },
+        "embeddingapiv4": {
+            "blacklist": [
+                "*"
+            ], 
+            "copylist": {
+                "inst.apk.py": "inst.py",
+                "tests_v1.xml": "tests_v1.xml",
+                "tests_v2.xml": "tests_v2.xml",
+                "tests_v3.xml": "tests_v3.xml",
+                "tests_v4.xml": "tests_v4.xml"
+            }, 
+            "subapp-list": {
+                "embeddingapiv1": {
+                    "blacklist": [
+                        "src/org/xwalk/embedding/test/v2",
+                        "src/org/xwalk/embedding/test/v3",
+                        "src/org/xwalk/embedding/test/v4",
+                        "src/org/xwalk/embedding/test/v5"
+                    ],
+                    "app-dir": "embeddingapi",
+                    "app-name": "embeddingapi_v1", 
+                    "app-type": "EMBEDDINGAPI", 
+                    "embeddingapi-library-name": "crosswalk-webview",
+                    "copylist": {
+                        "libs/chromium/base_java_test_support.jar": "libs/base_java_test_support.jar",
+                        "libs/chromium/content_java_test_support.jar": "libs/content_java_test_support.jar",
+                        "libs/chromium/net_java_test_support.jar": "libs/net_java_test_support.jar",
+                        "libs/testkit/testkit-junit.jar": "libs/testkit-junit.jar"
+                    }
+                },
+                "embeddingapiv2": {
+                    "blacklist": [
+                        "src/org/xwalk/embedding/test/v1",
+                        "src/org/xwalk/embedding/test/v3",
+                        "src/org/xwalk/embedding/test/v4",
+                        "src/org/xwalk/embedding/test/v5"
+                    ],
+                    "app-dir": "embeddingapi",
+                    "app-name": "embeddingapi_v2", 
+                    "app-type": "EMBEDDINGAPI", 
+                    "embeddingapi-library-name": "crosswalk-webview",
+                    "copylist": {
+                        "libs/chromium/base_java_test_support.jar": "libs/base_java_test_support.jar",
+                        "libs/chromium/content_java_test_support.jar": "libs/content_java_test_support.jar",
+                        "libs/chromium/net_java_test_support.jar": "libs/net_java_test_support.jar",
+                        "libs/testkit/testkit-junit.jar": "libs/testkit-junit.jar"
+                    }
+                },
+                "embeddingapiv3": {
+                    "blacklist": [
+                        "src/org/xwalk/embedding/test/v1",
+                        "src/org/xwalk/embedding/test/v2",
+                        "src/org/xwalk/embedding/test/v4",
+                        "src/org/xwalk/embedding/test/v5"
+                    ],
+                    "app-dir": "embeddingapi",
+                    "app-name": "embeddingapi_v3", 
+                    "app-type": "EMBEDDINGAPI", 
+                    "embeddingapi-library-name": "crosswalk-webview",
+                    "copylist": {
+                        "libs/chromium/base_java_test_support.jar": "libs/base_java_test_support.jar",
+                        "libs/chromium/content_java_test_support.jar": "libs/content_java_test_support.jar",
+                        "libs/chromium/net_java_test_support.jar": "libs/net_java_test_support.jar",
+                        "libs/testkit/testkit-junit.jar": "libs/testkit-junit.jar"
+                    }
+                },
+                "embeddingapiv4": {
+                    "blacklist": [
+                        "src/org/xwalk/embedding/test/v1",
+                        "src/org/xwalk/embedding/test/v2",
+                        "src/org/xwalk/embedding/test/v3",
+                        "src/org/xwalk/embedding/test/v5"
+                    ],
+                    "app-dir": "embeddingapi",
+                    "app-name": "embeddingapi_v4", 
+                    "app-type": "EMBEDDINGAPI", 
+                    "embeddingapi-library-name": "crosswalk-webview",
+                    "copylist": {
+                        "libs/chromium/base_java_test_support.jar": "libs/base_java_test_support.jar",
+                        "libs/chromium/content_java_test_support.jar": "libs/content_java_test_support.jar",
+                        "libs/chromium/net_java_test_support.jar": "libs/net_java_test_support.jar",
+                        "libs/testkit/testkit-junit.jar": "libs/testkit-junit.jar"
+                    }
+                }
+            }
+        },
+        "embeddingapi, embeddingapiv5": {
+            "blacklist": [
+                "*"
+            ], 
+            "copylist": {
+                "inst.apk.py": "inst.py",
+                "tests_v1.xml": "tests_v1.xml",
+                "tests_v2.xml": "tests_v2.xml",
+                "tests_v3.xml": "tests_v3.xml",
+                "tests_v4.xml": "tests_v4.xml",
+                "tests_v5.xml": "tests_v5.xml"
+            }, 
+            "subapp-list": {
+                "embeddingapiv1": {
+                    "blacklist": [
+                        "src/org/xwalk/embedding/test/v2",
+                        "src/org/xwalk/embedding/test/v3",
+                        "src/org/xwalk/embedding/test/v4",
+                        "src/org/xwalk/embedding/test/v5"
+                    ],
+                    "app-dir": "embeddingapi",
+                    "app-name": "embeddingapi_v1", 
+                    "app-type": "EMBEDDINGAPI", 
+                    "embeddingapi-library-name": "crosswalk-webview",
+                    "copylist": {
+                        "libs/chromium/base_java_test_support.jar": "libs/base_java_test_support.jar",
+                        "libs/chromium/content_java_test_support.jar": "libs/content_java_test_support.jar",
+                        "libs/chromium/net_java_test_support.jar": "libs/net_java_test_support.jar",
+                        "libs/testkit/testkit-junit.jar": "libs/testkit-junit.jar"
+                    }
+                },
+                "embeddingapiv2": {
+                    "blacklist": [
+                        "src/org/xwalk/embedding/test/v1",
+                        "src/org/xwalk/embedding/test/v3",
+                        "src/org/xwalk/embedding/test/v4",
+                        "src/org/xwalk/embedding/test/v5"
+                    ],
+                    "app-dir": "embeddingapi",
+                    "app-name": "embeddingapi_v2", 
+                    "app-type": "EMBEDDINGAPI", 
+                    "embeddingapi-library-name": "crosswalk-webview",
+                    "copylist": {
+                        "libs/chromium/base_java_test_support.jar": "libs/base_java_test_support.jar",
+                        "libs/chromium/content_java_test_support.jar": "libs/content_java_test_support.jar",
+                        "libs/chromium/net_java_test_support.jar": "libs/net_java_test_support.jar",
+                        "libs/testkit/testkit-junit.jar": "libs/testkit-junit.jar"
+                    }
+                },
+                "embeddingapiv3": {
+                    "blacklist": [
+                        "src/org/xwalk/embedding/test/v1",
+                        "src/org/xwalk/embedding/test/v2",
+                        "src/org/xwalk/embedding/test/v4",
+                        "src/org/xwalk/embedding/test/v5"
+                    ],
+                    "app-dir": "embeddingapi",
+                    "app-name": "embeddingapi_v3", 
+                    "app-type": "EMBEDDINGAPI", 
+                    "embeddingapi-library-name": "crosswalk-webview",
+                    "copylist": {
+                        "libs/chromium/base_java_test_support.jar": "libs/base_java_test_support.jar",
+                        "libs/chromium/content_java_test_support.jar": "libs/content_java_test_support.jar",
+                        "libs/chromium/net_java_test_support.jar": "libs/net_java_test_support.jar",
+                        "libs/testkit/testkit-junit.jar": "libs/testkit-junit.jar"
+                    }
+                },
+                "embeddingapiv4": {
+                    "blacklist": [
+                        "src/org/xwalk/embedding/test/v1",
+                        "src/org/xwalk/embedding/test/v2",
+                        "src/org/xwalk/embedding/test/v3",
+                        "src/org/xwalk/embedding/test/v5"
+                    ],
+                    "app-dir": "embeddingapi",
+                    "app-name": "embeddingapi_v4", 
+                    "app-type": "EMBEDDINGAPI", 
+                    "embeddingapi-library-name": "crosswalk-webview",
+                    "copylist": {
+                        "libs/chromium/base_java_test_support.jar": "libs/base_java_test_support.jar",
+                        "libs/chromium/content_java_test_support.jar": "libs/content_java_test_support.jar",
+                        "libs/chromium/net_java_test_support.jar": "libs/net_java_test_support.jar",
+                        "libs/testkit/testkit-junit.jar": "libs/testkit-junit.jar"
+                    }
+                },
+                "embeddingapiv5": {
+                    "blacklist": [
+                        "src/org/xwalk/embedding/test/v1",
+                        "src/org/xwalk/embedding/test/v2",
+                        "src/org/xwalk/embedding/test/v3",
+                        "src/org/xwalk/embedding/test/v4"
+                    ],
+                    "app-dir": "embeddingapi",
+                    "app-name": "embeddingapi_v5", 
                     "app-type": "EMBEDDINGAPI", 
                     "embeddingapi-library-name": "crosswalk-webview",
                     "copylist": {


### PR DESCRIPTION
- Improve the pack.py to pack multi apks to one pkg
- Update inst.apk.py to inst or uninst multi apks
- Remove the test.xml of copylist in suite.json

Impacted tests(approved): new 0, update 0, delete 0
Unit test platform: [Android]
Unit test result summary: pass 152, fail 19, block 22