### PR TITLE
[embeddingapi][XWALK-2754][hotfix] Adjust cases according to the change of onCreateWindowRequested feature

### DIFF
--- a/embeddingapi/embedding-api-android-tests/embeddingapi/assets/window_create_open.html
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/assets/window_create_open.html
@@ -5,30 +5,14 @@
 <title>test</title>
 <script language="javascript">
 
-function createWindow_open_self() {
-  window.open("index.html", "_self", "");
-}
-
-function createWindow_open_parent() {
-  window.open("index.html", "_parent", "");
-}
-
-function createWindow_open_top() {
-  window.open("index.html", "_top", "");
+function createWindow_open_blank() {
+  window.open("index.html", "_blank", "");
 }
 
 </script>
 </head>
 <body>
-  <button id="create_window_open_self" onclick="createWindow_open_self();">Create Window Self</button>
-  <button id="create_window_open_parent" onclick="createWindow_open_parent();">Create Window Parent</button>
-  <button id="create_window_open_top" onclick="createWindow_open_top();">Create Window Top</button>
-  
-  <!--<a id="create_window_a_blank" href="index.html" target="_blank">Create Window blank</a>-->
-
-  <a id="create_window_a_self" href="index.html" target="_self">Create Window Self</a>
-  <a id="create_window_a_parent" href="index.html" target="_parent">Create Window Parent</a>
-  <a id="create_window_a_top" href="index.html" target="_top">Create Window Top</a>
-
+  <button id="create_window_open_blank" onclick="createWindow_open_blank();">Create Window Blank</button>
+  <a id="create_window_a_blank" href="index.html" target="_blank">Create Window Blank</a>
 </body>
 </html>

--- a/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v4/XWalkUIClientTest.java
+++ b/embeddingapi/embedding-api-android-tests/embeddingapi/src/org/xwalk/embedding/test/v4/XWalkUIClientTest.java
@@ -16,13 +16,13 @@ import android.test.suitebuilder.annotation.SmallTest;
 public class XWalkUIClientTest extends XWalkViewTestBase {
 
     @SmallTest
-    public void testOnCreateWindowRequested_open_self() {
+    public void testOnCreateWindowRequested_open_blank() {
         try {
             final String url = "file:///android_asset/window_create_open.html";
             loadUrlSync(url);
             OnCreateWindowRequestedHelper mOnCreateWindowRequestedHelper = mTestHelperBridge.getOnCreateWindowRequestedHelper();
             int count = mOnCreateWindowRequestedHelper.getCallCount();
-            clickOnElementId("create_window_open_self",null);
+            clickOnElementId("create_window_open_blank",null);
             mOnCreateWindowRequestedHelper.waitForCallback(count);
             assertTrue(mOnCreateWindowRequestedHelper.getCalled());
         } catch (Exception e) {
@@ -32,77 +32,13 @@ public class XWalkUIClientTest extends XWalkViewTestBase {
     }
 
     @SmallTest
-    public void testOnCreateWindowRequested_open_parent() {
+    public void testOnCreateWindowRequested_navigate_blank() {
         try {
             final String url = "file:///android_asset/window_create_open.html";
             loadUrlSync(url);
             OnCreateWindowRequestedHelper mOnCreateWindowRequestedHelper = mTestHelperBridge.getOnCreateWindowRequestedHelper();
             int count = mOnCreateWindowRequestedHelper.getCallCount();
-            clickOnElementId("create_window_open_parent",null);
-            mOnCreateWindowRequestedHelper.waitForCallback(count);
-            assertTrue(mOnCreateWindowRequestedHelper.getCalled());
-        } catch (Exception e) {
-            assertTrue(false);
-            e.printStackTrace();
-        }
-    }
-
-    @SmallTest
-    public void testOnCreateWindowRequested_open_top() {
-        try {
-            final String url = "file:///android_asset/window_create_open.html";
-            loadUrlSync(url);
-            OnCreateWindowRequestedHelper mOnCreateWindowRequestedHelper = mTestHelperBridge.getOnCreateWindowRequestedHelper();
-            int count = mOnCreateWindowRequestedHelper.getCallCount();
-            clickOnElementId("create_window_open_top",null);
-            mOnCreateWindowRequestedHelper.waitForCallback(count);
-            assertTrue(mOnCreateWindowRequestedHelper.getCalled());
-        } catch (Exception e) {
-            assertTrue(false);
-            e.printStackTrace();
-        }
-    }
-
-    @SmallTest
-    public void testOnCreateWindowRequested_navigate_self() {
-        try {
-            final String url = "file:///android_asset/window_create_open.html";
-            loadUrlSync(url);
-            OnCreateWindowRequestedHelper mOnCreateWindowRequestedHelper = mTestHelperBridge.getOnCreateWindowRequestedHelper();
-            int count = mOnCreateWindowRequestedHelper.getCallCount();
-            clickOnElementId("create_window_a_self",null);
-            mOnCreateWindowRequestedHelper.waitForCallback(count);
-            assertTrue(mOnCreateWindowRequestedHelper.getCalled());
-        } catch (Exception e) {
-            assertTrue(false);
-            e.printStackTrace();
-        }
-    }
-
-    @SmallTest
-    public void testOnCreateWindowRequested_navigate_parent() {
-        try {
-            final String url = "file:///android_asset/window_create_open.html";
-            loadUrlSync(url);
-            OnCreateWindowRequestedHelper mOnCreateWindowRequestedHelper = mTestHelperBridge.getOnCreateWindowRequestedHelper();
-            int count = mOnCreateWindowRequestedHelper.getCallCount();
-            clickOnElementId("create_window_a_parent",null);
-            mOnCreateWindowRequestedHelper.waitForCallback(count);
-            assertTrue(mOnCreateWindowRequestedHelper.getCalled());
-        } catch (Exception e) {
-            assertTrue(false);
-            e.printStackTrace();
-        }
-    }
-
-    @SmallTest
-    public void testOnCreateWindowRequested_navigate_top() {
-        try {
-            final String url = "file:///android_asset/window_create_open.html";
-            loadUrlSync(url);
-            OnCreateWindowRequestedHelper mOnCreateWindowRequestedHelper = mTestHelperBridge.getOnCreateWindowRequestedHelper();
-            int count = mOnCreateWindowRequestedHelper.getCallCount();
-            clickOnElementId("create_window_a_top",null);
+            clickOnElementId("create_window_a_blank",null);
             mOnCreateWindowRequestedHelper.waitForCallback(count);
             assertTrue(mOnCreateWindowRequestedHelper.getCalled());
         } catch (Exception e) {


### PR DESCRIPTION
- According to the embeddingapi implement, onCreateWindowRequested only support '_blank', not support '_self', '_parent', '_top', so remove the undesired cases.


Impacted tests(approved): new 2, update 0, delete 6
Unit test platform: [Android]
Unit test result summary: pass 2, fail 0, block 0