### PR TITLE
[XWALK-3656] Use official start_url member in manifest

### DIFF
--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.baiduhi/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.baiduhi/manifest.json
@@ -1,9 +1,5 @@
 {
   "name": "deepin-webapps-baidu-hi",
   "xwalk_version": "0.0.1",
-  "app": {
-    "launch": {
-      "web_url": "http://web.im.baidu.com"
-    }
-  }
+  "start_url": "http://web.im.baidu.com"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.baidumap/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.baidumap/manifest.json
@@ -1,9 +1,5 @@
 {
   "name": "deepin-webapps-baidu-map",
   "xwalk_version": "0.0.1",
-  "app": {
-    "launch": {
-      "web_url": "http://map.baidu.com"
-    }
-  }
+  "start_url": "http://map.baidu.com"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.baidumusic/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.baidumusic/manifest.json
@@ -1,9 +1,5 @@
 {
   "name": "deepin-webapps-baidu-music",
   "xwalk_version": "0.0.1",
-  "app": {
-    "launch": {
-      "web_url": "http://fm.baidu.com"
-    }
-  }
+  "start_url": "http://fm.baidu.com"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.baiduonlinestorage/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.baiduonlinestorage/manifest.json
@@ -1,9 +1,5 @@
 {
   "name": "deepin-webapps-baidu-online-storage",
   "xwalk_version": "0.0.1",
-  "app": {
-    "launch": {
-      "web_url": "http://pan.baidu.com"
-    }
-  }
+  "start_url": "http://pan.baidu.com"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.cargobridge/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.cargobridge/manifest.json
@@ -1,9 +1,5 @@
 {
   "name": "deepin-webapps-cargo-bridge",
   "xwalk_version": "0.0.1",
-  "app": {
-    "launch": {
-      "web_url": "http://webstore.limexgames.net/ag_cargo_bridge/index.html"
-    }
-  }
+  "start_url": "http://webstore.limexgames.net/ag_cargo_bridge/index.html"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.chainrxn/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.chainrxn/manifest.json
@@ -1,9 +1,5 @@
 {
   "name": "deepin-webapps-chainrxn",
   "xwalk_version": "0.0.1",
-  "app": {
-    "launch": {
-      "web_url": "http://www.yvoschaap.com/chainrxn/"
-    }
-  }
+  "start_url": "http://www.yvoschaap.com/chainrxn/"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.dbankonlinestorage/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.dbankonlinestorage/manifest.json
@@ -1,9 +1,5 @@
 {
   "name": "deepin-webapps-dbank-online-storage",
   "xwalk_version": "0.0.1",
-  "app": {
-    "launch": {
-      "web_url": "http://ww.dbank.com"
-    }
-  }
+  "start_url": "http://ww.dbank.com"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.doitim/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.doitim/manifest.json
@@ -1,9 +1,5 @@
 {
   "name": "deepin-webapps-doit-im",
   "xwalk_version": "0.0.1",
-  "app": {
-    "launch": {
-      "web_url": "http://doit.im"
-    }
-  }
+  "start_url": "http://doit.im"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.douban/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.douban/manifest.json
@@ -1,9 +1,5 @@
 {
   "name": "deepin-webapps-douban",
   "xwalk_version": "0.0.1",
-  "app": {
-    "launch": {
-      "web_url": "http://douban.fm"
-    }
-  }
+      "start_url": "http://douban.fm"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.fetion/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.fetion/manifest.json
@@ -1,9 +1,5 @@
 {
   "name": "deepin-webapps-fetion",
   "xwalk_version": "0.0.1",
-  "app": {
-    "launch": {
-      "web_url": "https://webim.feixin.10086.cn"
-    }
-  }
+  "start_url": "https://webim.feixin.10086.cn"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.kingsoftfastdocs/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.kingsoftfastdocs/manifest.json
@@ -1,9 +1,5 @@
 {
   "name": "deepin-webapps-kingsoft-fast-docs",
   "xwalk_version": "0.0.1",
-  "app": {
-    "launch": {
-      "web_url": "http://w.wps.cn"
-    }
-  }
+  "start_url": "http://w.wps.cn"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.kingsoftonlinestorage/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.kingsoftonlinestorage/manifest.json
@@ -1,9 +1,5 @@
 {
   "name": "deepin-webapps-kingsoft-online-storage",
   "xwalk_version": "0.0.1",
-  "app": {
-    "launch": {
-      "web_url": "http://www.kuaipan.cn"
-    }
-  }
+  "start_url": "http://www.kuaipan.cn"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.kugoumusic/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.kugoumusic/manifest.json
@@ -1,9 +1,5 @@
 {
   "name": "deepin-webapps-kugou-music",
   "xwalk_version": "0.0.1",
-  "app": {
-    "launch": {
-      "web_url": "http://web.kugou.com"
-    }
-  }
+  "start_url": "http://web.kugou.com"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.kuwomusic/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.kuwomusic/manifest.json
@@ -1,9 +1,5 @@
 {
   "name": "deepin-webapps-kuwo-music",
   "xwalk_version": "0.0.1",
-  "app": {
-    "launch": {
-      "web_url": "http://player.kuwo.cn/webmusic/play"
-    }
-  }
+  "start_url": "http://player.kuwo.cn/webmusic/play"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.microsoftskydrive/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.microsoftskydrive/manifest.json
@@ -1,9 +1,5 @@
 {
   "name": "deepin-webapps-microsoft-skydrive",
   "xwalk_version": "0.0.1",
-  "app": {
-    "launch": {
-      "web_url": "https://skydrive.live.com"
-    }
-  }
+  "start_url": "https://skydrive.live.com"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.paulrouget/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.paulrouget/manifest.json
@@ -1,9 +1,5 @@
 {
   "name": "deepin-webapps-paulrouget",
   "xwalk_version": "0.0.1",
-  "app": {
-    "launch": {
-      "web_url": "https://developer.cdn.mozilla.net/media/uploads/demos/p/a/paulrouget/47e916de488e745f95aee0bc32d5fd31/runfield_1327576901_demo_package/index.html"
-    }
-  }
+  "start_url": "https://developer.cdn.mozilla.net/media/uploads/demos/p/a/paulrouget/47e916de488e745f95aee0bc32d5fd31/runfield_1327576901_demo_package/index.html"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.pirateslovedaisies/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.pirateslovedaisies/manifest.json
@@ -1,9 +1,5 @@
 {
   "name": "deepin-webapps-pirateslovedaisies",
   "xwalk_version": "0.0.1",
-  "app": {
-    "launch": {
-      "web_url": "http://www.pirateslovedaisies.com"
-    }
-  }
+  "start_url": "http://www.pirateslovedaisies.com"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.sinaweibo/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.sinaweibo/manifest.json
@@ -1,9 +1,5 @@
 {
   "name": "deepin-webapps-sina-weibo",
   "xwalk_version": "0.0.1",
-  "app": {
-    "launch": {
-      "web_url": "http://weibo.com"
-    }
-  }
+  "start_url": "http://weibo.com"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.test12306/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.test12306/manifest.json
@@ -1,9 +1,5 @@
 {
   "name": "deepin-webapps-12306",
   "xwalk_version": "0.0.1",
-  "app": {
-    "launch": {
-      "web_url": "https://kyfw.12306.cn/otn"
-    }
-  }
+  "start_url": "https://kyfw.12306.cn/otn"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.towerim/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.towerim/manifest.json
@@ -1,9 +1,5 @@
 {
   "name": "deepin-webapps-towerim",
   "xwalk_version": "0.0.1",
-  "app": {
-    "launch": {
-      "web_url": "http://tower.im"
-    }
-  }
+  "start_url": "http://tower.im"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.ttpod/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.ttpod/manifest.json
@@ -1,9 +1,5 @@
 {
   "name": "deepin-webapps-ttpod",
   "xwalk_version": "0.0.1",
-  "app": {
-    "launch": {
-      "web_url": "http://www.dongting.com"
-    }
-  }
+  "start_url": "http://www.dongting.com"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.xiamimusic/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.xiamimusic/manifest.json
@@ -1,9 +1,5 @@
 {
   "name": "deepin-webapps-xiami-music",
   "xwalk_version": "0.0.1",
-  "app": {
-    "launch": {
-      "web_url": "http://www.xiami.com/app/webmusic/index"
-    }
-  }
+  "start_url": "http://www.xiami.com/app/webmusic/index"
 }

--- a/misc/webappmanu-linux-tests/webapp/resources/org.webapps.youdaonote/manifest.json
+++ b/misc/webappmanu-linux-tests/webapp/resources/org.webapps.youdaonote/manifest.json
@@ -1,9 +1,5 @@
 {
   "name": "deepin-webapps-youdao-note",
   "xwalk_version": "0.0.1",
-  "app": {
-    "launch": {
-      "web_url": "http://note.youdao.com"
-    }
-  }
+  "start_url": "http://note.youdao.com"
 }

--- a/usecase/usecase-wrt-linux-tests/res/testapp/org.packagemanage.cookies/manifest.json
+++ b/usecase/usecase-wrt-linux-tests/res/testapp/org.packagemanage.cookies/manifest.json
@@ -9,9 +9,5 @@
             "density": "1.0"
         }
     ],
-    "app": {
-      "launch": {
-        "web_url": "http://www.quirksmode.org/js/cookies.html"
-      }
-    }
+    "start_url": "http://www.quirksmode.org/js/cookies.html"
 }

--- a/usecase/usecase-wrt-linux-tests/res/testapp/org.packagemanage.cookiesupgrade/manifest.json
+++ b/usecase/usecase-wrt-linux-tests/res/testapp/org.packagemanage.cookiesupgrade/manifest.json
@@ -9,9 +9,5 @@
             "density": "1.0"
         }
     ],
-    "app": {
-      "launch": {
-        "web_url": "http://www.quirksmode.org/js/cookies.html"
-      }
-    }
+    "start_url": "http://www.quirksmode.org/js/cookies.html"
 }


### PR DESCRIPTION
The start_url is an official member of manifest for a web application
specified at http://w3c.github.io/manifest/#start_url-member

It should be supported by Crosswalk Project since there are two features
requirement at
https://crosswalk-project.org/jira/browse/XWALK-890
https://crosswalk-project.org/jira/browse/XWALK-3696

However it is reported that an error appears when use, at
https://crosswalk-project.org/jira/browse/XWALK-3656

... and that is why the app->launch->web_url workaround is used.