### PR TITLE
[wrt][xwalk-3590] Update the install path for tizen

### DIFF
--- a/behavior/tests/ConfigurationExtension/res/setting-encrypt-disable.html
+++ b/behavior/tests/ConfigurationExtension/res/setting-encrypt-disable.html
@@ -73,7 +73,7 @@ Authors:
             <ol>
               <li>Click the "Install" button to install the widget.</li>
               <li>Use the command: "app_launcher -l" in "app" user to get the app id of setting-encrypt-disable.</li>
-              <li>Use the command: "vi /home/TIZEN_USER/apps_rw/xwalk-service/applications/'app-id'/index.html" to show the content of index.html in terminal.</li>
+              <li>Use the command: "vi /home/TIZEN_USER/apps_rw/xwalk/applications/'app-id'/index.html" to show the content of index.html in terminal.</li>
               <li>Click the "Uninstall" button to uninstall the widget.</li>
             </ol>
             <p>Expected Result: </p>

--- a/behavior/tests/ConfigurationExtension/res/setting-encrypt-enable.html
+++ b/behavior/tests/ConfigurationExtension/res/setting-encrypt-enable.html
@@ -73,7 +73,7 @@ Authors:
             <ol>
               <li>Click the "Install" button to install the widget.</li>
               <li>Use the command: "app_launcher -l" in "app" user to get the app id of setting-encrypt-enable.</li>
-              <li>Use the command: "vi /home/TIZEN_USER/apps_rw/xwalk-service/applications/'app-id'/index.html" to show the content of index.html in terminal.</li>
+              <li>Use the command: "vi /home/TIZEN_USER/apps_rw/xwalk/applications/'app-id'/index.html" to show the content of index.html in terminal.</li>
               <li>Click the "Uninstall" button to uninstall the widget.</li>
             </ol>
             <p>Expected Result: </p>

--- a/behavior/tests/PackageManagement/res/Sample-widget3.html
+++ b/behavior/tests/PackageManagement/res/Sample-widget3.html
@@ -70,7 +70,7 @@ Authors:
             <p>Test Step: </p>
             <ol>
               <li>Use the command: "app_launcher -l" in "app" user to get the app id of tct-behavior-tests.</li>
-              <li>Copy the "Sample-widget3.wgt" to "Downloads" folder. For example, use the command: "cp -a /home/TIZEN_USER/apps_rw/xwalk-service/applications/'app-id'/tests/PackageManagement/res/Sample-widget3.wgt /home/TIZEN_USER/content/Downloads".</li>
+              <li>Copy the "Sample-widget3.wgt" to "Downloads" folder. For example, use the command: "cp -a /home/TIZEN_USER/apps_rw/xwalk/applications/'app-id'/tests/PackageManagement/res/Sample-widget3.wgt /home/TIZEN_USER/content/Downloads".</li>
               <li>Open the file browser and select "Sample-widget3" webapp to install.</li>
               <li>Click the "Uninstall" button to uninstall the widget "Sample-widget3".</li>
             </ol>

--- a/behavior/tests/Stability/res/test-half-memory.html
+++ b/behavior/tests/Stability/res/test-half-memory.html
@@ -77,7 +77,7 @@ Authors:
                 <li>Push a file that the size is larger than half memory into the folder and rename the file as "zipzip.png".</li>
                 <li>Use the command :"zip -rq ../test-half-memory.wgt *" to create a "test-half-memory.wgt".</li>
                 <li>Use the command: "app_launcher -l" in "app" user to get the app id of tct-behavior-tests.</li>
-                <li>Push the created widget to device with the command "sdb push 'path'/test-half-memory.wgt /home/TIZEN_USER/apps_rw/xwalk-service/applications/'app-id'/tests/Stability/res/".</li>
+                <li>Push the created widget to device with the command "sdb push 'path'/test-half-memory.wgt /home/TIZEN_USER/apps_rw/xwalk/applications/'app-id'/tests/Stability/res/".</li>
               </ol>
               <li>Click the "Install" button to install the widget.</li>
               <li>Click the "Uninstall" button to uninstall the widget.</li>

--- a/behavior/tests/WRTSupport/res/protection-encryption-check.html
+++ b/behavior/tests/WRTSupport/res/protection-encryption-check.html
@@ -70,7 +70,7 @@ Authors:
             <p>Pre-condition: </p>
             <p>Confirm the widget application is encrypted.The resources(js, CSS, HTML files) of protection-encryption-check application is encrypted.For example: </p>
             <li>Use the command: "app_launcher -l" in "app" user to get the app id of protection-encryption-check.</li>
