### PR TITLE
[apptools-android] Instead 'crash' with 'cache' for apptools android

### DIFF
--- a/apptools/apptools-android-tests/apptools/comm.py
+++ b/apptools/apptools-android-tests/apptools/comm.py
@@ -40,11 +40,11 @@ ConstPath = os.path.dirname(SCRIPT_PATH)
 
 
 def setUp():
-    global device, XwalkPath, crosswalkVersion, PackTools, ARCH, crashdir
+    global device, XwalkPath, crosswalkVersion, PackTools, ARCH, cachedir
 
     #device = "E6OKCY411012"
     device = os.environ.get('DEVICE_ID')
-    crashdir = os.environ.get('CROSSWALK_APP_TOOLS_CACHE_DIR')
+    cachedir = os.environ.get('CROSSWALK_APP_TOOLS_CACHE_DIR')
     if not device:
         print ("Get env error\n")
         sys.exit(1)
@@ -113,11 +113,11 @@ def update(self, cmd):
     self.assertEquals(updatestatus[0], 0)
     self.assertNotIn("ERROR:", updatestatus[1])
     version = updatestatus[1].split('\n')[-1].split(' ')[-1][1:-1]
-    if not crashdir:
+    if not cachedir:
         namelist = os.listdir(os.getcwd())        
     else:
-        newcrashdir = os.environ.get('CROSSWALK_APP_TOOLS_CACHE_DIR')
-        os.chdir(newcrashdir)
+        newcachedir = os.environ.get('CROSSWALK_APP_TOOLS_CACHE_DIR')
+        os.chdir(newcachedir)
         namelist = os.listdir(os.getcwd())
         os.chdir(XwalkPath + 'org.xwalk.test')
     crosswalk = 'crosswalk-{}.zip'.format(version)

--- a/apptools/apptools-android-tests/apptools/setup_cache_dir.py
+++ b/apptools/apptools-android-tests/apptools/setup_cache_dir.py
@@ -34,21 +34,21 @@ import commands
 import shutil
 
 class TestCrosswalkApptoolsFunctions(unittest.TestCase):
-    def test_setup_crash_dir(self):
+    def test_setup_cache_dir(self):
         comm.setUp()
         os.chdir(comm.XwalkPath)
-        os.mkdir("crash")
+        os.mkdir("cache")
         comm.create(self)
-        os.environ["CROSSWALK_APP_TOOLS_CACHE_DIR"] = comm.XwalkPath + "crash"
+        os.environ["CROSSWALK_APP_TOOLS_CACHE_DIR"] = comm.XwalkPath + "cache"
         os.chdir('org.xwalk.test')
         updatecmd =  comm.PackTools + "crosswalk-app update 13.42.319.5"
         comm.update(self, updatecmd)
         namelist = os.listdir(os.getcwd())
-        os.chdir(comm.XwalkPath + "crash")
+        os.chdir(comm.XwalkPath + "cache")
         crosswalklist = os.listdir(os.getcwd())
         os.environ["CROSSWALK_APP_TOOLS_CACHE_DIR"] = comm.XwalkPath
         os.chdir(comm.XwalkPath)
-        shutil.rmtree("crash")
+        shutil.rmtree("cache")
         comm.clear("org.xwalk.test")
         self.assertNotIn("crosswalk-13.42.319.5.zip", namelist)
         self.assertIn("crosswalk-13.42.319.5.zip", crosswalklist)

--- a/apptools/apptools-android-tests/tests.full.xml
+++ b/apptools/apptools-android-tests/tests.full.xml
@@ -48,9 +48,9 @@
           <test_script_entry>/opt/apptools-android-tests/apptools/version.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_setup_crash_dir" priority="P1" purpose="Android - Validate if download file under CROSSWALK_APP_TOOLS_CACHE_DIR dir" status="approved" type="Functional">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_setup_cache_dir" priority="P1" purpose="Android - Validate if download file under CROSSWALK_APP_TOOLS_CACHE_DIR dir" status="approved" type="Functional">
         <description>
-          <test_script_entry>/opt/apptools-android-tests/apptools/setup_crash_dir.py</test_script_entry>
+          <test_script_entry>/opt/apptools-android-tests/apptools/setup_cache_dir.py</test_script_entry>
         </description>
       </testcase>
       <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_check_target_version" priority="P1" purpose="Android - Validate if point out required minimum API target version" status="designed" type="Functional">

--- a/apptools/apptools-android-tests/tests.xml
+++ b/apptools/apptools-android-tests/tests.xml
@@ -48,9 +48,9 @@
           <test_script_entry>/opt/apptools-android-tests/apptools/version.py</test_script_entry>
         </description>
       </testcase>
-      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_setup_crash_dir" purpose="Android - Validate if download file under CROSSWALK_APP_TOOLS_CACHE_DIR dir">
+      <testcase component="Crosswalk App Tools/CLI" execution_type="auto" id="Crosswalk_setup_cache_dir" purpose="Android - Validate if download file under CROSSWALK_APP_TOOLS_CACHE_DIR dir">
         <description>
-          <test_script_entry>/opt/apptools-android-tests/apptools/setup_crash_dir.py</test_script_entry>
+          <test_script_entry>/opt/apptools-android-tests/apptools/setup_cache_dir.py</test_script_entry>
         </description>
       </testcase>
     </set>


### PR DESCRIPTION
Impacted tests(approved):new 0,update 1,delete 0
Unit test platform:[Android]
Unit test result summary:pass 1,fail 0,block 0