### PR TITLE
[apptools-android] remove useless code for apptools android

### DIFF
--- a/apptools/apptools-android-tests/apptools/build.py
+++ b/apptools/apptools-android-tests/apptools/build.py
@@ -83,7 +83,6 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         os.remove(os.getcwd() + '/prj/android/xwalk_core_library/libs/x86/libxwalkcore.so')
         buildcmd =  comm.PackTools + "crosswalk-app build"
         buildstatus = commands.getstatusoutput(buildcmd)
-        comm.run(self)
         comm.clear("org.xwalk.test")
         self.assertEquals(buildstatus[0], 1)
 

--- a/apptools/apptools-android-tests/apptools/create_remote.py
+++ b/apptools/apptools-android-tests/apptools/create_remote.py
@@ -58,7 +58,6 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         crosswalk = 'crosswalk-{}.zip'.format(version)
         namelist = os.listdir(os.getcwd())
         self.assertIn(crosswalk, namelist)
-        comm.run(self)
         comm.clear("org.xwalk.test")
         self.assertEquals(packstatus[0], 0)
 

--- a/apptools/apptools-android-tests/apptools/setup_crash_dir.py
+++ b/apptools/apptools-android-tests/apptools/setup_crash_dir.py
@@ -49,7 +49,6 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         os.environ["CROSSWALK_APP_TOOLS_CACHE_DIR"] = comm.XwalkPath
         os.chdir(comm.XwalkPath)
         shutil.rmtree("crash")
-        comm.run(self)
         comm.clear("org.xwalk.test")
         self.assertNotIn("crosswalk-13.42.319.5.zip", namelist)
         self.assertIn("crosswalk-13.42.319.5.zip", crosswalklist)

--- a/apptools/apptools-android-tests/apptools/update.py
+++ b/apptools/apptools-android-tests/apptools/update.py
@@ -53,7 +53,6 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
             cmd = "tac test |sed -n '%dp' |awk -F 'href=' '{print $2}' |awk -F '\"|/' '{print $2}'" % int(line)
             version = commands.getstatusoutput(cmd)[1]
         commands.getstatusoutput("rm -rf test")
-        comm.run(self)
         comm.clear("org.xwalk.test")
         self.assertEquals(currentVersion, version)
 
@@ -75,7 +74,6 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
             cmd = "tac test |sed -n '%dp' |awk -F 'href=' '{print $2}' |awk -F '\"|/' '{print $2}'" % int(line)
             version = commands.getstatusoutput(cmd)[1]
         commands.getstatusoutput("rm -rf test")
-        comm.run(self)
         comm.clear("org.xwalk.test")
         self.assertEquals(currentVersion, version)
 
@@ -97,7 +95,6 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
             cmd = "tac test |sed -n '%dp' |awk -F 'href=' '{print $2}' |awk -F '\"|/' '{print $2}'" % int(line)
             version = commands.getstatusoutput(cmd)[1]
         commands.getstatusoutput("rm -rf test")
-        comm.run(self)
         comm.clear("org.xwalk.test")
         self.assertEquals(currentVersion, version)
 
@@ -119,7 +116,6 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
             cmd = "tac test |sed -n '%dp' |awk -F 'href=' '{print $2}' |awk -F '\"|/' '{print $2}'" % int(line)
             version = commands.getstatusoutput(cmd)[1]
         commands.getstatusoutput("rm -rf test")
-        comm.run(self)
         comm.clear("org.xwalk.test")
         self.assertEquals(currentVersion, version)
 
@@ -129,7 +125,6 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         os.chdir('org.xwalk.test')
         updatecmd =  comm.PackTools + "crosswalk-app update channel"
         updatestatus = commands.getstatusoutput(updatecmd)
-        comm.run(self)
         comm.clear("org.xwalk.test")
         self.assertIn("ERROR:", updatestatus[1])
 
@@ -139,7 +134,6 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         os.chdir('org.xwalk.test')
         updatecmd =  comm.PackTools + "crosswalk-app update 13.42.319.7"
         comm.update(self, updatecmd)
-        comm.run(self)
         comm.clear("org.xwalk.test")
 
     def test_update_currentVersion(self):
@@ -151,7 +145,6 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         newupdatecmd =  comm.PackTools + "crosswalk-app update 13.42.319.7"
         updatestatus = commands.getstatusoutput(newupdatecmd)
         self.assertIn("Using cached", updatestatus[1])
-        comm.run(self)
         comm.clear("org.xwalk.test")
 
     def test_update_lowerVersion(self):
@@ -162,7 +155,6 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         comm.update(self, updatecmd)
         newupdatecmd =  comm.PackTools + "crosswalk-app update 11.40.277.1"
         comm.update(self, newupdatecmd)
-        comm.run(self)
         comm.clear("org.xwalk.test")
 
     def test_update_invalid_version(self):
@@ -171,7 +163,6 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         os.chdir('org.xwalk.test')
         updatecmd =  comm.PackTools + "crosswalk-app update 0.0.0.0"
         updatestatus = commands.getstatusoutput(updatecmd)
-        comm.run(self)
         comm.clear("org.xwalk.test")
         self.assertIn("ERROR:", updatestatus[1])
 
@@ -182,7 +173,6 @@ class TestCrosswalkApptoolsFunctions(unittest.TestCase):
         updatecmd =  comm.PackTools + "crosswalk-app update"
         updatestatus = commands.getstatusoutput(updatecmd)
         print updatestatus[1]
-        comm.run(self)
         comm.clear("org.xwalk.test")
         self.assertNotEquals(updatestatus[0], 0)
 


### PR DESCRIPTION
Failure analysis:
                  https://crosswalk-project.org/jira/browse/XWALK-4056

Impacted tests(approved):new 0,update 13,delete 0
Unit test platform:[Android]
Unit test result summary:pass 12,fail 1,block 0