-            <p>use the command: "vi /home/TIZEN_USER/apps_rw/xwalk-service/applications/'app-id'/index.html" to show the content of "index.html" in terminal, the content of "index.html" is encrypted.</p>
+            <p>use the command: "vi /home/TIZEN_USER/apps_rw/xwalk/applications/'app-id'/index.html" to show the content of "index.html" in terminal, the content of "index.html" is encrypted.</p>
             <p>Test Step: </p>
             <ol>
               <li>Click the "Install" button to install the widget.</li>

--- a/tools/atip/tools/set_env.sh
+++ b/tools/atip/tools/set_env.sh
@@ -55,7 +55,7 @@ elif [[ $1 == "xw_tizen" ]]; then
     export CONNECT_TYPE="sdb"
     export TIZEN_USER=""
     export LAUNCHER=""
-    export WEBDRIVER_VARS="{\"webdriver_url\":\"http://127.0.0.1:9515\", \"desired_capabilities\": {\"xwalkOptions\": {\"tizenAppId\": \"TEST_APP_ID\", \"tizenDebuggerAddress\": \"http://127.0.0.1:9333\"}}, \"test_prefix\": \"file:///opt/TESTER-HOME-DIR/apps_rw/xwalk-service/applications/TEST_APP_ID/\"}"
+    export WEBDRIVER_VARS="{\"webdriver_url\":\"http://127.0.0.1:9515\", \"desired_capabilities\": {\"xwalkOptions\": {\"tizenAppId\": \"TEST_APP_ID\", \"tizenDebuggerAddress\": \"http://127.0.0.1:9333\"}}, \"test_prefix\": \"file:///opt/TESTER-HOME-DIR/apps_rw/xwalk/applications/TEST_APP_ID/\"}"
 elif [[ $1 == "chrome_ubuntu" ]]; then
     export TEST_PLATFORM="chrome_ubuntu"
     export DEVICE_ID=""

--- a/tools/atip/tools/webdriver.xw_tizen.json
+++ b/tools/atip/tools/webdriver.xw_tizen.json
@@ -11,5 +11,5 @@
         "device": "", 
         "name": "xw_tizen"
     }, 
-    "url-prefix": "file:///opt/TESTER-HOME-DIR/apps_rw/xwalk-service/applications/TEST_APP_ID/"
+    "url-prefix": "file:///opt/TESTER-HOME-DIR/apps_rw/xwalk/applications/TEST_APP_ID/"
 }

