### PR TITLE
[webapi] Leverage Crosswalk Web API category

### DIFF
--- a/webapi/webapi-appuri-w3c-tests/tests.full.xml
+++ b/webapi/webapi-appuri-w3c-tests/tests.full.xml
@@ -3,7 +3,7 @@
 <test_definition>
   <suite category="W3C/HTML5 APIs" name="webapi-appuri-w3c-tests">
     <set name="AppURI" type="js">
-      <testcase component="W3C_HTML5 APIs/System Apps/App URI" execution_type="auto" id="uri_protocol" priority="P1" purpose="Check if the protocol value of window.location is right" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Runtime and Packaging/App URI" execution_type="auto" id="uri_protocol" priority="P1" purpose="Check if the protocol value of window.location is right" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-appuri-w3c-tests/appuri/URI.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
@@ -15,7 +15,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/System Apps/App URI" execution_type="auto" id="uri_href" priority="P1" purpose="Check if the href value of window.location is right" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Runtime and Packaging/App URI" execution_type="auto" id="uri_href" priority="P1" purpose="Check if the href value of window.location is right" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-appuri-w3c-tests/appuri/URI.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
@@ -27,7 +27,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/System Apps/App URI" execution_type="auto" id="uri_origin" priority="P1" purpose="Check if the origin value of window.location is right" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Runtime and Packaging/App URI" execution_type="auto" id="uri_origin" priority="P1" purpose="Check if the origin value of window.location is right" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-appuri-w3c-tests/appuri/URI.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
         </description>
@@ -39,7 +39,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/System Apps/App URI" execution_type="auto" id="uri_pathname" priority="P1" purpose="Check if the pathname value of window.location is right" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Runtime and Packaging/App URI" execution_type="auto" id="uri_pathname" priority="P1" purpose="Check if the pathname value of window.location is right" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-appuri-w3c-tests/appuri/URI.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
         </description>
@@ -51,7 +51,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/System Apps/App URI" execution_type="auto" id="uri_hash" priority="P1" purpose="Check if the hash value of window.location is right" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Runtime and Packaging/App URI" execution_type="auto" id="uri_hash" priority="P1" purpose="Check if the hash value of window.location is right" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-appuri-w3c-tests/appuri/URI.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
         </description>
@@ -63,7 +63,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/System Apps/App URI" execution_type="auto" id="uri_port" priority="P1" purpose="Check if the port value of window.location is right" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Runtime and Packaging/App URI" execution_type="auto" id="uri_port" priority="P1" purpose="Check if the port value of window.location is right" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-appuri-w3c-tests/appuri/URI.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
         </description>
@@ -75,7 +75,7 @@
           </spec>
         </specs>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/System Apps/App URI" execution_type="auto" id="uri_image_src" priority="P1" purpose="Check if the src value of image is right" status="approved" type="compliance">
+      <testcase component="W3C_HTML5 APIs/Runtime and Packaging/App URI" execution_type="auto" id="uri_image_src" priority="P1" purpose="Check if the src value of image is right" status="approved" type="compliance">
         <description>
           <test_script_entry>/opt/webapi-appuri-w3c-tests/appuri/URI.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
         </description>

--- a/webapi/webapi-appuri-w3c-tests/tests.xml
+++ b/webapi/webapi-appuri-w3c-tests/tests.xml
@@ -3,37 +3,37 @@
 <test_definition>
   <suite category="W3C/HTML5 APIs" name="webapi-appuri-w3c-tests">
     <set name="AppURI" type="js">
-      <testcase component="W3C_HTML5 APIs/System Apps/App URI" execution_type="auto" id="uri_protocol" purpose="Check if the protocol value of window.location is right">
+      <testcase component="W3C_HTML5 APIs/Runtime and Packaging/App URI" execution_type="auto" id="uri_protocol" purpose="Check if the protocol value of window.location is right">
         <description>
           <test_script_entry>/opt/webapi-appuri-w3c-tests/appuri/URI.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=1</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/System Apps/App URI" execution_type="auto" id="uri_href" purpose="Check if the href value of window.location is right">
+      <testcase component="W3C_HTML5 APIs/Runtime and Packaging/App URI" execution_type="auto" id="uri_href" purpose="Check if the href value of window.location is right">
         <description>
           <test_script_entry>/opt/webapi-appuri-w3c-tests/appuri/URI.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=2</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/System Apps/App URI" execution_type="auto" id="uri_origin" purpose="Check if the origin value of window.location is right">
+      <testcase component="W3C_HTML5 APIs/Runtime and Packaging/App URI" execution_type="auto" id="uri_origin" purpose="Check if the origin value of window.location is right">
         <description>
           <test_script_entry>/opt/webapi-appuri-w3c-tests/appuri/URI.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=3</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/System Apps/App URI" execution_type="auto" id="uri_pathname" purpose="Check if the pathname value of window.location is right">
+      <testcase component="W3C_HTML5 APIs/Runtime and Packaging/App URI" execution_type="auto" id="uri_pathname" purpose="Check if the pathname value of window.location is right">
         <description>
           <test_script_entry>/opt/webapi-appuri-w3c-tests/appuri/URI.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=4</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/System Apps/App URI" execution_type="auto" id="uri_hash" purpose="Check if the hash value of window.location is right">
+      <testcase component="W3C_HTML5 APIs/Runtime and Packaging/App URI" execution_type="auto" id="uri_hash" purpose="Check if the hash value of window.location is right">
         <description>
           <test_script_entry>/opt/webapi-appuri-w3c-tests/appuri/URI.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=5</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/System Apps/App URI" execution_type="auto" id="uri_port" purpose="Check if the port value of window.location is right">
+      <testcase component="W3C_HTML5 APIs/Runtime and Packaging/App URI" execution_type="auto" id="uri_port" purpose="Check if the port value of window.location is right">
         <description>
           <test_script_entry>/opt/webapi-appuri-w3c-tests/appuri/URI.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=6</test_script_entry>
         </description>
       </testcase>
-      <testcase component="W3C_HTML5 APIs/System Apps/App URI" execution_type="auto" id="uri_image_src" purpose="Check if the src value of image is right">
+      <testcase component="W3C_HTML5 APIs/Runtime and Packaging/App URI" execution_type="auto" id="uri_image_src" purpose="Check if the src value of image is right">
         <description>
           <test_script_entry>/opt/webapi-appuri-w3c-tests/appuri/URI.html?total_num=8&amp;amp;locator_key=id&amp;amp;value=7</test_script_entry>
         </description>


### PR DESCRIPTION
As Kenneth pointed out, App URI is still being used by us and Firefox
OS, so that should stay around.

Though the App URI spec was published by W3C System Application WG, we
leverage Crosswalk Web API category as testing component. See
https://crosswalk-project.org/documentation/apis/web_apis.html

https://crosswalk-project.org/jira/browse/XWALK-388