### PR TITLE
[webapi] Enable Test Suites for Crosswalk Linux

### DIFF
--- a/tools/build/pack_deb.py
+++ b/tools/build/pack_deb.py
@@ -372,6 +372,7 @@ def packDEB(build_json=None, app_src=None, app_dest=None, app_name=None):
     orig_dir = os.getcwd()
     os.chdir(app_src)
     LOG.info("Change dir to : %s" % app_src)
+    pkg_name = "org.test." + app_name.replace("-", "")
 
     if doCMD(pack_cmd, DEFAULT_CMD_TIMEOUT):
 		for parent,dirnames,filenames in os.walk(os.path.join(app_src, "pkg")):
@@ -379,7 +380,7 @@ def packDEB(build_json=None, app_src=None, app_dest=None, app_name=None):
 			if app_name:
 				os.chdir(os.path.join(app_src, "pkg"))
 				for filename in filenames:
-					rename_cmd = "mv %s %s" % (filename, app_name + ".deb")
+					rename_cmd = "mv %s %s" % (filename, pkg_name + ".deb")
 					if not doCMD(rename_cmd, DEFAULT_CMD_TIMEOUT):
 						os.chdir(orig_dir)
 						return False
@@ -415,7 +416,7 @@ def packAPP(build_json=None, app_src=None, app_dest=None, app_name=None):
 def createIndexFile(index_file_path=None, hosted_app=None):
     try:
         index_url = "opt/%s/webrunner/index.html?testsuite=../tests.xml" \
-                        "&testprefix=../../.." % PKG_NAME
+                        "&testprefix=../../../.." % PKG_NAME
         html_content = "<!doctype html><head><meta http-equiv='Refresh' " \
                        "content='1; url=%s'></head>" % index_url
         index_file = open(index_file_path, "w")
@@ -490,7 +491,7 @@ def buildPKGAPP(build_json=None):
 				LOG.error("Fail to make the crosswalk-app-tools-deb dir: %s" % e)
 				return False
 
-		pkg_name = "org.test." + PKG_NAME
+		pkg_name = "org.test." + PKG_NAME.replace("-", "")
 		pack_cmd = "crosswalk-app create " + pkg_name
 		orig_dir = os.getcwd()
 		LOG.info("+Change dir to %s: " % os.path.join(BUILD_ROOT_SRC, "crosswalk-app-tools-deb"))

--- a/webapi/tct-audio-html5-tests/inst.deb.py
+++ b/webapi/tct-audio-html5-tests/inst.deb.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import subprocess
+from optparse import OptionParser
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+PARAMETERS = None
+
+def doCMD(cmd):
+    print "-->> \"%s\"" % cmd
+    output = []
+    cmd_return_code = 1
+    cmd_proc = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
+
+    while True:
+        output_line = cmd_proc.stdout.readline().strip("\r\n")
+        cmd_return_code = cmd_proc.poll()
+        if output_line == '' and cmd_return_code != None:
+            break
+        sys.stdout.write("%s\n" % output_line)
+        sys.stdout.flush()
+        output.append(output_line)
+
+    return (cmd_return_code, output)
+
+def uninstPKGs():
+    action_status = True
+    for root, dirs, files in os.walk(SCRIPT_DIR):
+        for file in files:
+            if file.endswith(".deb"):
+                debName = os.path.basename(os.path.splitext(file)[0])
+                pkg_id = debName.split(".")[-1]
+                (return_code, output) = doCMD(
+                    "sudo dpkg -P %s" % pkg_id)
+                if return_code != 0:
+                    action_status = False
+                    break
+    return action_status
+
+def instPKGs():
+    action_status = True
+    for root, dirs, files in os.walk(SCRIPT_DIR):
+        for file in files:
+            if file.endswith(".deb"):
+                cmd = "sudo dpkg -i %s/%s" % (root, file)
+                (return_code, output) = doCMD(cmd)
+                if return_code != 0:
+                    action_status = False
+                    break
+    return action_status
+
+def main():
+    try:
+        usage = "usage: inst.py -i"
+        opts_parser = OptionParser(usage=usage)
+        opts_parser.add_option(
+            "-i", dest="binstpkg", action="store_true", help="Install package")
+        opts_parser.add_option(
+            "-u", dest="buninstpkg", action="store_true", help="Uninstall package")
+        global PARAMETERS
+        (PARAMETERS, args) = opts_parser.parse_args()
+    except Exception, e:
+        print "Got wrong option: %s, exit ..." % e
+        sys.exit(1)
+
+    if PARAMETERS.binstpkg and PARAMETERS.buninstpkg:
+        print "-i and -u are conflict"
+        sys.exit(1)
+
+    if PARAMETERS.buninstpkg:
+        if not uninstPKGs():
+            sys.exit(1)
+    else:
+        if not instPKGs():
+            sys.exit(1)
+
+if __name__ == "__main__":
+    main()
+    sys.exit(0)

