### PR TITLE
[webapi] Correct component of HTML5 Application caches

### DIFF
--- a/webapi/tct-appcache-html5-tests/tests.full.xml
+++ b/webapi/tct-appcache-html5-tests/tests.full.xml
@@ -3,7 +3,7 @@
 <test_definition>
   <suite category="W3C/HTML5 APIs" name="tct-appcache-html5-tests">
     <set name="AppCache" type="js">
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_abort_exist" priority="P1" purpose="Check if the ApplicationCache.abort method exists" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_abort_exist" priority="P1" purpose="Check if the ApplicationCache.abort method exists" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_abort_exist.html</test_script_entry>
         </description>
@@ -15,7 +15,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_CHECKING_exist" priority="P1" purpose="Check if ApplicationCache.CHECKING exists" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_CHECKING_exist" priority="P1" purpose="Check if ApplicationCache.CHECKING exists" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_CHECKING_exist.html</test_script_entry>
         </description>
@@ -27,7 +27,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_DOWNLOADING_exist" priority="P1" purpose="Check if ApplicationCache.DOWNLOADING exists" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_DOWNLOADING_exist" priority="P1" purpose="Check if ApplicationCache.DOWNLOADING exists" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_DOWNLOADING_exist.html</test_script_entry>
         </description>
@@ -39,7 +39,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_IDLE_exist" priority="P1" purpose="Check if ApplicationCache.IDLE exists" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_IDLE_exist" priority="P1" purpose="Check if ApplicationCache.IDLE exists" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_IDLE_exist.html</test_script_entry>
         </description>
@@ -51,7 +51,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_OBSOLETE_exist" priority="P1" purpose="Check if ApplicationCache.OBSOLETE exists" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_OBSOLETE_exist" priority="P1" purpose="Check if ApplicationCache.OBSOLETE exists" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_OBSOLETE_exist.html</test_script_entry>
         </description>
@@ -63,7 +63,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_oncached_exist" priority="P1" purpose="Check if ApplicationCache.oncached method exists" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_oncached_exist" priority="P1" purpose="Check if ApplicationCache.oncached method exists" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_oncached_exist.html</test_script_entry>
         </description>
@@ -75,7 +75,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_onchecking_exist" priority="P1" purpose="Check if ApplicationCache.onchecking method exists" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_onchecking_exist" priority="P1" purpose="Check if ApplicationCache.onchecking method exists" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_onchecking_exist.html</test_script_entry>
         </description>
@@ -87,7 +87,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_ondownloading_exist" priority="P1" purpose="Check if ApplicationCache.ondownloading method exists" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_ondownloading_exist" priority="P1" purpose="Check if ApplicationCache.ondownloading method exists" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_ondownloading_exist.html</test_script_entry>
         </description>
@@ -99,7 +99,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_onerror_exist" priority="P1" purpose="Check if ApplicationCache.onerror method exists" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_onerror_exist" priority="P1" purpose="Check if ApplicationCache.onerror method exists" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_onerror_exist.html</test_script_entry>
         </description>
@@ -111,7 +111,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_onnoupdate_exist" priority="P1" purpose="Check if ApplicationCache.onnoupdate method exists" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_onnoupdate_exist" priority="P1" purpose="Check if ApplicationCache.onnoupdate method exists" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_onnoupdate_exist.html</test_script_entry>
         </description>
@@ -123,7 +123,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_onobsolete_exist" priority="P1" purpose="Check if ApplicationCache.onobsolete method exists" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_onobsolete_exist" priority="P1" purpose="Check if ApplicationCache.onobsolete method exists" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_onobsolete_exist.html</test_script_entry>
         </description>
@@ -135,7 +135,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_onprogress_exist" priority="P1" purpose="Check if ApplicationCache.onprogress method exists" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_onprogress_exist" priority="P1" purpose="Check if ApplicationCache.onprogress method exists" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_onprogress_exist.html</test_script_entry>
         </description>