--- a/usecase/usecase-webapi-xwalk-tests/samples/ApplicationSwitching/js/main.js
+++ b/usecase/usecase-webapi-xwalk-tests/samples/ApplicationSwitching/js/main.js
@@ -32,8 +32,8 @@ var resume1Url, resume2Url;
 var flag = false;
 var resume1_flag = false , resume2_flag = false;
 $(document).delegate("#main", "pageinit", function() {
-  resume1Url = "TESTER-HOME-DIR/apps_rw/xwalk-service/applications/xwalktests.XwalkSysTests/tests/ApplicationSwitching/res/TestResume1.wgt";
-  resume2Url = "TESTER-HOME-DIR/apps_rw/xwalk-service/applications/xwalktests.XwalkSysTests/tests/ApplicationSwitching/res/TestResume2.wgt";
+  resume1Url = "TESTER-HOME-DIR/apps_rw/xwalk/applications/xwalktests.XwalkSysTests/tests/ApplicationSwitching/res/TestResume1.wgt";
+  resume2Url = "TESTER-HOME-DIR/apps_rw/xwalk/applications/xwalktests.XwalkSysTests/tests/ApplicationSwitching/res/TestResume2.wgt";
   $("#install1").bind("vclick", function() {
     install(resume1Url, "install1");
     resume1_flag = true;

--- a/usecase/usecase-webapi-xwalk-tests/samples/Package/js/main.js
+++ b/usecase/usecase-webapi-xwalk-tests/samples/Package/js/main.js
@@ -21,8 +21,8 @@ Authors:
 var installUrl, updateUrl;
 var flag = false;
 $(document).ready(function() {
-    installUrl = "TESTER-HOME-DIR/apps_rw/xwalk-service/applications/usecaseweb.WebAPIWEBUseCaseTests/samples/Package/res/TestPackage1.wgt";
-    updateUrl = "TESTER-HOME-DIR/apps_rw/xwalk-service/applications/usecaseweb.WebAPIWEBUseCaseTests/samples/Package/res/TestPackage2.wgt";
+    installUrl = "TESTER-HOME-DIR/apps_rw/xwalk/applications/usecaseweb.WebAPIWEBUseCaseTests/samples/Package/res/TestPackage1.wgt";
+    updateUrl = "TESTER-HOME-DIR/apps_rw/xwalk/applications/usecaseweb.WebAPIWEBUseCaseTests/samples/Package/res/TestPackage2.wgt";
     try {
         tizen.package.setPackageInfoEventListener(packageEventCallback);
     } catch (e) {

--- a/usecase/usecase-wrt-tizen-tests/samples/ApplicationProtection/index.html
+++ b/usecase/usecase-wrt-tizen-tests/samples/ApplicationProtection/index.html
@@ -47,8 +47,8 @@ Authors:
   <ol>
     <li>Create /opt/share folder on device</li>
     <li>Install the webapp setting-encrypt-enable.wgt and setting-encrypt-disable.wgt in testapp folder.</li>
-    <li>"ls /home/TIZEN_USER/apps_rw/xwalk-service/applications/'enable_pkgid'" to list the webapp file</li>
-    <li>"cat /home/TIZEN_USER/apps_rw/xwalk-service/applications/'disable_pkgid'/index.html" to show the webapp index.html</li>
+    <li>"ls /home/TIZEN_USER/apps_rw/xwalk/applications/'enable_pkgid'" to list the webapp file</li>
+    <li>"cat /home/TIZEN_USER/apps_rw/xwalk/applications/'disable_pkgid'/index.html" to show the webapp index.html</li>
     <li>Uninstall the widget.</li>        
   </ol>
 </div>

--- a/wrt/tct-appwgt-wrt-tests/scripts/wrt_appwgt_install.sh
+++ b/wrt/tct-appwgt-wrt-tests/scripts/wrt_appwgt_install.sh
@@ -47,7 +47,7 @@ if [ $? -ne 0 ]
 then
   exit 1
 fi
-widgetpath="/home/$TIZEN_USER/apps_rw/xwalk-service/applications/$appid"
+widgetpath="/home/$TIZEN_USER/apps_rw/xwalk/applications/$appid"
 if [ ! -d $widgetpath ]
 then
   existbh "The path of the application does not exist." 1

--- a/wrt/tct-appwgt-wrt-tests/scripts/wrt_appwgt_install_no_signature.sh
+++ b/wrt/tct-appwgt-wrt-tests/scripts/wrt_appwgt_install_no_signature.sh
@@ -47,7 +47,7 @@ if [ $? -ne 0 ]
 then
   exit 1
 fi
-widgetpath="/home/$TIZEN_USER/apps_rw/xwalk-service/applications/$appid"
+widgetpath="/home/$TIZEN_USER/apps_rw/xwalk/applications/$appid"
 if [ ! -d $widgetpath ]
 then
   existbh "The path of the application does not exist." 1

--- a/wrt/tct-appwgt-wrt-tests/scripts/wrt_appwgt_install_only_author_signature.sh
+++ b/wrt/tct-appwgt-wrt-tests/scripts/wrt_appwgt_install_only_author_signature.sh
@@ -47,7 +47,7 @@ if [ $? -ne 0 ]
 then
   exit 1
 fi
-widgetpath="/home/$TIZEN_USER/apps_rw/xwalk-service/applications/$appid"
+widgetpath="/home/$TIZEN_USER/apps_rw/xwalk/applications/$appid"
 if [ ! -d $widgetpath ]
 then
   existbh "The path of the application does not exist." 1

--- a/wrt/tct-appwgt-wrt-tests/scripts/wrt_appwgt_install_valid_signature.sh
+++ b/wrt/tct-appwgt-wrt-tests/scripts/wrt_appwgt_install_valid_signature.sh
@@ -47,7 +47,7 @@ if [ $? -ne 0 ]
 then
   exit 1
 fi
-widgetpath="/home/"$TIZEN_USER"/apps_rw/xwalk-service/applications/$appid"
+widgetpath="/home/"$TIZEN_USER"/apps_rw/xwalk/applications/$appid"
 if [ ! -d $widgetpath ]
 then
   existbh "The path of the application does not exist." 1

--- a/wrt/tct-appwgt-wrt-tests/scripts/wrt_appwgt_uninstall.sh
+++ b/wrt/tct-appwgt-wrt-tests/scripts/wrt_appwgt_uninstall.sh
@@ -43,7 +43,7 @@ find_app $APP_NAME
 if [ $? -ne 0 ];then
   exit 1
 fi
-widgetpath="/home/$TIZEN_USER/apps_rw/xwalk-service/applications/$appid"
+widgetpath="/home/$TIZEN_USER/apps_rw/xwalk/applications/$appid"
 if [ ! -d $widgetpath ];then
   uninstall_app $APP_NAME
   existbh "The path of the application does not exist." 1

--- a/wrt/wrt-packagemgt-tizen-tests/packagemgt/Crosswalk_WebApp_Install_Resource.sh
+++ b/wrt/wrt-packagemgt-tizen-tests/packagemgt/Crosswalk_WebApp_Install_Resource.sh
@@ -39,7 +39,7 @@ get_currentuser
 getPkgid $webAppTest
 get_uninstall=`pkgcmd -u -n  $pkg_id -q`
 
-rm -rf /home/$TIZEN_USER/apps_rw/xwalk-service/Storage/ext/webapptest.webapptestversion
+rm -rf /home/$TIZEN_USER/apps_rw/xwalk/Storage/ext/webapptest.webapptestversion
 pkgcmd -i -t wgt -p  $xpk_path/$webAppTest.wgt -q
 getAppid $webAppTest
 if [[ -n $app_id ]]; then
@@ -49,7 +49,7 @@ if [[ -n $app_id ]]; then
                 exit 1
 fi
 
-myPath="/home/$TIZEN_USER/apps_rw/xwalk-service/Storage/ext/webapptest.webapptestversion"
+myPath="/home/$TIZEN_USER/apps_rw/xwalk/Storage/ext/webapptest.webapptestversion"
 if [ ! -d $myPath ]; then 
      echo "Pass,webapp have not isolated storage partition before running"
      get_uninstall=`pkgcmd -u -n  webapptest -q`

--- a/wrt/wrt-packagemgt-tizen-tests/packagemgt/Crosswalk_WebApp_Launcher_Cache.sh
+++ b/wrt/wrt-packagemgt-tizen-tests/packagemgt/Crosswalk_WebApp_Launcher_Cache.sh
@@ -61,7 +61,7 @@ fi
 sleep 2
 
 # check cache
-myPath="/home/$TIZEN_USER/apps_rw/xwalk-service/Storage/ext/$app_id/def/GPUCache"
+myPath="/home/$TIZEN_USER/apps_rw/xwalk/Storage/ext/$app_id/def/GPUCache"
 getPkgid $webAppTest
 if [ ! -d $myPath ]; then 
      echo "Fail,webapp have not isolated storage cache file when runing"

--- a/wrt/wrt-packagemgtmanu-tizen-tests/packagemgtmanu/Crosswalk_WebApp_Uninstall_Resource.html
+++ b/wrt/wrt-packagemgtmanu-tizen-tests/packagemgtmanu/Crosswalk_WebApp_Uninstall_Resource.html
@@ -45,17 +45,17 @@ Authors:
       <li>Run this webapp by typing "app_launcher -s $appid", get $appid with command: "app_launcher -l", check the app isolated</li>      
       <li>Uninstall the app by typing "pkgcmd -u -n $pkgid -q" in the command line</li>
       <li>Reboot the device</li>
-      <li>Check webapp storage patition path:/home/tizen_user/apps_rw/xwalk-service/Storage/ext/$pkgid. (note:tizen_user is the current device normal user, "app" user on ivi, "guest" user on tizen commom)</li>
+      <li>Check webapp storage patition path:/home/tizen_user/apps_rw/xwalk/Storage/ext/$pkgid. (note:tizen_user is the current device normal user, "app" user on ivi, "guest" user on tizen commom)</li>
     </ol>
     <p>
       <strong>Expected Output:</strong>
     </p>
     <ol>
       <li>The webapp install successfully and you can get $pkgid</li>
-      <li>The webapp isolated partition is created in path /home/tizen_user/apps_rw/xwalk-service/Storage/ext. (note:tizen_user is the current device normal user, "app" user on ivi, "guest" user on tizen commom) <li>
+      <li>The webapp isolated partition is created in path /home/tizen_user/apps_rw/xwalk/Storage/ext. (note:tizen_user is the current device normal user, "app" user on ivi, "guest" user on tizen commom) <li>
       <li>Web app can be uninstall successfully</li>
       <li>Device reboot successfully</li>
-      <li>Webapp isolated storage partition is deleted (path:/home/tizen_user/apps_rw/xwalk-service/Storage/ext. note:tizen_user is the current device normal user, "app" user on ivi, "guest" user on tizen commom)</li>
+      <li>Webapp isolated storage partition is deleted (path:/home/tizen_user/apps_rw/xwalk/Storage/ext. note:tizen_user is the current device normal user, "app" user on ivi, "guest" user on tizen commom)</li>
     </ol>
   </body>
 </html>


### PR DESCRIPTION
- Update the installed app path from 'xwalk-server' to 'xwalk'
- About manual cases, i just tested one of the most typical case

Impacted tests(approved): new 0, update 10, delete 0
Unit test platform: [Tizen]
Unit test result summary: pass 10, fail 0, block 0

Bug: xwalk-3590