### PR TITLE
[wrt][xwalk-3599] Update ssh connection code in run_test.py

### DIFF
--- a/wrt/wrt-manifest-tizen-tests/run_test.py
+++ b/wrt/wrt-manifest-tizen-tests/run_test.py
@@ -75,9 +75,12 @@ def do_Clear(sourceDir):
         print Exception,"Clear :"+ sourceDir + " ------------------------->error",e 
 
 def getUSERID():
-    cmd = "sdb -s %s shell id -u %s" % (getEnv_Id, Tizen_User)
+    if Test_Device_Type=="sdb":
+        cmd = "sdb -s %s shell id -u %s" % (getEnv_Id, Tizen_User)  
+    else:
+        cmd = "ssh %s \"id -u %s\"" % (getEnv_Id, Tizen_User)
     return doCMD(cmd)
-
+    
 def manifest_Packing(pakeNo,pakeType):
     try:
         print "-------------- Packing WebApp: "+ pakeNo +" -----------------"


### PR DESCRIPTION
- Add the code for ssh connection when test device
  type is ssh

Impacted tests(approved): new 0, update 264, delete 0
Unit test platform: [Tizen]
Unit test result summary: pass 264, fail 0, block 0

Bug: xwalk-3599