### PR TITLE
[webapi] Wait for gamepad's component to be determined

### DIFF
--- a/webapi/webapi-gamepad-w3c-tests/tests.full.xml
+++ b/webapi/webapi-gamepad-w3c-tests/tests.full.xml
@@ -3,7 +3,7 @@
 <test_definition>
   <suite category="W3C/HTML5 APIs" name="webapi-gamepad-w3c-tests">
     <set name="Gamepad" type="js">
-      <testcase component="W3C_HTML5 APIs/System Apps/Gamepad" execution_type="auto" id="GamepadEvent_basic" priority="P1" purpose="Check if GamepadEvent exist" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/TBD/Gamepad" execution_type="auto" id="GamepadEvent_basic" priority="P1" purpose="Check if GamepadEvent exist" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/GamepadEvent_basic.html</test_script_entry>
         </description>
@@ -15,7 +15,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/System Apps/Gamepad" execution_type="auto" id="Navigator_getGamepads_basic" priority="P1" purpose="Check if getGamepads attribute of navigator exist and type of function" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/TBD/Gamepad" execution_type="auto" id="Navigator_getGamepads_basic" priority="P1" purpose="Check if getGamepads attribute of navigator exist and type of function" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/Navigator_getGamepads_basic.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
@@ -27,7 +27,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/System Apps/Gamepad" execution_type="auto" id="Navigator_getGamepads_value" priority="P1" purpose="Check if the value of navigator.getGamepads() type of object " status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/TBD/Gamepad" execution_type="auto" id="Navigator_getGamepads_value" priority="P1" purpose="Check if the value of navigator.getGamepads() type of object " status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/Navigator_getGamepads_basic.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>

--- a/webapi/webapi-gamepad-w3c-tests/tests.xml
+++ b/webapi/webapi-gamepad-w3c-tests/tests.xml
@@ -3,17 +3,17 @@
 <test_definition>
   <suite category="W3C/HTML5 APIs" name="webapi-gamepad-w3c-tests">
     <set name="Gamepad" type="js">
-      <testcase component="W3C_HTML5 APIs/System Apps/Gamepad" execution_type="auto" id="GamepadEvent_basic" purpose="Check if GamepadEvent exist">
+      <testcase component="W3C_HTML5 APIs/TBD/Gamepad" execution_type="auto" id="GamepadEvent_basic" purpose="Check if GamepadEvent exist">
         <description>
           <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/GamepadEvent_basic.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/System Apps/Gamepad" execution_type="auto" id="Navigator_getGamepads_basic" purpose="Check if getGamepads attribute of navigator exist and type of function">
+      <testcase component="W3C_HTML5 APIs/TBD/Gamepad" execution_type="auto" id="Navigator_getGamepads_basic" purpose="Check if getGamepads attribute of navigator exist and type of function">
         <description>
           <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/Navigator_getGamepads_basic.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/System Apps/Gamepad" execution_type="auto" id="Navigator_getGamepads_value" purpose="Check if the value of navigator.getGamepads() type of object">
+      <testcase component="W3C_HTML5 APIs/TBD/Gamepad" execution_type="auto" id="Navigator_getGamepads_value" purpose="Check if the value of navigator.getGamepads() type of object">
         <description>
           <test_script_entry>/opt/webapi-gamepad-w3c-tests/gamepad/Navigator_getGamepads_basic.html?total_num=2&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>


### PR DESCRIPTION
Definitely the gamepad spec is published by W3C Web Applications Working
Group, not by System Application WG.

https://crosswalk-project.org/jira/browse/XWALK-892