### PR TITLE
[XWALK-4239] Automate Cordova API 4.0 build in pack_cordova_sample.py

### DIFF
--- a/tools/build/README.md
+++ b/tools/build/README.md
@@ -5,12 +5,21 @@ pack_cordova_sample.py is used for auto build Cordova sample apps, including mob
 
 ## Pre-conditions
 
+###mobilespec build based on Cordova 4.0
+* Require Android API level 22
+* Require Cordova-CLI 5.0.0, install with command: '$ sudo npm install cordova@5.0.0 -g
+* Copy 'mobilespec' suite to crosswalk-test-suite/tools/mobilespec
+* Copy 'cordova-mobile-spec' suite(https://github.com/apache/cordova-mobile-spec.git) to crosswalk-test-suite/tools/mobilespec
+* Copy 'cordova-coho' suite(https://github.com/apache/cordova-coho.git) to crosswalk-test-suite/tools/mobilespec
+
 ###mobilespec build based on Cordova 3.6
 * Build upstream Cordova with Mobile Spec 3.6, steps please follow [https://github.com/apache/cordova-mobile-spec/blob/3.6.x/createmobilespec/README.md](https://github.com/apache/cordova-mobile-spec/blob/3.6.x/createmobilespec/README.md), here will generate a 'mobilespec' folder
 * Copy 'mobilespec' folder to crosswalk-test-suite/tools
 * You may need to install latest cordova by ```sudo npm -g install cordova```  
 
 ###Sample apps build based on Cordova 4.0
+* Require Android API level 22
+* Require Cordova-CLI 5.0.0, install with command: '$ sudo npm install cordova@5.0.0 -g
 * latest plugman tool, steps as below:  
   ```git clone https://git-wip-us.apache.org/repos/asf/cordova-plugman.git```  
   ```cd cordova-plugman```  

--- a/tools/build/pack.py
+++ b/tools/build/pack.py
@@ -654,8 +654,12 @@ def packCordova_cli(build_json=None, app_src=None, app_dest=None, app_name=None)
         cordova_tmp_path = os.path.join(outputs_dir, "%s-armv7-debug.apk"%app_name)
         cordova_tmp_path_spare = os.path.join(outputs_dir, "android-armv7-debug.apk")
 
-    if not doCopy(cordova_tmp_path, os.path.join(app_dest, "%s.apk" % app_name)):
+    if not os.path.exists(cordova_tmp_path):
         if not doCopy(cordova_tmp_path_spare, os.path.join(app_dest, "%s.apk" % app_name)):
+            os.chdir(orig_dir)
+            return False
+    else:
+        if not doCopy(cordova_tmp_path, os.path.join(app_dest, "%s.apk" % app_name)):
             os.chdir(orig_dir)
             return False
     os.chdir(orig_dir)


### PR DESCRIPTION
- Automate Cordova API 4.0 build in pack_cordova_sample.py
- Improve pack.py, pack_cordova_sample.py to check exist before copy generated apk
- Check pack_cordova_sample.py with mobilespec, helloworld, remotedebugging and gallery successfully

BUG=https://crosswalk-project.org/jira/browse/XWALK-4239
BUG=https://crosswalk-project.org/jira/browse/XWALK-4240