--- a/webapi/tct-audio-html5-tests/suite.json
+++ b/webapi/tct-audio-html5-tests/suite.json
@@ -67,6 +67,23 @@
                     "PACK-TOOL-ROOT/resources/webrunner": "webrunner"
                 }
             }
+        },
+        "deb": {
+            "blacklist": [
+                "*"
+            ],
+            "copylist": {
+                "inst.deb.py": "inst.py",
+                "tests.full.xml": "tests.full.xml",
+                "tests.xml": "tests.xml"
+            },
+            "pkg-app": {
+                "blacklist": ["crosswalk-app-tools-deb"],
+                "copylist": {
+                    "PACK-TOOL-ROOT/resources/webrunner": "webrunner",
+                    "PACK-TOOL-ROOT/resources/testharness": "resources"
+                }
+            }
         }
     },
     "pkg-name": "tct-audio-html5-tests"

--- a/webapi/tct-notification-w3c-tests/inst.deb.py
+++ b/webapi/tct-notification-w3c-tests/inst.deb.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import subprocess
+from optparse import OptionParser
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+PARAMETERS = None
+
+def doCMD(cmd):
+    print "-->> \"%s\"" % cmd
+    output = []
+    cmd_return_code = 1
+    cmd_proc = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
+
+    while True:
+        output_line = cmd_proc.stdout.readline().strip("\r\n")
+        cmd_return_code = cmd_proc.poll()
+        if output_line == '' and cmd_return_code != None:
+            break
+        sys.stdout.write("%s\n" % output_line)
+        sys.stdout.flush()
+        output.append(output_line)
+
+    return (cmd_return_code, output)
+
+def uninstPKGs():
+    action_status = True
+    for root, dirs, files in os.walk(SCRIPT_DIR):
+        for file in files:
+            if file.endswith(".deb"):
+                debName = os.path.basename(os.path.splitext(file)[0])
+                pkg_id = debName.split(".")[-1]
+                (return_code, output) = doCMD(
+                    "sudo dpkg -P %s" % pkg_id)
+                if return_code != 0:
+                    action_status = False
+                    break
+    return action_status
+
+def instPKGs():
+    action_status = True
+    for root, dirs, files in os.walk(SCRIPT_DIR):
+        for file in files:
+            if file.endswith(".deb"):
+                cmd = "sudo dpkg -i %s/%s" % (root, file)
+                (return_code, output) = doCMD(cmd)
+                if return_code != 0:
+                    action_status = False
+                    break
+    return action_status
+
+def main():
+    try:
+        usage = "usage: inst.py -i"
+        opts_parser = OptionParser(usage=usage)
+        opts_parser.add_option(
+            "-i", dest="binstpkg", action="store_true", help="Install package")
+        opts_parser.add_option(
+            "-u", dest="buninstpkg", action="store_true", help="Uninstall package")
+        global PARAMETERS
+        (PARAMETERS, args) = opts_parser.parse_args()
+    except Exception, e:
+        print "Got wrong option: %s, exit ..." % e
+        sys.exit(1)
+
+    if PARAMETERS.binstpkg and PARAMETERS.buninstpkg:
+        print "-i and -u are conflict"
+        sys.exit(1)
+
+    if PARAMETERS.buninstpkg:
+        if not uninstPKGs():
+            sys.exit(1)
+    else:
+        if not instPKGs():
+            sys.exit(1)
+
+if __name__ == "__main__":
+    main()
+    sys.exit(0)

--- a/webapi/tct-notification-w3c-tests/suite.json
+++ b/webapi/tct-notification-w3c-tests/suite.json
@@ -66,6 +66,23 @@
                     "PACK-TOOL-ROOT/resources/webrunner": "webrunner"
                 }
             }
