### PR TITLE
[apptools]Add apptools test suite for linux

### DIFF
--- a/apptools/apptools-linux-tests/COPYING
+++ b/apptools/apptools-linux-tests/COPYING
@@ -1,0 +1,24 @@
+Copyright (c) 2015 Intel Corporation.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of works must retain the original copyright notice, this list
+  of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the original copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Intel Corporation nor the names of its contributors
+  may be used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/apptools/apptools-linux-tests/README
+++ b/apptools/apptools-linux-tests/README
@@ -1,0 +1,31 @@
+## Introduction
+
+This test suite is for apptools-linux-tests
+1. ./allpairs.py is create pkgName.py and report directory for package name
+
+## Precondition
+
+1. The Node.js, the debuild tool, the Crosswalk runtime, and git must be functional
+2. Download crosswalk-app-tools and configure it
+    2.1 Download Crosswalk app tools:  git clone https://github.com/crosswalk-project/crosswalk-app-tools.git  
+    2.2 Initialize the Crosswalk app tools:  cd crosswalk-app-tools , then  npm install  
+    3.3 Checkout the deb backend:  cd node_modules , then  git clone https://github.com/crosswalk-project/crosswalk-app-tools-deb.git crosswalk-app-tools-backend-deb  
+    4.4 Install dependencies:  cd crosswalk-app-tools-backend-deb , then  npm install , and  cd ../..  
+    5.5 The main script is  crosswalk-app-tools/bin/crosswalk-app . Set environment PATH or invoke with directory
+
+## Test Steps
+
+1. unzip apptools-linux-tests<version>.zip -d [testprefix-path]
+2. cd [testprefix-path]/opt/apptools-linux-tests/
+3. run test case
+    testkit-lite -f $PWD/tests.xml -A --comm deepin --testprefix $PWD/../../ -o $PWD/result.xml
+
+## Authors:
+
+* Yin, Haichao <haichaox.yin@intel.com>
+
+## LICENSE
+
+Copyright (c) 2015 Intel Corporation.
+Except as noted, this software is licensed under BSD-3-Clause License.
+Please see the COPYING file for the BSD-3-Clause License.