@@ -147,7 +147,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_onupdateready_exist" priority="P1" purpose="Check if ApplicationCache.onupdateready method exists" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_onupdateready_exist" priority="P1" purpose="Check if ApplicationCache.onupdateready method exists" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_onupdateready_exist.html</test_script_entry>
         </description>
@@ -159,7 +159,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_status_exist" priority="P1" purpose="Check if ApplicationCache.status attribute exists" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_status_exist" priority="P1" purpose="Check if ApplicationCache.status attribute exists" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_status_exist.html</test_script_entry>
         </description>
@@ -171,7 +171,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_swapCache_exist" priority="P1" purpose="Check if ApplicationCache.swapCache method exists" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_swapCache_exist" priority="P1" purpose="Check if ApplicationCache.swapCache method exists" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_swapCache_exist.html</test_script_entry>
         </description>
@@ -183,7 +183,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_UNCACHED_exist" priority="P1" purpose="Check if ApplicationCache.UNCACHED exists" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_UNCACHED_exist" priority="P1" purpose="Check if ApplicationCache.UNCACHED exists" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_UNCACHED_exist.html</test_script_entry>
         </description>
@@ -195,7 +195,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_UPDATEREADY_exist" priority="P1" purpose="Check if ApplicationCache.UPDATEREADY exists" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_UPDATEREADY_exist" priority="P1" purpose="Check if ApplicationCache.UPDATEREADY exists" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_UPDATEREADY_exist.html</test_script_entry>
         </description>
@@ -207,7 +207,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_update_exist" priority="P1" purpose="Check if ApplicationCache.update method exists" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_update_exist" priority="P1" purpose="Check if ApplicationCache.update method exists" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_update_exist.html</test_script_entry>
         </description>
@@ -219,7 +219,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_CHECKING_type" priority="P2" purpose="Check if appcache.CHECKING const is of type number" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_CHECKING_type" priority="P2" purpose="Check if appcache.CHECKING const is of type number" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_CHECKING_type.html</test_script_entry>
         </description>
@@ -231,7 +231,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_DOWNLOADING_type" priority="P2" purpose="Check if appcache.DOWNLOADING const is of type number" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_DOWNLOADING_type" priority="P2" purpose="Check if appcache.DOWNLOADING const is of type number" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_DOWNLOADING_type.html</test_script_entry>
         </description>
@@ -243,7 +243,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_IDLE_type" priority="P2" purpose="Check if appcache.IDLE const is of type number" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_IDLE_type" priority="P2" purpose="Check if appcache.IDLE const is of type number" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_IDLE_type.html</test_script_entry>
         </description>
@@ -255,7 +255,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_OBSOLETE_type" priority="P2" purpose="Check if appcache.OBSOLETE const is of type number" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_OBSOLETE_type" priority="P2" purpose="Check if appcache.OBSOLETE const is of type number" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_OBSOLETE_type.html</test_script_entry>
         </description>
@@ -267,7 +267,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_status_type" priority="P2" purpose="Check if ApplicationCache.status is of type number" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_status_type" priority="P2" purpose="Check if ApplicationCache.status is of type number" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_status_type.html</test_script_entry>
         </description>
@@ -279,7 +279,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_UNCACHED_type" priority="P2" purpose="Check if appcache.UNCACHED const is of type number" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_UNCACHED_type" priority="P2" purpose="Check if appcache.UNCACHED const is of type number" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_UNCACHED_type.html</test_script_entry>
         </description>
@@ -291,7 +291,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_UPDATEREADY_type" priority="P2" purpose="Check if appcache.UPDATEREADY const is of type number" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_UPDATEREADY_type" priority="P2" purpose="Check if appcache.UPDATEREADY const is of type number" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_UPDATEREADY_type.html</test_script_entry>
         </description>
@@ -303,7 +303,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_cache_in_window" priority="P3" purpose="Check if window.applicationCache returns the ApplicationCache object that applies to the active document of that Window" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_cache_in_window" priority="P3" purpose="Check if window.applicationCache returns the ApplicationCache object that applies to the active document of that Window" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_cache_in_window.html</test_script_entry>
         </description>
