### PR TITLE
[webapi][xwalk-3797] Remove unsupported url tests in HTML5 input element

### DIFF
--- a/webapi/webapi-input-html5-tests/tests.full.xml
+++ b/webapi/webapi-input-html5-tests/tests.full.xml
@@ -375,7 +375,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/HTML5 telephone, email and URL state of input element" execution_type="auto" id="url-value-2" priority="P2" purpose="Test checks that the value sanitization algorithm is as follows: Strip leading and trailing whitespace from the value" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/HTML5 telephone, email and URL state of input element" execution_type="auto" id="url-value-2" priority="P2" purpose="Test checks that the value sanitization algorithm is as follows: Strip leading and trailing whitespace from the value" status="designed" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-input-html5-tests/input/w3c/semantics/forms/the-input-element/url.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
         </description>

--- a/webapi/webapi-input-html5-tests/tests.xml
+++ b/webapi/webapi-input-html5-tests/tests.xml
@@ -158,11 +158,6 @@
           <test_script_entry>/opt/webapi-input-html5-tests/input/w3c/semantics/forms/the-input-element/url.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/DOM, Forms and Styles/HTML5 telephone, email and URL state of input element" execution_type="auto" id="url-value-2" purpose="Test checks that the value sanitization algorithm is as follows: Strip leading and trailing whitespace from the value">
-        <description>
-          <test_script_entry>/opt/webapi-input-html5-tests/input/w3c/semantics/forms/the-input-element/url.html?total_num=4&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
-        </description>
-      </testcase>
     </set>
   </suite>
 </test_definition>


### PR DESCRIPTION
- It looks like the white space in url value was only stripped in Chromium M41, while all other releases before and after that one this is not done. Remove the tests from Crosswalk 13.

  See https://code.google.com/p/chromium/issues/detail?id=446108 for more context.