### PR TITLE
[usecase] Automate 2 usecases

### DIFF
--- a/usecase/usecase-webapi-xwalk-tests/samples/Es6NumericLiterals/index.html
+++ b/usecase/usecase-webapi-xwalk-tests/samples/Es6NumericLiterals/index.html
@@ -43,7 +43,7 @@ Authors:
   <h3 id="main_page_title"></h3>
 </div>
 <div class="content">
-  <iframe width="100%" height="300px;" src="res/index.html"></iframe>
+  <iframe id="resFrame" width="100%" height="300px;" src="res/index.html"></iframe>
 </div>
 
 <div class="footer">

--- a/usecase/usecase-webapi-xwalk-tests/samples/FileApiPersistent/index.html
+++ b/usecase/usecase-webapi-xwalk-tests/samples/FileApiPersistent/index.html
@@ -44,7 +44,7 @@ Authors:
 </div>
 
 <div class="content">
-  <iframe width="100%" height="300px;" src="res/index.html"></iframe>
+  <iframe id="resFrame" width="100%" height="300px;" src="res/index.html"></iframe>
 </div>
 
 <div class="footer">

--- a/usecase/usecase-webapi-xwalk-tests/samples/FileApiPersistent/res/index.html
+++ b/usecase/usecase-webapi-xwalk-tests/samples/FileApiPersistent/res/index.html
@@ -36,8 +36,8 @@ Authors:
 <link rel="help" href="http://www.w3.org/TR/2011/WD-file-system-api-20110419/#widl-LocalFileSystem-PERSISTENT">
 <div>This usecase is for File API PERSISTENT.</div>
 <br>
-<div><input type="button" value="Create And Write" onclick="createAndWrite()" /></div>
-<div><input type="button" value="Read" onclick="read()" /></div>
+<div><input type="button" id="bt1" value="Create And Write" onclick="createAndWrite()" /></div>
+<div><input type="button" id="bt2" value="Read" onclick="read()" /></div>
 <br>
 <div id="log"></div>
 <script>

--- a/usecase/usecase-webapi-xwalk-tests/tests.android.xml
+++ b/usecase/usecase-webapi-xwalk-tests/tests.android.xml
@@ -147,9 +147,9 @@
       </testcase>
       <testcase component="Crosswalk Use Cases/WebAPI" execution_type="manual" id="InAppPayment" purpose="InAppPayment">
       </testcase>
-      <testcase component="Crosswalk Use Cases/WebAPI" execution_type="manual" id="Es6NumericLiterals" purpose="Es6NumericLiterals">
+      <testcase component="Crosswalk Use Cases/WebAPI" execution_type="auto" id="Es6NumericLiterals" purpose="Es6NumericLiterals">
       </testcase>
-      <testcase component="Crosswalk Use Cases/WebAPI" execution_type="manual" id="FileApiPersistent" purpose="FileApiPersistent">
+      <testcase component="Crosswalk Use Cases/WebAPI" execution_type="auto" id="FileApiPersistent" purpose="FileApiPersistent">
       </testcase>
     </set>
   </suite>

--- a/usecase/usecase-webapi-xwalk-tests/tests.auto.xml
+++ b/usecase/usecase-webapi-xwalk-tests/tests.auto.xml
@@ -143,5 +143,17 @@
         </description>
       </testcase>
     </set>
+    <set name="Others APIs" background="brand-danger3" icon="glyphicon-gift"  type="js" ui-auto="bdd">
+      <testcase component="Crosswalk Use Cases/WebAPI" execution_type="auto" id="Es6NumericLiterals" purpose="Es6NumericLiterals">
+        <description>
+          <bdd_test_script_entry test_script_expected_result="0">/opt/usecase-webapi-xwalk-tests/testscripts/Es6NumericLiterals.feature</bdd_test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk Use Cases/WebAPI" execution_type="auto" id="FileApiPersistent" purpose="FileApiPersistent">
+        <description>
+          <bdd_test_script_entry test_script_expected_result="0">/opt/usecase-webapi-xwalk-tests/testscripts/FileApiPersistent.feature</bdd_test_script_entry>
+        </description>
+      </testcase>
+    </set>
   </suite>
 </test_definition>

--- a/usecase/usecase-webapi-xwalk-tests/tests.full.xml
+++ b/usecase/usecase-webapi-xwalk-tests/tests.full.xml
@@ -305,16 +305,22 @@
       <testcase component="Crosswalk Use Cases/WebAPI" execution_type="manual" id="Locale" platform="tizen" priority="P0" purpose="Locale" status="approved" type="functional_positive">
       </testcase>
     </set>
