### PR TITLE
modify android application for usecase embeddinapi apk of shared mode

### DIFF
--- a/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/AndroidManifest.xml
@@ -27,7 +27,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
-        android:name="android.app.Application"
+        android:name="org.xwalk.core.XWalkApplication"
         android:hardwareAccelerated="true"
         android:label="usecase-embedding-android-tests" >
         <activity


### PR DESCRIPTION
-App crash when enter Embedding Usecase in shared mode
-Change android application for usecase embeddinapi apk of shared mode

BUG=https://crosswalk-project.org/jira/browse/XWALK-4149
BUG=https://crosswalk-project.org/jira/browse/XWALK-4172

Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: [Android]
Unit test result summary: pass 1, fail 0, block 0