--- a/apptools/apptools-linux-tests/apptools/allpairs.py
+++ b/apptools/apptools-linux-tests/apptools/allpairs.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2015 Intel Corporation.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of works must retain the original copyright notice, this
+#   list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the original copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+# * Neither the name of Intel Corporation nor the names of its contributors
+#   may be used to endorse or promote products derived from this work without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Authors:
+#         Yin, Haichao<haichaox.yin@intel.com>
+
+import os
+import sys
+import commands
+import shutil
+import comm
+
+def generate_unittest():
+    try:
+        flag = ''
+        num = 0
+        reportPath = os.path.join(comm.SCRIPT_DIR_NAME, '../report')
+        comm.setUp()
+        positive_datas = ['org.xwalk.tests', 'org.xwalk.t1234', 'org.example._xwalk', 'org.example.xwal_', 'org.example.te_st', 'org.xwalk.Tests', 'or_g.example.xwalk', 'org000.example.xwalk', '_org.example.xwalk', 'org.example123.xwalk']  
+        negative_datas = ['org.xwalk', 'test', 'org.example.1234test', 'org.example.1234', '123org.example.xwalk', 'org.123example.xwalk']
+
+        if os.path.exists(reportPath):
+            shutil.rmtree(reportPath)
+        os.mkdir(reportPath)
+        pkgNameTestPath = os.path.join(comm.SCRIPT_DIR_NAME, "pkgName.py")
+        if os.path.exists(pkgNameTestPath):
+                os.remove(pkgNameTestPath)
+        testfile = open(pkgNameTestPath,'a+')
+        testfile.write(
+            "#!/usr/bin/env python \n# coding=utf-8 \nimport random,os,sys,unittest,allpairs \nreload(sys) \nsys.setdefaultencoding( \"utf-8\" ) \nclass TestCaseUnit(unittest.TestCase): \n "
+        )
+                
+        for positive_data in positive_datas:
+            num += 1
+            flag = 'positive' + str(num)
+            cmd = positive_data
+            casenum = "\n  def test_pkgName_" + flag + "(self):\n     self.assertEqual(\"PASS\", allpairs.tryRunApp(\"" + flag +"\", \"" + cmd+ "\"))"+ "\n"
+            testfile.write(casenum)
+        for negative_data in negative_datas:
+            num += 1
+            flag = 'negative' + str(num)
+            cmd = negative_data
+            casenum = "\n  def test_pkgName_" + flag + "(self):\n     self.assertEqual(\"PASS\", allpairs.tryRunApp(\"" + flag +"\", \"" + cmd+ "\"))"+ "\n"
+            testfile.write(casenum)
+        testfile.write("\nif __name__ == '__main__':\n    unittest.main()")
+        testfile.close()
+        os.system("chmod +x " + pkgNameTestPath)
+    except Exception,e:
+        print Exception,"Generate pkgName.py error:",e
+        sys.exit(1)
+
+def tryRunApp(item, projectName):
+    try:
+        comm.setUp()
+        flag = item[:10].strip()
+        os.system("chmod 777 " + comm.TEMP_DATA_PATH)
+        os.chdir(comm.TEMP_DATA_PATH)
+        cmd = "crosswalk-app create " + projectName
+        packstatus = commands.getstatusoutput(cmd)
+
+        if 'negative' in flag:
+            if 'ERROR' in packstatus[1]:
+                result = 'PASS'
+                print "%21s\tFILE\tFILE" % projectName
+            else:
+                result = 'FILE'
+                print "%21s\tFILE\tPASS" % projectName
+        elif 'positive' in flag:
+            if packstatus[0] == 0:
+                result = 'PASS'
+                print "%21s\tPASS\tPASS" % projectName
+            else:
+                result = 'FILE'
+                print "%21s\tPASS\tFILE" % projectName
+
+        comm.cleanTempData(projectName)
+        os.chdir(comm.SCRIPT_DIR_NAME)
+        os.system("rm -R " + comm.TEMP_DATA_PATH)
+        return result
+    except Exception,e:
+        print Exception,"Run pkgName.py error:",e
+        sys.exit(1)
+
+if __name__ == '__main__':
+    generate_unittest()