@@ -315,7 +315,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_CHECKING_value" priority="P2" purpose="Check if the value of constant appcache.CHECKING is 2" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_CHECKING_value" priority="P2" purpose="Check if the value of constant appcache.CHECKING is 2" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_CHECKING_value.html</test_script_entry>
         </description>
@@ -327,7 +327,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_DOWNLOADING_value" priority="P2" purpose="Check if the value of constant appcache.DOWNLOADING is 3" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_DOWNLOADING_value" priority="P2" purpose="Check if the value of constant appcache.DOWNLOADING is 3" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_DOWNLOADING_value.html</test_script_entry>
         </description>
@@ -339,7 +339,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_IDLE_value" priority="P2" purpose="Check if the value of constant appcache.IDLE is 1" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_IDLE_value" priority="P2" purpose="Check if the value of constant appcache.IDLE is 1" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_IDLE_value.html</test_script_entry>
         </description>
@@ -351,7 +351,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_OBSOLETE_value" priority="P2" purpose="Check if the value of constant appcache.OBSOLETE is 5" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_OBSOLETE_value" priority="P2" purpose="Check if the value of constant appcache.OBSOLETE is 5" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_OBSOLETE_value.html</test_script_entry>
         </description>
@@ -363,7 +363,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_status_readonly" priority="P2" purpose="Check if appcache.status attribute is readonly" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_status_readonly" priority="P2" purpose="Check if appcache.status attribute is readonly" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_status_readonly.html</test_script_entry>
         </description>
@@ -375,7 +375,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_status_UNCACHED" priority="P2" purpose="Check if the value of appcache.status is applicationCache.UNCACHED" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_status_UNCACHED" priority="P2" purpose="Check if the value of appcache.status is applicationCache.UNCACHED" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_status_UNCACHED.html</test_script_entry>
         </description>
@@ -387,7 +387,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_swapCache_newcache_execption_InvalidStateError" priority="P2" purpose="Check if ApplicationCache.swapCache() throws InvalidStateError exception when there is no newer application cache" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_swapCache_newcache_execption_InvalidStateError" priority="P2" purpose="Check if ApplicationCache.swapCache() throws InvalidStateError exception when there is no newer application cache" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_swapCache_newcache_execption_InvalidStateError.html</test_script_entry>
         </description>
@@ -399,7 +399,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_UNCACHED_value" priority="P2" purpose="Check if the value of constant appcache.UNCACHED is 0" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_UNCACHED_value" priority="P2" purpose="Check if the value of constant appcache.UNCACHED is 0" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_UNCACHED_value.html</test_script_entry>
         </description>
@@ -411,7 +411,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_UPDATEREADY_value" priority="P2" purpose="Check if the value of constant appcache.UPDATEREADY is 4" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_UPDATEREADY_value" priority="P2" purpose="Check if the value of constant appcache.UPDATEREADY is 4" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_UPDATEREADY_value.html</test_script_entry>
         </description>
@@ -423,7 +423,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_update_nocache_execption_InvalidStateError" priority="P2" purpose="Check if ApplicationCache.update() method throws InvalidStateError exception when no application cache to update" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_update_nocache_execption_InvalidStateError" priority="P2" purpose="Check if ApplicationCache.update() method throws InvalidStateError exception when no application cache to update" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_update_nocache_execption_InvalidStateError.html</test_script_entry>
         </description>

