### PR TITLE
[embeddingapi][XWALK-4161]modify AnimatableXWalkViewActivity onDestro…

### DIFF
--- a/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/AnimatableXWalkViewActivity.java
+++ b/usecase/usecase-embedding-android-tests/embeddingapi/src/org/xwalk/embedded/api/sample/AnimatableXWalkViewActivity.java
@@ -52,7 +52,9 @@ public class AnimatableXWalkViewActivity extends XWalkActivity {
         super.onDestroy();
 
         // Reset the preference for animatable XWalkView.
-        XWalkPreferences.setValue(XWalkPreferences.ANIMATABLE_XWALK_VIEW, false);
+        if (mXWalkView != null) {
+            XWalkPreferences.setValue(XWalkPreferences.ANIMATABLE_XWALK_VIEW, false);
+	}
     }
 
     @Override


### PR DESCRIPTION
…y funcation

-App crash when exit 'Animatable XWalkView' case in shared Embedding Usecase
-Add protection in AnimatableXWalkViewActivity onDestroy funcation

BUG=https://crosswalk-project.org/jira/browse/XWALK-4161

Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: [Android]
Unit test result summary: pass 1, fail 0, block 0