### PR TITLE
[usecase-webapi] Resolve unstable issue in ResourceTiming.feature

### DIFF
--- a/usecase/usecase-webapi-xwalk-tests/testscripts/ResourceTiming.feature
+++ b/usecase/usecase-webapi-xwalk-tests/testscripts/ResourceTiming.feature
@@ -1,8 +1,9 @@
 Feature: Usecase WebAPI
  Scenario: Performance & Optimization/ResourceTiming Test
     When launch "usecase-webapi-xwalk-tests"
-     And I go to "/samples/ResourceTiming/index.html"
-     And I press "requestShow"
+    And I go to "/samples/ResourceTiming/index.html"
+    And I press "requestShow"
+    And I wait for 5 seconds
     Then I should see "ms" in "fetchStart_redirectStart" area
     Then I should see "ms" in "domainLookupStart_redirectStart" area
     Then I should see "ms" in "connectStart_domainLookupEnd" area


### PR DESCRIPTION
When the device performance or network in poor, there is no enough
 time for loading resource, this make the test result unstable.
Add waiting time for 5 second.

Impacted tests(approved): new 0, update 1, delete 0
Unit test platform: Crosswalk Project for Android 14.43.342.0
Unit test result summary: pass 1, fail 0, block 0

BUG=https://crosswalk-project.org/jira/browse/XWALK-4095