-    <set name="Others APIs" background="brand-danger3" icon="glyphicon-gift">
+    <set name="Others APIs" background="brand-danger3" icon="glyphicon-gift"  type="js" ui-auto="bdd">
       <testcase component="Crosswalk Use Cases/WebAPI" execution_type="manual" id="Advertising" platform="android" priority="P0" purpose="Advertising" status="approved" type="functional_positive">
       </testcase>
       <testcase component="Crosswalk Use Cases/WebAPI" execution_type="manual" id="InAppPayment" platform="android" priority="P0" purpose="InAppPayment" status="approved" type="functional_positive">
       </testcase>
       <testcase component="Crosswalk Use Cases/WebAPI" execution_type="manual" id="DownloadAndroid" platform="android" priority="P0" purpose="DownloadAndroid" status="design" type="functional_positive">
       </testcase>
-      <testcase component="Crosswalk Use Cases/WebAPI" execution_type="manual" id="Es6NumericLiterals" platform="all" priority="P0" purpose="Es6NumericLiterals" status="approved" type="functional_positive">
+      <testcase component="Crosswalk Use Cases/WebAPI" execution_type="auto" id="Es6NumericLiterals" platform="all" priority="P0" purpose="Es6NumericLiterals" status="approved" type="functional_positive">
+        <description>
+          <bdd_test_script_entry test_script_expected_result="0">/opt/usecase-webapi-xwalk-tests/testscripts/Es6NumericLiterals.feature</bdd_test_script_entry>
+        </description>
       </testcase>
-      <testcase component="Crosswalk Use Cases/WebAPI" execution_type="manual" id="FileApiPersistent" platform="all" priority="P0" purpose="FileApiPersistent" status="approved" type="functional_positive">
+      <testcase component="Crosswalk Use Cases/WebAPI" execution_type="auto" id="FileApiPersistent" platform="all" priority="P0" purpose="FileApiPersistent" status="approved" type="functional_positive">
+        <description>
+          <bdd_test_script_entry test_script_expected_result="0">/opt/usecase-webapi-xwalk-tests/testscripts/FileApiPersistent.feature</bdd_test_script_entry>
+        </description>
       </testcase>
       <testcase component="sample" type="functional_positive" status="approved" execution_type="manual" platform="tizen" priority="P0" id="MediaRenderer" purpose="Media Renderer">
       </testcase>

--- a/usecase/usecase-webapi-xwalk-tests/tests.tizen.xml
+++ b/usecase/usecase-webapi-xwalk-tests/tests.tizen.xml
@@ -178,9 +178,9 @@
       </testcase>
     </set>
     <set background="brand-danger3" icon="glyphicon-gift" name="Others APIs">
-      <testcase component="Crosswalk Use Cases/WebAPI" execution_type="manual" id="Es6NumericLiterals" purpose="Es6NumericLiterals">
+      <testcase component="Crosswalk Use Cases/WebAPI" execution_type="auto" id="Es6NumericLiterals" purpose="Es6NumericLiterals">
       </testcase>
-      <testcase component="Crosswalk Use Cases/WebAPI" execution_type="manual" id="FileApiPersistent" purpose="FileApiPersistent">
+      <testcase component="Crosswalk Use Cases/WebAPI" execution_type="auto" id="FileApiPersistent" purpose="FileApiPersistent">
       </testcase>
       <testcase component="sample" execution_type="manual" id="MediaRenderer" purpose="Media Renderer">
       </testcase>

--- a/usecase/usecase-webapi-xwalk-tests/testscripts/Es6NumericLiterals.feature
+++ b/usecase/usecase-webapi-xwalk-tests/testscripts/Es6NumericLiterals.feature
@@ -1,0 +1,8 @@
+Feature: Usecase WebAPI
+ Scenario: Others APIs/Es6NumericLiterals Test
+    When launch "usecase-webapi-xwalk-tests"
+     And I go to "/samples/Es6NumericLiterals/index.html"
+     And I go to frame "resFrame"
+    Then I should see "true" in "blog" area
+    Then I should see "true" in "olog" area
+

--- a/usecase/usecase-webapi-xwalk-tests/testscripts/FileApiPersistent.feature
+++ b/usecase/usecase-webapi-xwalk-tests/testscripts/FileApiPersistent.feature
@@ -1,0 +1,10 @@
+Feature: Usecase WebAPI
+ Scenario: Others APIs/FileApiPersistent Test
+    When launch "usecase-webapi-xwalk-tests"
+     And I go to "/samples/FileApiPersistent/index.html"
+     And I go to frame "resFrame"
+     And I click "bt1"
+    Then I should see "Write completed" in "log" area
+     And I click "bt2"
+    Then I should see "PERSISTENT CONTENT" in "log" area
+


### PR DESCRIPTION
- Fail Reason: the Es6NumericLiterals is not supported.

Impacted TCs num(approved): New 0, Update 2, Delete 0
Unit test Platform: Andriod
Unit test result summary: Pass 1, Fail 1, Blocked 0