--- a/webapi/tct-appcache-html5-tests/tests.xml
+++ b/webapi/tct-appcache-html5-tests/tests.xml
@@ -3,182 +3,182 @@
 <test_definition>
   <suite category="W3C/HTML5 APIs" name="tct-appcache-html5-tests">
     <set name="AppCache" type="js">
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_abort_exist" purpose="Check if the ApplicationCache.abort method exists">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_abort_exist" purpose="Check if the ApplicationCache.abort method exists">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_abort_exist.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_CHECKING_exist" purpose="Check if ApplicationCache.CHECKING exists">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_CHECKING_exist" purpose="Check if ApplicationCache.CHECKING exists">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_CHECKING_exist.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_DOWNLOADING_exist" purpose="Check if ApplicationCache.DOWNLOADING exists">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_DOWNLOADING_exist" purpose="Check if ApplicationCache.DOWNLOADING exists">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_DOWNLOADING_exist.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_IDLE_exist" purpose="Check if ApplicationCache.IDLE exists">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_IDLE_exist" purpose="Check if ApplicationCache.IDLE exists">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_IDLE_exist.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_OBSOLETE_exist" purpose="Check if ApplicationCache.OBSOLETE exists">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_OBSOLETE_exist" purpose="Check if ApplicationCache.OBSOLETE exists">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_OBSOLETE_exist.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_oncached_exist" purpose="Check if ApplicationCache.oncached method exists">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_oncached_exist" purpose="Check if ApplicationCache.oncached method exists">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_oncached_exist.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_onchecking_exist" purpose="Check if ApplicationCache.onchecking method exists">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_onchecking_exist" purpose="Check if ApplicationCache.onchecking method exists">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_onchecking_exist.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_ondownloading_exist" purpose="Check if ApplicationCache.ondownloading method exists">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_ondownloading_exist" purpose="Check if ApplicationCache.ondownloading method exists">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_ondownloading_exist.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_onerror_exist" purpose="Check if ApplicationCache.onerror method exists">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_onerror_exist" purpose="Check if ApplicationCache.onerror method exists">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_onerror_exist.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_onnoupdate_exist" purpose="Check if ApplicationCache.onnoupdate method exists">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_onnoupdate_exist" purpose="Check if ApplicationCache.onnoupdate method exists">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_onnoupdate_exist.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_onobsolete_exist" purpose="Check if ApplicationCache.onobsolete method exists">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_onobsolete_exist" purpose="Check if ApplicationCache.onobsolete method exists">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_onobsolete_exist.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_onprogress_exist" purpose="Check if ApplicationCache.onprogress method exists">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_onprogress_exist" purpose="Check if ApplicationCache.onprogress method exists">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_onprogress_exist.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_onupdateready_exist" purpose="Check if ApplicationCache.onupdateready method exists">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_onupdateready_exist" purpose="Check if ApplicationCache.onupdateready method exists">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_onupdateready_exist.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_status_exist" purpose="Check if ApplicationCache.status attribute exists">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_status_exist" purpose="Check if ApplicationCache.status attribute exists">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_status_exist.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_swapCache_exist" purpose="Check if ApplicationCache.swapCache method exists">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_swapCache_exist" purpose="Check if ApplicationCache.swapCache method exists">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_swapCache_exist.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_UNCACHED_exist" purpose="Check if ApplicationCache.UNCACHED exists">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_UNCACHED_exist" purpose="Check if ApplicationCache.UNCACHED exists">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_UNCACHED_exist.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_UPDATEREADY_exist" purpose="Check if ApplicationCache.UPDATEREADY exists">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_UPDATEREADY_exist" purpose="Check if ApplicationCache.UPDATEREADY exists">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_UPDATEREADY_exist.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_update_exist" purpose="Check if ApplicationCache.update method exists">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_update_exist" purpose="Check if ApplicationCache.update method exists">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_update_exist.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_CHECKING_type" purpose="Check if appcache.CHECKING const is of type number">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_CHECKING_type" purpose="Check if appcache.CHECKING const is of type number">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_CHECKING_type.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_DOWNLOADING_type" purpose="Check if appcache.DOWNLOADING const is of type number">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_DOWNLOADING_type" purpose="Check if appcache.DOWNLOADING const is of type number">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_DOWNLOADING_type.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_IDLE_type" purpose="Check if appcache.IDLE const is of type number">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_IDLE_type" purpose="Check if appcache.IDLE const is of type number">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_IDLE_type.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_OBSOLETE_type" purpose="Check if appcache.OBSOLETE const is of type number">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_OBSOLETE_type" purpose="Check if appcache.OBSOLETE const is of type number">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_OBSOLETE_type.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_status_type" purpose="Check if ApplicationCache.status is of type number">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_status_type" purpose="Check if ApplicationCache.status is of type number">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_status_type.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_UNCACHED_type" purpose="Check if appcache.UNCACHED const is of type number">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_UNCACHED_type" purpose="Check if appcache.UNCACHED const is of type number">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_UNCACHED_type.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_UPDATEREADY_type" purpose="Check if appcache.UPDATEREADY const is of type number">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_UPDATEREADY_type" purpose="Check if appcache.UPDATEREADY const is of type number">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_UPDATEREADY_type.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_cache_in_window" purpose="Check if window.applicationCache returns the ApplicationCache object that applies to the active document of that Window">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_cache_in_window" purpose="Check if window.applicationCache returns the ApplicationCache object that applies to the active document of that Window">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_cache_in_window.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_CHECKING_value" purpose="Check if the value of constant appcache.CHECKING is 2">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_CHECKING_value" purpose="Check if the value of constant appcache.CHECKING is 2">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_CHECKING_value.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_DOWNLOADING_value" purpose="Check if the value of constant appcache.DOWNLOADING is 3">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_DOWNLOADING_value" purpose="Check if the value of constant appcache.DOWNLOADING is 3">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_DOWNLOADING_value.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_IDLE_value" purpose="Check if the value of constant appcache.IDLE is 1">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_IDLE_value" purpose="Check if the value of constant appcache.IDLE is 1">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_IDLE_value.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_OBSOLETE_value" purpose="Check if the value of constant appcache.OBSOLETE is 5">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_OBSOLETE_value" purpose="Check if the value of constant appcache.OBSOLETE is 5">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_OBSOLETE_value.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_status_readonly" purpose="Check if appcache.status attribute is readonly">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_status_readonly" purpose="Check if appcache.status attribute is readonly">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_status_readonly.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_status_UNCACHED" purpose="Check if the value of appcache.status is applicationCache.UNCACHED">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_status_UNCACHED" purpose="Check if the value of appcache.status is applicationCache.UNCACHED">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_status_UNCACHED.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_swapCache_newcache_execption_InvalidStateError" purpose="Check if ApplicationCache.swapCache() throws InvalidStateError exception when there is no newer application cache">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_swapCache_newcache_execption_InvalidStateError" purpose="Check if ApplicationCache.swapCache() throws InvalidStateError exception when there is no newer application cache">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_swapCache_newcache_execption_InvalidStateError.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_UNCACHED_value" purpose="Check if the value of constant appcache.UNCACHED is 0">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_UNCACHED_value" purpose="Check if the value of constant appcache.UNCACHED is 0">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_UNCACHED_value.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_UPDATEREADY_value" purpose="Check if the value of constant appcache.UPDATEREADY is 4">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_UPDATEREADY_value" purpose="Check if the value of constant appcache.UPDATEREADY is 4">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_UPDATEREADY_value.html</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/HTML5 Application caches" execution_type="auto" id="appcache_update_nocache_execption_InvalidStateError" purpose="Check if ApplicationCache.update() method throws InvalidStateError exception when no application cache to update">
+      <testcase component="W3C_HTML5 APIs/Storage/HTML5 Application caches" execution_type="auto" id="appcache_update_nocache_execption_InvalidStateError" purpose="Check if ApplicationCache.update() method throws InvalidStateError exception when no application cache to update">
         <description>
           <test_script_entry>/opt/tct-appcache-html5-tests/appcache/appcache_update_nocache_execption_InvalidStateError.html</test_script_entry>
         </description>


### PR DESCRIPTION
Historically the components are from the Tizen API reference
hierarchical structure. The appcache shall be categorized in Storage,
see
https://developer.tizen.org/dev-guide/2.3.0/org.tizen.web.apireference/html/w3c_api/w3c_api_m.html#storage

https://crosswalk-project.org/jira/browse/XWALK-1355