### PR TITLE
[webapi][xwalk-1893] Add note message for nacl

### DIFF
--- a/webapi/webapi-nacl-xwalk-tests/README
+++ b/webapi/webapi-nacl-xwalk-tests/README
@@ -7,6 +7,12 @@ This test suite is for testing webapi-nacl-xwalk-tests specification:
 
 Make sure there is a nacl server in network
 
+## Note
+
+* Nacl_api_Var_Dictionary.html:
+  [XWALK-1893] "Function Delete returned undefined" error occurred when deleting key value in the Nacl module's dictionary,
+  the issue has tracked by  https://code.google.com/p/nativeclient/issues/detail?id=3919
+
 ## Authors:
 
 * Wang, Hongjuan <hongjuanx.wang@intel.com>


### PR DESCRIPTION
- Nacl_api_Var_Dictionary.html has one bug:
  [XWALK-1893] "Function Delete returned undefined" error occurred when deleting key value in the Nacl module's dictionary,
  the issue has tracked by  https://code.google.com/p/nativeclient/issues/detail?id=3919