+        },
+        "deb": {
+            "blacklist": [
+                "*"
+            ],
+            "copylist": {
+                "inst.deb.py": "inst.py",
+                "tests.full.xml": "tests.full.xml",
+                "tests.xml": "tests.xml"
+            },
+            "pkg-app": {
+                "blacklist": ["crosswalk-app-tools-deb"],
+                "copylist": {
+                    "PACK-TOOL-ROOT/resources/webrunner": "webrunner",
+                    "PACK-TOOL-ROOT/resources/testharness": "resources"
+                }
+            }
         }
     },
     "pkg-name": "tct-notification-w3c-tests"

--- a/webapi/tct-video-html5-tests/inst.deb.py
+++ b/webapi/tct-video-html5-tests/inst.deb.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import subprocess
+from optparse import OptionParser
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+PARAMETERS = None
+
+def doCMD(cmd):
+    print "-->> \"%s\"" % cmd
+    output = []
+    cmd_return_code = 1
+    cmd_proc = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
+
+    while True:
+        output_line = cmd_proc.stdout.readline().strip("\r\n")
+        cmd_return_code = cmd_proc.poll()
+        if output_line == '' and cmd_return_code != None:
+            break
+        sys.stdout.write("%s\n" % output_line)
+        sys.stdout.flush()
+        output.append(output_line)
+
+    return (cmd_return_code, output)
+
+def uninstPKGs():
+    action_status = True
+    for root, dirs, files in os.walk(SCRIPT_DIR):
+        for file in files:
+            if file.endswith(".deb"):
+                debName = os.path.basename(os.path.splitext(file)[0])
+                pkg_id = debName.split(".")[-1]
+                (return_code, output) = doCMD(
+                    "sudo dpkg -P %s" % pkg_id)
+                if return_code != 0:
+                    action_status = False
+                    break
+    return action_status
+
+def instPKGs():
+    action_status = True
+    for root, dirs, files in os.walk(SCRIPT_DIR):
+        for file in files:
+            if file.endswith(".deb"):
+                cmd = "sudo dpkg -i %s/%s" % (root, file)
+                (return_code, output) = doCMD(cmd)
+                if return_code != 0:
+                    action_status = False
+                    break
+    return action_status
+
+def main():
+    try:
+        usage = "usage: inst.py -i"
+        opts_parser = OptionParser(usage=usage)
+        opts_parser.add_option(
+            "-i", dest="binstpkg", action="store_true", help="Install package")
+        opts_parser.add_option(
+            "-u", dest="buninstpkg", action="store_true", help="Uninstall package")
+        global PARAMETERS
+        (PARAMETERS, args) = opts_parser.parse_args()
+    except Exception, e:
+        print "Got wrong option: %s, exit ..." % e
+        sys.exit(1)
+
+    if PARAMETERS.binstpkg and PARAMETERS.buninstpkg:
+        print "-i and -u are conflict"
+        sys.exit(1)
+
+    if PARAMETERS.buninstpkg:
+        if not uninstPKGs():
+            sys.exit(1)
+    else:
+        if not instPKGs():
+            sys.exit(1)
+
+if __name__ == "__main__":
+    main()
+    sys.exit(0)

--- a/webapi/tct-video-html5-tests/suite.json
+++ b/webapi/tct-video-html5-tests/suite.json
@@ -66,6 +66,23 @@
                     "PACK-TOOL-ROOT/resources/webrunner": "webrunner"
                 }
             }
+        },
+        "deb": {
+            "blacklist": [
+                "*"
+            ],
+            "copylist": {
+                "inst.deb.py": "inst.py",
+                "tests.full.xml": "tests.full.xml",
+                "tests.xml": "tests.xml"
+            },
+            "pkg-app": {
+                "blacklist": ["crosswalk-app-tools-deb"],
+                "copylist": {
+                    "PACK-TOOL-ROOT/resources/webrunner": "webrunner",
+                    "PACK-TOOL-ROOT/resources/testharness": "resources"
+                }
+            }
         }
     },
     "pkg-name": "tct-video-html5-tests"


### PR DESCRIPTION
Enable webapi test suites (Audio/Web Notifications/Video)
on Crosswalk Project for Linux

Audio:
Impacted tests(approved): new 0, update 0, delete 0
Unit test platform: [Linux]
Unit test result summary: pass 246, fail 50, block 45

Video:
Impacted tests(approved): new 0, update 0, delete 0
Unit test platform: [Linux]
Unit test result summary: pass 285, fail 51, block 43

Web Notifications:
Impacted tests(approved): new 0, update 0, delete 0
Unit test platform: [Linux]
Unit test result summary: pass 13, fail 0, block 2