### PR TITLE
[webapi][xwalk-3765] Increase allowed timing delta

### DIFF
--- a/webapi/webapi-resourcetiming-w3c-tests/resourcetiming-py/w3c/submission/COPYING
+++ b/webapi/webapi-resourcetiming-w3c-tests/resourcetiming-py/w3c/submission/COPYING
@@ -5,6 +5,10 @@ with some modification:
 1. Pull request: https://github.com/w3c/web-platform-tests/pull/402
                  https://github.com/w3c/web-platform-tests/pull/426
 
+2. test_resource_timing.html
+- var TEST_ALLOWED_TIMING_DELTA = 20;
++ var TEST_ALLOWED_TIMING_DELTA = 100;
+
 These tests are copyright by W3C and/or the author listed in the test
 file. The tests are dual-licensed under the W3C Test Suite License:
 http://www.w3.org/Consortium/Legal/2008/04-testsuite-license

--- a/webapi/webapi-resourcetiming-w3c-tests/resourcetiming-py/w3c/submission/test_resource_timing.html
+++ b/webapi/webapi-resourcetiming-w3c-tests/resourcetiming-py/w3c/submission/test_resource_timing.html
@@ -16,7 +16,7 @@
 
         var URL_PREFIX = pathname + "resources/";
         var TEST_TIMEOUT = 30 * 1000;   //Test will timeout in 30 seconds
-        var TEST_ALLOWED_TIMING_DELTA = 20;
+        var TEST_ALLOWED_TIMING_DELTA = 100;
 
         var waitTimer;
         var expectedEntries = new Array();

--- a/webapi/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/COPYING
+++ b/webapi/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/COPYING
@@ -5,6 +5,11 @@ with some modification:
 1. Pull request: https://github.com/w3c/web-platform-tests/pull/402
                  https://github.com/w3c/web-platform-tests/pull/426
 
+2. test_resource_timing.html
+- var TEST_ALLOWED_TIMING_DELTA = 20;
++ var TEST_ALLOWED_TIMING_DELTA = 100;
+
+
 These tests are copyright by W3C and/or the author listed in the test
 file. The tests are dual-licensed under the W3C Test Suite License:
 http://www.w3.org/Consortium/Legal/2008/04-testsuite-license

--- a/webapi/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_timing.html
+++ b/webapi/webapi-resourcetiming-w3c-tests/resourcetiming/w3c/submission/test_resource_timing.html
@@ -16,7 +16,7 @@
 
         var URL_PREFIX = pathname + "resources/";
         var TEST_TIMEOUT = 30 * 1000;   //Test will timeout in 30 seconds
-        var TEST_ALLOWED_TIMING_DELTA = 20;
+        var TEST_ALLOWED_TIMING_DELTA = 100;
 
         var waitTimer;
         var expectedEntries = new Array();


### PR DESCRIPTION
- Sometimes the TEST_ALLOWED_TIMING_DELTA is too short
  when the testing device in poor performance

Impacted tests(approved): new 1, update 0, delete 0
Unit test platform: [Android][Crosswalk 13.41.309.0]
Unit test result summary: pass 1, fail 0, block 0