--- a/apptools/apptools-linux-tests/apptools/build.py
+++ b/apptools/apptools-linux-tests/apptools/build.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2015 Intel Corporation.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of works must retain the original copyright notice, this
+#   list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the original copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+# * Neither the name of Intel Corporation nor the names of its contributors
+#   may be used to endorse or promote products derived from this work without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Authors:
+#         Yin, Haichao<haichaox.yin@intel.com>
+
+import unittest
+import os
+import comm
+
+class TestCrosswalkApptoolsFunctions(unittest.TestCase):
+    def test_build_normal(self):
+        comm.setUp()
+        comm.create(self)
+        os.chdir(comm.TEST_PROJECT_COMM)
+        buildcmd = "crosswalk-app build"
+        comm.build(self, buildcmd)
+        comm.run(self)
+        comm.cleanTempData(comm.TEST_PROJECT_COMM)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/apptools/apptools-linux-tests/apptools/comm.py
+++ b/apptools/apptools-linux-tests/apptools/comm.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2015 Intel Corporation.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of works must retain the original copyright notice, this
+#   list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the original copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+# * Neither the name of Intel Corporation nor the names of its contributors
+#   may be used to endorse or promote products derived from this work without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Authors:
+#         Yin, Haichao<haichaox.yin@intel.com>
+
+import os
+import sys
+import commands
+import shutil
+
+SCRIPT_FILE_PATH = os.path.realpath(__file__)
+SCRIPT_DIR_NAME = os.path.dirname(SCRIPT_FILE_PATH)
+TEMP_DATA_PATH = os.path.join(SCRIPT_DIR_NAME, "../tempdata/")
+TEST_PROJECT_COMM = "org.xwalk.testlinux"
+
+def setUp():
+    if not 'crosswalk-app' in os.environ.get('PATH'):
+        print "Please set environment path for crosswalk-app"
+        sys.exit(1)
+
+    if not os.path.exists(TEMP_DATA_PATH):
+        os.mkdir(TEMP_DATA_PATH)
+        os.system("chmod +x " + TEMP_DATA_PATH)
+    
+def cleanTempData(removeForder):
+    removeForder = os.path.join(TEMP_DATA_PATH, removeForder)
+    if os.path.exists(removeForder):
+        shutil.rmtree(removeForder)
+
+def create(self):
+    try:
+		setUp()
+		os.chdir(TEMP_DATA_PATH)
+		cleanTempData(TEST_PROJECT_COMM)
+		cmd = "crosswalk-app create " + TEST_PROJECT_COMM
+		packstatus = commands.getstatusoutput(cmd)
+		self.assertEquals(packstatus[0], 0)
+		self.assertIn(TEST_PROJECT_COMM, os.listdir(TEMP_DATA_PATH))
+    except Exception,e:
+        print Exception,"Create org.xwalk.testlinux error:",e
+        sys.exit(1)
+
+def build(self, cmd):
+    buildstatus = commands.getstatusoutput(cmd)
+    self.assertEquals(buildstatus[0], 0)
+    self.assertIn("pkg", os.listdir(os.path.join(TEMP_DATA_PATH, TEST_PROJECT_COMM)))
+    os.chdir('pkg')
+    debs = os.listdir(os.getcwd())
+    for deb in debs:
+        print "The pkg deb is " + deb
+        self.assertIn(".deb", deb)
+
+def run(self):
+    setUp()
+    debs = os.listdir(os.getcwd())
+    for deb in debs:
+        projectName = deb.split('_')[0]
+        cmdInstall = 'sudo dpkg -i ' + deb
+        cmdSearchList = 'dpkg -l ' + projectName
+        cmdLaunch = projectName
+        cmdUninstall = 'sudo dpkg -P ' + projectName
+
+        print "Begin install deb file " + deb
+        instStatus = commands.getstatusoutput(cmdInstall)
+        self.assertEquals(instStatus[0], 0)
+        print "Begin search deb file " + projectName
+        listStatus = commands.getstatusoutput(cmdSearchList)
+        self.assertTrue(listStatus)
+        print "Begin launch deb file " + projectName
+        launchStatus = commands.getstatusoutput(cmdLaunch)
+        self.assertEquals(launchStatus[0], 0)
+        print "Begin uninstall deb file " + projectName
+        uninstStatus = commands.getstatusoutput(cmdUninstall)
+        self.assertEquals(uninstStatus[0], 0)
+
+    try:
+        shutil.rmtree(TEMP_DATA_PATH)
+    except:
+        os.system("rm -rf " + TEMP_DATA_PATH + "/* &>/dev/null")
+        os.system("rm -R " + TEMP_DATA_PATH)

