### PR TITLE
[webapi] Improve 11 tests for ContactsManager

### DIFF
--- a/webapi/webapi-contactsmanager-w3c-tests/contactsmanager/Contact.html
+++ b/webapi/webapi-contactsmanager-w3c-tests/contactsmanager/Contact.html
@@ -41,8 +41,8 @@ Authors:
 <script>
 
 var contact;
-var data = new Date(1987,10,27);
-var dataString = data.toString();
+var data = new Date();
+var dataTime = data.getTime();
 
 setup(function () {
   var url = new ContactField({
@@ -53,7 +53,7 @@ setup(function () {
   var emailAddr = new ContactField({
     types: ['work'],
     preferred: true,
-    value: 'kangx.xu@intel.com'
+    value: 'tester@sample.com'
   });
   var address = new ContactAddress({
     types: ['work'],
@@ -68,7 +68,7 @@ setup(function () {
   var instantAddr = new ContactField({
     types: ['home'],
     preferred: true,
-    value: 'msn:kangx.xu@intel.com'
+    value: 'msn:tester@sample.com'
   });
   var contactName = new ContactName({
     givenNames: ['John'],
@@ -109,7 +109,7 @@ test(function () {
 
 test(function () {
   assert_true(!!contact, "The Contact initialized");
-  assert_equals(contact.emails[0].value, "kangx.xu@intel.com", "The Contact.emails[0].value");
+  assert_equals(contact.emails[0].value, "tester@sample.com", "The Contact.emails[0].value");
 }, "Check if the Contact emails attribute is valid");
 
 test(function () {
@@ -149,7 +149,7 @@ test(function () {
 
 test(function () {
   assert_true(!!contact, "The Contact initialized");
-  assert_equals(contact.birthday.toString(), dataString, "The Contact.birthday");
+  assert_equals(contact.birthday.getTime(), dataTime, "The Contact.birthday");
 }, "Check if the Contact birthday attribute is valid");
 
 test(function () {
@@ -159,12 +159,12 @@ test(function () {
 
 test(function () {
   assert_true(!!contact, "The Contact initialized");
-  assert_equals(contact.impp[0].value, "msn:kangx.xu@intel.com", "The Contact.impp[0].value");
+  assert_equals(contact.impp[0].value, "msn:tester@sample.com", "The Contact.impp[0].value");
 }, "Check if the Contact impp attribute is valid");
 
 test(function () {
   assert_true(!!contact, "The Contact initialized");
-  assert_equals(contact.anniversary.toString(), dataString, "The Contact.anniversary");
+  assert_equals(contact.anniversary.getTime(), dataTime, "The Contact.anniversary");
 }, "Check if the Contact anniversary attribute is valid");
 
 test(function () {

--- a/webapi/webapi-contactsmanager-w3c-tests/contactsmanager/Contact_attributes.html
+++ b/webapi/webapi-contactsmanager-w3c-tests/contactsmanager/Contact_attributes.html
@@ -42,7 +42,7 @@ Authors:
 var contact;
 
 setup(function () {
-  var data = new Date(1987,10,27);
+  var data = new Date();
   var url = new ContactField({
     types: ['work'],
     preferred: true,
@@ -51,7 +51,7 @@ setup(function () {
   var emailAddr = new ContactField({
     types: ['work'],
     preferred: true,
-    value: 'kangx.xu@intel.com'
+    value: 'tester@sample.com'
   });
   var address = new ContactAddress({
     types: ['work'],
@@ -66,7 +66,7 @@ setup(function () {
   var instantAddr = new ContactField({
     types: ['home'],
     preferred: true,
-    value: 'msn:kangx.xu@intel.com'
+    value: 'msn:tester@sample.com'
   });
   var contactName = new ContactName({
     givenNames: ['John'],

--- a/webapi/webapi-contactsmanager-w3c-tests/contactsmanager/ContactsManager_save_Contact_fullset.html
+++ b/webapi/webapi-contactsmanager-w3c-tests/contactsmanager/ContactsManager_save_Contact_fullset.html
@@ -51,7 +51,7 @@ t.step(function () {
   var emailAddr = new ContactField({
     types: ['work'],
     preferred: true,
-    value: 'kangx.xu@intel.com'
+    value: 'tester@sample.com'
   });
   var address = new ContactAddress({
     types: ['work'],
@@ -66,10 +66,10 @@ t.step(function () {
   var instantAddr = new ContactField({
     types: ['home'],
     preferred: true,
-    value: 'msn:kangx.xu@intel.com'
+    value: 'msn:tester@sample.com'
   });
-  var data = new Date(1987,10,27);
-  var dataString = data.toString();
+  var data = new Date();
+  var dataTime = data.getTime();
   var contactName = new ContactName({
     givenNames: ['John'],
     familyNames: ['Doe']
@@ -96,16 +96,16 @@ t.step(function () {
         assert_equals(info.name.familyNames[0], "Doe", "The Contact.name.familyNames[0]");
         assert_equals(info.phoneNumbers[0].value, "+34698765432", "The Contact.phoneNumbers[0].value");
         assert_equals(info.urls[0].value, "http://www.intel.com/", "The Contact.urls[0].value");
-        assert_equals(info.emails[0].value, "kangx.xu@intel.com", "The Contact.emails[0].value");
+        assert_equals(info.emails[0].value, "tester@sample.com", "The Contact.emails[0].value");
         assert_equals(info.photos[0], "test", "The Contact.photos[0]");
         assert_equals(info.categories[0], "swimmer,biker", "The Contact.categories[0]");
         assert_equals(info.addresses[0].countryName, "china", "The Contact.addresses[0].countryName");
         assert_equals(info.organizations[0], "Bubba Gump Shrimp Co.", "The Contact.organizations[0]");
         assert_equals(info.jobTitles[0], "Shrimp Man", "The Contact.jobTitles[0]");
-        assert_equals(info.birthday.toString(), dataString, "The Contact.birthday");
+        assert_equals(info.birthday.getTime(), dataTime, "The Contact.birthday");
         assert_equals(info.notes[0], "I am proficient in Tiger-Crane Style", "The Contact.notes[0]");
-        assert_equals(info.impp[0].value, "msn:kangx.xu@intel.com", "The Contact.impp[0].value");
-        assert_equals(info.anniversary.toString(), dataString, "The Contact.anniversary");
+        assert_equals(info.impp[0].value, "msn:tester@sample.com", "The Contact.impp[0].value");
+        assert_equals(info.anniversary.getTime(), dataTime, "The Contact.anniversary");
         assert_equals(info.gender, "male", "The Contact.gender attribute");
       });
       t.done();

--- a/webapi/webapi-contactsmanager-w3c-tests/contactsmanager/ContactsManager_save_emails_fullset.html
+++ b/webapi/webapi-contactsmanager-w3c-tests/contactsmanager/ContactsManager_save_emails_fullset.html
@@ -55,7 +55,7 @@ t.step(function () {
   var emailAddr = new ContactField({
     types: ['work'],
     preferred: true,
-    value: 'kangx.xu@intel.com'
+    value: 'tester@sample.com'
   });
   var contact = new Contact({
     name: contactName,
@@ -65,7 +65,7 @@ t.step(function () {
   contacts.save(contact).then(
     function (info) {
       t.step(function () {
-        assert_equals(info.emails[0].value, "kangx.xu@intel.com", "The Contact.emails[0].value");
+        assert_equals(info.emails[0].value, "tester@sample.com", "The Contact.emails[0].value");
         assert_equals(info.emails[0].types[0], "work", "The Contact.emails[0].types[0]");
         assert_true(info.emails[0].preferred, "The value of Contact.emails[0].preferred is true");
       });

--- a/webapi/webapi-contactsmanager-w3c-tests/contactsmanager/ContactsManager_save_emails_multiple.html
+++ b/webapi/webapi-contactsmanager-w3c-tests/contactsmanager/ContactsManager_save_emails_multiple.html
@@ -55,12 +55,12 @@ t.step(function () {
   var emailWork = new ContactField({
     types: ['work'],
     preferred: true,
-    value: 'kangx.xu@intel.com'
+    value: 'tester@sample.com'
   });
   var emailLive = new ContactField({
     types: ['work'],
     preferred: true,
-    value: 'xuk003428@archermind.com'
+    value: 'tester2@sample.com'
   });
   var contact = new Contact({
     name: contactName,
@@ -70,8 +70,8 @@ t.step(function () {
   contacts.save(contact).then(
     function (info) {
       t.step(function () {
-        assert_equals(info.emails[0].value, "kangx.xu@intel.com", "The Contact.emails[0].value");
-        assert_equals(info.emails[1].value, "xuk003428@archermind.com", "The Contact.emails[1].value");
+        assert_equals(info.emails[0].value, "tester@sample.com", "The Contact.emails[0].value");
+        assert_equals(info.emails[1].value, "tester2@sample.com", "The Contact.emails[1].value");
       });
       t.done();
     },

--- a/webapi/webapi-contactsmanager-w3c-tests/contactsmanager/ContactsManager_save_emails_partset.html
+++ b/webapi/webapi-contactsmanager-w3c-tests/contactsmanager/ContactsManager_save_emails_partset.html
@@ -52,7 +52,7 @@ t.step(function () {
     preferred: true,
     value: '+34698765432'
   });
-  var emailAddr = new ContactField({value: 'kangx.xu@intel.com'});
+  var emailAddr = new ContactField({value: 'tester@sample.com'});
   var contact = new Contact({
     name: contactName,
     emails: [emailAddr],
@@ -61,7 +61,7 @@ t.step(function () {
   contacts.save(contact).then(
     function (info) {
       t.step(function () {
-        assert_equals(info.emails[0].value, "kangx.xu@intel.com", "The Contact.emails[0].value");
+        assert_equals(info.emails[0].value, "tester@sample.com", "The Contact.emails[0].value");
       });
       t.done();
     },

--- a/webapi/webapi-contactsmanager-w3c-tests/contactsmanager/ContactsManager_save_impp_fullset.html
+++ b/webapi/webapi-contactsmanager-w3c-tests/contactsmanager/ContactsManager_save_impp_fullset.html
@@ -55,7 +55,7 @@ t.step(function () {
   var instantAddr = new ContactField({
     types: ['home'],
     preferred: true,
-    value: 'msn:kangx.xu@intel.com'
+    value: 'msn:tester@sample.com'
   });
   var contact = new Contact({
     name: contactName,
@@ -66,7 +66,7 @@ t.step(function () {
     function (info) {
       t.step(function () {
         assert_equals(info.impp[0].types[0], "home", "The Contact.impp[0].types[0]");
-        assert_equals(info.impp[0].value, "msn:kangx.xu@intel.com", "The Contact.impp[0].value");
+        assert_equals(info.impp[0].value, "msn:tester@sample.com", "The Contact.impp[0].value");
         assert_true(info.impp[0].preferred, "The value of Contact.impp[0].preferred is true");
       });
       t.done();

--- a/webapi/webapi-contactsmanager-w3c-tests/contactsmanager/ContactsManager_save_impp_multiple.html
+++ b/webapi/webapi-contactsmanager-w3c-tests/contactsmanager/ContactsManager_save_impp_multiple.html
@@ -55,12 +55,12 @@ t.step(function () {
   var instantAddrWork = new ContactField({
     types: ['home'],
     preferred: true,
-    value: 'msn:kangx.xu@intel.com'
+    value: 'msn:tester@sample.com'
   });
   var instantAddrLive = new ContactField({
     types: ['work'],
     preferred: true,
-    value: 'msn:xuk003428@archermind.com'
+    value: 'msn:tester2@sample.com'
   });
   var contact = new Contact({
     name: contactName,
@@ -70,8 +70,8 @@ t.step(function () {
   contacts.save(contact).then(
     function (info) {
       t.step(function () {
-        assert_equals(info.impp[0].value, "msn:kangx.xu@intel.com", "The Contact.impp[0].value");
-        assert_equals(info.impp[1].value, "msn:xuk003428@archermind.com", "The Contact.impp[1].value");
+        assert_equals(info.impp[0].value, "msn:tester@sample.com", "The Contact.impp[0].value");
+        assert_equals(info.impp[1].value, "msn:tester2@sample.com", "The Contact.impp[1].value");
       });
       t.done();
     },

--- a/webapi/webapi-contactsmanager-w3c-tests/contactsmanager/ContactsManager_save_impp_partset.html
+++ b/webapi/webapi-contactsmanager-w3c-tests/contactsmanager/ContactsManager_save_impp_partset.html
@@ -52,7 +52,7 @@ t.step(function () {
     preferred: true,
     value: '+34698765432'
   });
-  var instantAddr = new ContactField({value: 'msn:kangx.xu@intel.com'});
+  var instantAddr = new ContactField({value: 'msn:tester@sample.com'});
   var contact = new Contact({
     name: contactName,
     impp: [instantAddr],
@@ -61,7 +61,7 @@ t.step(function () {
   contacts.save(contact).then(
     function (info) {
       t.step(function () {
-        assert_equals(info.impp[0].value, "msn:kangx.xu@intel.com", "The Contact.impp[0].value");
+        assert_equals(info.impp[0].value, "msn:tester@sample.com", "The Contact.impp[0].value");
       });
       t.done();
     },

--- a/webapi/webapi-contactsmanager-w3c-tests/contactsmanager/ContactsManager_save_urls_multiple.html
+++ b/webapi/webapi-contactsmanager-w3c-tests/contactsmanager/ContactsManager_save_urls_multiple.html
@@ -60,7 +60,7 @@ t.step(function () {
   var urlLive = new ContactField({
     types: ['work'],
     preferred: true,
-    value: 'http://www.baidu.com/'
+    value: 'http://www.sample.com/'
   });
   var contact = new Contact({
     name: contactName,
@@ -71,7 +71,7 @@ t.step(function () {
     function (info) {
       t.step(function () {
         assert_equals(info.urls[0].value, "http://www.intel.com/", "The Contact.urls[0].value");
-        assert_equals(info.urls[1].value, "http://www.baidu.com/", "The Contact.urls[1].value");
+        assert_equals(info.urls[1].value, "http://www.sample.com/", "The Contact.urls[1].value");
       });
       t.done();
     },


### PR DESCRIPTION
Impacted tests(approved): new 0, update 11, delete 0
Unit test platform: [android][crosswalk 14.43.342.0]
Unit test result summary: pass 10, fail 1, block 0

Comments:
Type of Contact.birthday should be Date object, but after
saving, type was changed to "string" in the success callback
of ContactsManager.save(). Issue tracked by XWALK-4108