--- a/apptools/apptools-linux-tests/apptools/create.py
+++ b/apptools/apptools-linux-tests/apptools/create.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2015 Intel Corporation.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of works must retain the original copyright notice, this
+#   list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the original copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+# * Neither the name of Intel Corporation nor the names of its contributors
+#   may be used to endorse or promote products derived from this work without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+# EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Authors:
+#         Yin, Haichao<haichaox.yin@intel.com>
+
+import unittest
+import sys
+import os
+import commands
+import comm
+
+class TestCrosswalkApptoolsFunctions(unittest.TestCase):
+    def test_normal(self):
+        comm.create(self)
+        comm.cleanTempData(comm.TEST_PROJECT_COMM)
+
+    def test_dir_exist(self):
+        try:
+            comm.setUp()
+            os.chdir(comm.TEMP_DATA_PATH)
+            os.mkdir(comm.TEST_PROJECT_COMM)
+            cmd = "crosswalk-app create " + comm.TEST_PROJECT_COMM
+            packstatus = commands.getstatusoutput(cmd)
+            '''
+            2048 return from packstatus, is directory already exist
+            '''
+            self.assertEquals(packstatus[0], 2048)
+            comm.cleanTempData(comm.TEST_PROJECT_COMM)
+        except Exception,e:
+            print Exception,"Create org.xwalk.testlinux error:",e
+            sys.exit(1)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/apptools/apptools-linux-tests/apptools/pkgName.py
+++ b/apptools/apptools-linux-tests/apptools/pkgName.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python 
+# coding=utf-8 
+import random,os,sys,unittest,allpairs 
+reload(sys) 
+sys.setdefaultencoding( "utf-8" ) 
+class TestCaseUnit(unittest.TestCase): 
+ 
+  def test_pkgName_positive1(self):
+     self.assertEqual("PASS", allpairs.tryRunApp("positive1", "org.xwalk.tests"))
+
+  def test_pkgName_positive2(self):
+     self.assertEqual("PASS", allpairs.tryRunApp("positive2", "org.xwalk.t1234"))
+
+  def test_pkgName_positive3(self):
+     self.assertEqual("PASS", allpairs.tryRunApp("positive3", "org.example._xwalk"))
+
+  def test_pkgName_positive4(self):
+     self.assertEqual("PASS", allpairs.tryRunApp("positive4", "org.example.xwal_"))
+
+  def test_pkgName_positive5(self):
+     self.assertEqual("PASS", allpairs.tryRunApp("positive5", "org.example.te_st"))
+
+  def test_pkgName_positive6(self):
+     self.assertEqual("PASS", allpairs.tryRunApp("positive6", "org.xwalk.Tests"))
+
+  def test_pkgName_positive7(self):
+     self.assertEqual("PASS", allpairs.tryRunApp("positive7", "or_g.example.xwalk"))
+
+  def test_pkgName_positive8(self):
+     self.assertEqual("PASS", allpairs.tryRunApp("positive8", "org000.example.xwalk"))
+
+  def test_pkgName_positive9(self):
+     self.assertEqual("PASS", allpairs.tryRunApp("positive9", "_org.example.xwalk"))
+
+  def test_pkgName_positive10(self):
+     self.assertEqual("PASS", allpairs.tryRunApp("positive10", "org.example123.xwalk"))
+
+  def test_pkgName_negative11(self):
+     self.assertEqual("PASS", allpairs.tryRunApp("negative11", "org.xwalk"))
+
+  def test_pkgName_negative12(self):
+     self.assertEqual("PASS", allpairs.tryRunApp("negative12", "test"))
+
+  def test_pkgName_negative13(self):
+     self.assertEqual("PASS", allpairs.tryRunApp("negative13", "org.example.1234test"))
+
+  def test_pkgName_negative14(self):
+     self.assertEqual("PASS", allpairs.tryRunApp("negative14", "org.example.1234"))
+
+  def test_pkgName_negative15(self):
+     self.assertEqual("PASS", allpairs.tryRunApp("negative15", "123org.example.xwalk"))
+
+  def test_pkgName_negative16(self):
+     self.assertEqual("PASS", allpairs.tryRunApp("negative16", "org.123example.xwalk"))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/apptools/apptools-linux-tests/suite.json
+++ b/apptools/apptools-linux-tests/suite.json
@@ -1,0 +1,23 @@
+{
+    "pkg-blacklist": [
+        "config.xml",
+        "pack.py",
+        "testcase.xsl",
+        "testresult.xsl",
+        "tests.css",
+        "icon.png",
+        "manifest.json",
+        "suite.json",
+        "inst.*"
+    ],
+    "pkg-list": {
+        "deb": {
+            "blacklist": [],
+            "copylist": {
+                "tests.full.xml": "tests.full.xml",
+                "tests.xml": "tests.xml"
+            }
+        }
+    },
+    "pkg-name": "apptools-linux-tests"
+}

--- a/apptools/apptools-linux-tests/tests.full.xml
+++ b/apptools/apptools-linux-tests/tests.full.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="./testcase.xsl"?>
+<test_definition>
+  <suite category="Crosswalk App Tools" name="wrt-apptools-linux-tests">
+    <set name="apptools" type="pyunit">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create" priority="P1" purpose="Linux - Validate if App Tool can work well with create option" status="approved" type="Functional" subcase="3">
+        <description>
+          <test_script_entry>/opt/wrt-apptools-linux-tests/apptools/create.py</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_build" priority="P1" purpose="Linux - Validate if App Tool can work well with build option" status="designed" type="Functional" subcase="2">
+        <description>
+          <test_script_entry>/opt/wrt-apptools-linux-tests/apptools/build.py</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_pkgName" priority="P1" purpose="Linux - Validate if the App Tool rules about package name" status="approved" type="Functional" subcase="16">
+        <description>
+          <test_script_entry>/opt/wrt-apptools-linux-tests/apptools/pkgName.py</test_script_entry>
+        </description>
+      </testcase>
+    </set>
+  </suite>
+</test_definition>

--- a/apptools/apptools-linux-tests/tests.full.xml
+++ b/apptools/apptools-linux-tests/tests.full.xml
@@ -3,7 +3,7 @@
 <test_definition>
   <suite category="Crosswalk App Tools" name="wrt-apptools-linux-tests">
     <set name="apptools" type="pyunit">
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create" priority="P1" purpose="Linux - Validate if App Tool can work well with create option" status="approved" type="Functional" subcase="3">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create" priority="P1" purpose="Linux - Validate if App Tool can work well with create option" status="approved" type="Functional" subcase="2">
         <description>
           <test_script_entry>/opt/wrt-apptools-linux-tests/apptools/create.py</test_script_entry>
         </description>

--- a/apptools/apptools-linux-tests/tests.xml
+++ b/apptools/apptools-linux-tests/tests.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="./testcase.xsl"?>
+<test_definition>
+  <suite category="Crosswalk App Tools" name="wrt-apptools-linux-tests">
+    <set name="apptools" type="pyunit">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create" purpose="Linux - Validate if App Tool can work well with create option" subcase="3">
+        <description>
+          <test_script_entry>/opt/wrt-apptools-linux-tests/apptools/create.py</test_script_entry>
+        </description>
+      </testcase>
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_pkgName" purpose="Linux - Validate if the App Tool rules about package name" subcase="16">
+        <description>
+          <test_script_entry>/opt/wrt-apptools-linux-tests/apptools/pkgName.py</test_script_entry>
+        </description>
+      </testcase>
+    </set>
+  </suite>
+</test_definition>

--- a/apptools/apptools-linux-tests/tests.xml
+++ b/apptools/apptools-linux-tests/tests.xml
@@ -3,7 +3,7 @@
 <test_definition>
   <suite category="Crosswalk App Tools" name="wrt-apptools-linux-tests">
     <set name="apptools" type="pyunit">
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create" purpose="Linux - Validate if App Tool can work well with create option" subcase="3">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_create" purpose="Linux - Validate if App Tool can work well with create option" subcase="2">
         <description>
           <test_script_entry>/opt/wrt-apptools-linux-tests/apptools/create.py</test_script_entry>
         </description>


### PR DESCRIPTION
Impacted tests(approved): new 18, update 0, delete 0
Unit test platform: [Linux]
Unit test result summary: pass 16, fail 2, block 0

Fail reason:
  - Create pkgname like "org.example.1234test/org.example.1234" successfully, but expect failed

Bug id: xwalk-3818